### PR TITLE
feat(highlighter): clear filters on view switch with one-click restore

### DIFF
--- a/src/components/layout/highlighter/HighlighterPanel.tsx
+++ b/src/components/layout/highlighter/HighlighterPanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { createPortal } from 'react-dom'
-import { Tag, Activity, Cpu, Users, X, Trash2, Search, Pencil } from 'lucide-react'
+import { Tag, Activity, Cpu, Users, X, Trash2, Search, Pencil, RotateCcw } from 'lucide-react'
 import { useWorkspaceStore, getActiveView, buildElementMap } from '@/store/workspace'
 import type { ElementStatus } from '@/types/model'
 import { TagManagerPanel } from '../FloatingBottomStrip'
@@ -51,6 +51,9 @@ export default function HighlighterPanel() {
   const setTechs = useWorkspaceStore((s) => s.setActiveTechFilter)
   const setTeams = useWorkspaceStore((s) => s.setActiveTeamFilter)
   const clearAll = useWorkspaceStore((s) => s.clearAllHighlightFilters)
+  const stashedFilters = useWorkspaceStore((s) => s.lastClearedHighlightFilters)
+  const restoreFilters = useWorkspaceStore((s) => s.restoreHighlightFilters)
+  const dismissStash = useWorkspaceStore((s) => s.dismissClearedHighlightFiltersHint)
 
   const view = workspace && activeViewKey ? getActiveView(workspace, activeViewKey) : undefined
   const elementMap = useMemo(() => (workspace ? buildElementMap(workspace) : new Map()), [workspace])
@@ -312,6 +315,65 @@ export default function HighlighterPanel() {
           <X size={14} />
         </button>
       </header>
+
+      {/* Restore-from-previous-view banner */}
+      {stashedFilters && (() => {
+        const stashedTotal =
+          stashedFilters.activeTagFilter.length +
+          stashedFilters.activeStatusFilter.length +
+          stashedFilters.activeTechFilter.length +
+          stashedFilters.activeTeamFilter.length
+        return (
+          <div
+            role="status"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 14px',
+              borderBottom: '1px solid var(--color-border)',
+              background: 'var(--color-accent-active)',
+              fontSize: 'var(--text-xs)',
+              color: 'var(--color-text-primary)',
+            }}
+          >
+            <span style={{ flex: 1, minWidth: 0 }}>
+              <strong style={{ fontWeight: 700 }}>{stashedTotal}</strong> filter{stashedTotal === 1 ? '' : 's'} cleared on view change
+            </span>
+            <button
+              type="button"
+              onClick={restoreFilters}
+              title="Restore the filters from the previous view"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '3px 8px',
+                fontSize: 11,
+                fontWeight: 600,
+                color: 'var(--color-accent)',
+                background: 'transparent',
+                border: '1px solid var(--color-accent)',
+                borderRadius: 'var(--radius-sm)',
+                cursor: 'pointer',
+              }}
+            >
+              <RotateCcw size={11} />
+              Restore
+            </button>
+            <button
+              type="button"
+              onClick={dismissStash}
+              title="Dismiss"
+              aria-label="Dismiss restore hint"
+              className="btn-icon"
+              style={{ minWidth: 20, minHeight: 20, padding: 2 }}
+            >
+              <X size={11} />
+            </button>
+          </div>
+        )
+      })()}
 
       {/* Tabs */}
       <div

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -4,7 +4,7 @@ import {
   MousePointer, LayoutDashboard, Maximize2, ZoomIn, ZoomOut,
   LayoutGrid, Search, Save, Settings, Monitor,
   Presentation, FolderOpen, Image, FileCode, Copy, Plus,
-  Highlighter, MousePointerClick,
+  Highlighter, MousePointerClick, RotateCcw,
 } from 'lucide-react'
 import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews } from '@/store/workspace'
 import { serializeDSL } from '@/lib/dsl'
@@ -232,6 +232,15 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
       keywords: ['filter', 'highlight', 'tag', 'tech', 'team', 'status'],
       when: () => !!store().workspace,
       execute: () => store().setHighlighterPanelOpen(!store().highlighterPanelOpen),
+    },
+    {
+      id: 'restore-cleared-highlight-filters',
+      label: 'Restore Highlighter Filters from Previous View',
+      category: 'view',
+      icon: RotateCcw,
+      keywords: ['restore', 'highlight', 'filter', 'previous', 'undo'],
+      when: () => !!store().lastClearedHighlightFilters,
+      execute: () => store().restoreHighlightFilters(),
     },
     {
       id: 'toggle-multi-select',

--- a/src/store/slices/filter-slice.ts
+++ b/src/store/slices/filter-slice.ts
@@ -6,11 +6,13 @@ import type { WorkspaceState } from '../workspace-types'
 export type FilterSlice = Pick<WorkspaceState,
   | 'activeTagFilter' | 'activeStatusFilter' | 'activeTechFilter' | 'activeTeamFilter'
   | 'tagFilterMode' | 'statusFilterMode' | 'techFilterMode' | 'teamFilterMode'
+  | 'lastClearedHighlightFilters'
   | 'setActiveTagFilter' | 'toggleActiveTagFilter'
   | 'setActiveStatusFilter' | 'toggleActiveStatusFilter'
   | 'setActiveTechFilter' | 'toggleActiveTechFilter'
   | 'setActiveTeamFilter' | 'toggleActiveTeamFilter'
   | 'clearAllHighlightFilters'
+  | 'restoreHighlightFilters' | 'dismissClearedHighlightFiltersHint'
   | 'setTagFilterMode' | 'setStatusFilterMode' | 'setTechFilterMode' | 'setTeamFilterMode'
 >
 
@@ -24,6 +26,7 @@ export const createFilterSlice: StateCreator<
   activeStatusFilter: [],
   activeTechFilter: [],
   activeTeamFilter: [],
+  lastClearedHighlightFilters: null,
   tagFilterMode: 'any',
   statusFilterMode: 'any',
   techFilterMode: 'all',
@@ -58,7 +61,21 @@ export const createFilterSlice: StateCreator<
     activeStatusFilter: [],
     activeTechFilter: [],
     activeTeamFilter: [],
+    // Manual clear is intentional — drop any pending "restore from previous view" hint too.
+    lastClearedHighlightFilters: null,
   }),
+
+  restoreHighlightFilters: () => set((s) => {
+    const stash = s.lastClearedHighlightFilters
+    if (!stash) return
+    s.activeTagFilter = stash.activeTagFilter
+    s.activeStatusFilter = stash.activeStatusFilter
+    s.activeTechFilter = stash.activeTechFilter
+    s.activeTeamFilter = stash.activeTeamFilter
+    s.lastClearedHighlightFilters = null
+  }),
+
+  dismissClearedHighlightFiltersHint: () => set({ lastClearedHighlightFilters: null }),
 
   setTagFilterMode: (mode) => set({ tagFilterMode: mode }),
   setStatusFilterMode: (mode) => set({ statusFilterMode: mode }),

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -51,6 +51,7 @@ export const createLifecycleSlice: StateCreator<
       activeStatusFilter: [],
       activeTechFilter: [],
       activeTeamFilter: [],
+      lastClearedHighlightFilters: null,
       scopeViolations: validateScope(workspace),
     })
   },
@@ -70,6 +71,7 @@ export const createLifecycleSlice: StateCreator<
       createViewDefaults: null,
       undoStack: [],
       redoStack: [],
+      lastClearedHighlightFilters: null,
       scopeViolations: [],
     }),
 

--- a/src/store/slices/navigation-slice.ts
+++ b/src/store/slices/navigation-slice.ts
@@ -1,6 +1,31 @@
 import type { StateCreator } from 'zustand'
 import type { WorkspaceState } from '../workspace-types'
 import { findChildViewHelper as findChildView, getZoomTarget } from '../workspace-selectors'
+import { announce } from '@/lib/announce'
+
+/** If any Highlighter filter is non-empty, snapshot all four into
+ *  `lastClearedHighlightFilters` and clear the active filters. Idempotent
+ *  when filters are empty (preserves any pre-existing stash). Modes are
+ *  preferences and are intentionally NOT touched. */
+function clearHighlightFiltersWithStash(s: WorkspaceState): boolean {
+  const hasActive =
+    s.activeTagFilter.length > 0 ||
+    s.activeStatusFilter.length > 0 ||
+    s.activeTechFilter.length > 0 ||
+    s.activeTeamFilter.length > 0
+  if (!hasActive) return false
+  s.lastClearedHighlightFilters = {
+    activeTagFilter: [...s.activeTagFilter],
+    activeStatusFilter: [...s.activeStatusFilter],
+    activeTechFilter: [...s.activeTechFilter],
+    activeTeamFilter: [...s.activeTeamFilter],
+  }
+  s.activeTagFilter = []
+  s.activeStatusFilter = []
+  s.activeTechFilter = []
+  s.activeTeamFilter = []
+  return true
+}
 
 /** Navigation state: which view is active, the breadcrumb history, the
  *  pending zoom-confirm prompt, and a transient focusElementId that the
@@ -28,11 +53,15 @@ export const createNavigationSlice: StateCreator<
 
   clearFocusElement: () => set({ focusElementId: null }),
 
-  setActiveView: (key) => set({
-    activeViewKey: key,
-    selectedElementIds: [],
-    selectedRelationshipId: null,
-    selectedGroupId: null,
+  setActiveView: (key) => set((s) => {
+    const changed = s.activeViewKey !== key
+    s.activeViewKey = key
+    s.selectedElementIds = []
+    s.selectedRelationshipId = null
+    s.selectedGroupId = null
+    if (changed && clearHighlightFiltersWithStash(s)) {
+      announce('Highlighter cleared on view change')
+    }
   }),
 
   drillInto: (elementId) => set((s) => {
@@ -48,6 +77,9 @@ export const createNavigationSlice: StateCreator<
     s.selectedElementIds = []
     s.selectedRelationshipId = null
     s.selectedGroupId = null
+    if (clearHighlightFiltersWithStash(s)) {
+      announce('Highlighter cleared on view change')
+    }
   }),
 
   zoomInto: (elementId) => {
@@ -108,5 +140,8 @@ export const createNavigationSlice: StateCreator<
     s.selectedElementIds = []
     s.selectedRelationshipId = null
     s.selectedGroupId = null
+    if (clearHighlightFiltersWithStash(s)) {
+      announce('Highlighter cleared on view change')
+    }
   }),
 })

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -54,6 +54,14 @@ export interface WorkspaceState extends UndoState {
   /** Multi-select tech filter — element matches if any of its technology tokens is in this set. */
   activeTechFilter: string[]
   activeTeamFilter: string[]
+  /** Snapshot of filters that were active before a view-switch cleared them.
+   *  Lets the UI offer a one-click restore. Null when there's nothing to restore. */
+  lastClearedHighlightFilters: {
+    activeTagFilter: string[]
+    activeStatusFilter: ElementStatus[]
+    activeTechFilter: string[]
+    activeTeamFilter: string[]
+  } | null
   minimapEnabled: boolean
   snapToGrid: boolean
   multiSelectMode: boolean
@@ -156,6 +164,10 @@ export interface WorkspaceState extends UndoState {
   setActiveTeamFilter: (teams: string[]) => void
   toggleActiveTeamFilter: (team: string) => void
   clearAllHighlightFilters: () => void
+  /** Re-apply filters from `lastClearedHighlightFilters` and clear the stash. No-op if stash is null. */
+  restoreHighlightFilters: () => void
+  /** Drop the cleared-filters stash without restoring (user dismisses the affordance). */
+  dismissClearedHighlightFiltersHint: () => void
   updateElementStyle: (style: import('@/types/model').ElementStyle) => void
   removeElementStyle: (tag: string) => void
   renameTag: (oldTag: string, newTag: string) => void

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -702,6 +702,133 @@ describe('multiSelectMode', () => {
   })
 })
 
+// ─── Highlighter filters cleared on view change ──────────────────────
+
+describe('Highlighter filters cleared on view change', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().loadWorkspace(makeWorkspace())
+  })
+
+  it('setActiveView clears active filters and stashes them when filters were non-empty', () => {
+    const keyA = useWorkspaceStore.getState().addView('systemLandscape', undefined, 'A')
+    const keyB = useWorkspaceStore.getState().addView('systemLandscape', undefined, 'B')
+    useWorkspaceStore.getState().setActiveView(keyA)
+    useWorkspaceStore.setState({ activeTagFilter: ['Database'], activeTechFilter: ['Go'] })
+
+    useWorkspaceStore.getState().setActiveView(keyB)
+
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual([])
+    expect(useWorkspaceStore.getState().activeTechFilter).toEqual([])
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters).toEqual({
+      activeTagFilter: ['Database'],
+      activeStatusFilter: [],
+      activeTechFilter: ['Go'],
+      activeTeamFilter: [],
+    })
+  })
+
+  it('setActiveView leaves the stash alone when there are no active filters to clear', () => {
+    const keyA = useWorkspaceStore.getState().addView('systemLandscape', undefined, 'A')
+    const keyB = useWorkspaceStore.getState().addView('systemLandscape', undefined, 'B')
+    useWorkspaceStore.getState().setActiveView(keyA)
+    useWorkspaceStore.setState({
+      lastClearedHighlightFilters: {
+        activeTagFilter: ['Database'], activeStatusFilter: [], activeTechFilter: [], activeTeamFilter: [],
+      },
+    })
+
+    useWorkspaceStore.getState().setActiveView(keyB)
+
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters).toEqual({
+      activeTagFilter: ['Database'], activeStatusFilter: [], activeTechFilter: [], activeTeamFilter: [],
+    })
+  })
+
+  it('setActiveView with the same key is a no-op for filters', () => {
+    const keyA = useWorkspaceStore.getState().addView('systemLandscape', undefined, 'A')
+    useWorkspaceStore.getState().setActiveView(keyA)
+    useWorkspaceStore.setState({ activeTagFilter: ['Database'] })
+
+    useWorkspaceStore.getState().setActiveView(keyA)
+
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual(['Database'])
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters).toBeNull()
+  })
+
+  it('drillInto clears active filters and stashes them', () => {
+    useWorkspaceStore.getState().addContainer('api', 'Web')
+    useWorkspaceStore.getState().addView('container', 'api', 'API Containers')
+    const landscapeKey = useWorkspaceStore.getState().addView('systemLandscape')
+    useWorkspaceStore.getState().setActiveView(landscapeKey)
+    useWorkspaceStore.setState({ activeTagFilter: ['Database'] })
+
+    useWorkspaceStore.getState().drillInto('api')
+
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual([])
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters?.activeTagFilter).toEqual(['Database'])
+  })
+
+  it('navigateBack clears active filters and stashes them', () => {
+    const landscapeKey = useWorkspaceStore.getState().addView('systemLandscape')
+    useWorkspaceStore.getState().addContainer('api', 'Web')
+    useWorkspaceStore.getState().addView('container', 'api', 'API Containers')
+    useWorkspaceStore.getState().setActiveView(landscapeKey)
+    useWorkspaceStore.setState({ viewHistory: [landscapeKey], activeTagFilter: ['Database'] })
+
+    useWorkspaceStore.getState().navigateBack()
+
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual([])
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters?.activeTagFilter).toEqual(['Database'])
+  })
+
+  it('restoreHighlightFilters reapplies the stash and clears it', () => {
+    useWorkspaceStore.setState({
+      lastClearedHighlightFilters: {
+        activeTagFilter: ['Database'], activeStatusFilter: ['Live'], activeTechFilter: ['Go'], activeTeamFilter: ['Platform'],
+      },
+    })
+
+    useWorkspaceStore.getState().restoreHighlightFilters()
+
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual(['Database'])
+    expect(useWorkspaceStore.getState().activeStatusFilter).toEqual(['Live'])
+    expect(useWorkspaceStore.getState().activeTechFilter).toEqual(['Go'])
+    expect(useWorkspaceStore.getState().activeTeamFilter).toEqual(['Platform'])
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters).toBeNull()
+  })
+
+  it('restoreHighlightFilters is a no-op when stash is null', () => {
+    useWorkspaceStore.setState({ activeTagFilter: ['Live'] })
+    useWorkspaceStore.getState().restoreHighlightFilters()
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual(['Live'])
+  })
+
+  it('clearAllHighlightFilters drops the stash so manual clear is final', () => {
+    useWorkspaceStore.setState({
+      activeTagFilter: ['Database'],
+      lastClearedHighlightFilters: {
+        activeTagFilter: ['OldTag'], activeStatusFilter: [], activeTechFilter: [], activeTeamFilter: [],
+      },
+    })
+
+    useWorkspaceStore.getState().clearAllHighlightFilters()
+
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual([])
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters).toBeNull()
+  })
+
+  it('dismissClearedHighlightFiltersHint drops the stash without restoring', () => {
+    useWorkspaceStore.setState({
+      lastClearedHighlightFilters: {
+        activeTagFilter: ['Database'], activeStatusFilter: [], activeTechFilter: [], activeTeamFilter: [],
+      },
+    })
+    useWorkspaceStore.getState().dismissClearedHighlightFiltersHint()
+    expect(useWorkspaceStore.getState().lastClearedHighlightFilters).toBeNull()
+    expect(useWorkspaceStore.getState().activeTagFilter).toEqual([])
+  })
+})
+
 // ─── activeWorkspaceFilename ─────────────────────────────────────────
 
 describe('activeWorkspaceFilename', () => {


### PR DESCRIPTION
## Summary

When a user switches views with Highlighter filters active, the filter values (specific tags, technologies, owners) often don't exist or don't have the same meaning in the new view. The result is a silently dimmed canvas where most or all nodes are filtered out and there is no visible cue that the filter is the cause.

This change makes view-switch the safe default: filters clear automatically, and a one-click restore is offered so the cross-view audit case (e.g. \"where does Critical status appear?\") isn't penalized.

### Behavior

- `setActiveView`, `drillInto`, `navigateBack`: if any of the four filter arrays (tag / status / tech / team) is non-empty, snapshot all four into `lastClearedHighlightFilters` and reset them. Modes (any/all) are preferences and are preserved.
- Same-key `setActiveView` still clears selection (preserves the existing contract) but does not touch filters.
- Empty active filters at view-switch time leave the existing stash in place, so the restore offer survives multiple navigations.
- `HighlighterPanel` shows a \"N filters cleared on view change\" banner with **Restore** and dismiss buttons whenever the stash is non-null.
- Command palette adds **Restore Highlighter Filters from Previous View**, so the affordance is reachable when the panel is closed.
- Manual `clearAllHighlightFilters` drops the stash (intentional — manual clear means \"start fresh\").
- Workspace load/close clears the stash so it can't bleed across workspaces.
- Announces \"Highlighter cleared on view change\" to the existing aria-live region for screen-reader users.

### Files

- `src/store/slices/filter-slice.ts` — new `lastClearedHighlightFilters` state, `restoreHighlightFilters` and `dismissClearedHighlightFiltersHint` actions; `clearAllHighlightFilters` also nulls the stash.
- `src/store/slices/navigation-slice.ts` — `clearHighlightFiltersWithStash` helper; wired into the three view-switch actions.
- `src/store/slices/lifecycle-slice.ts` — `loadWorkspace` and `closeWorkspace` now reset the stash.
- `src/store/workspace-types.ts` — type additions.
- `src/components/layout/highlighter/HighlighterPanel.tsx` — restore banner.
- `src/lib/commands.ts` — palette command.
- `src/store/workspace.test.ts` — 8 new tests covering the behavior.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test:unit` — 978/978 pass (8 new tests for the new behavior)
- [ ] Manual: apply filters in a Container view → switch to System Landscape → banner shows \"Restore\" → click → filters return.
- [ ] Manual: apply filters → drill into a child view → banner shows.
- [ ] Manual: apply filters → switch view → close panel → `⌘K` → \"Restore Highlighter Filters from Previous View\" is in the palette.
- [ ] Manual: apply filters → switch view → click Trash icon (manual clear-all) → banner does NOT reappear (stash dropped).
- [ ] Manual: load a different workspace → previous workspace's stash does not surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)