### PR TITLE
fix(multi-select): mark multi-select bar as canvas chrome so clicks land

### DIFF
--- a/e2e/canvas/group-add-render.spec.ts
+++ b/e2e/canvas/group-add-render.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../fixtures/workspace'
+
+/**
+ * Regression: clicking Group on the multi-select bar in multi-select mode
+ * created an empty group (or none at all) — the bar's button click never
+ * fired its onClick.
+ *
+ * Root cause: FloatingInspector attaches a document `mousedown` listener
+ * that calls `clearSelection()` whenever the click target is outside the
+ * inspector AND not inside `.react-flow` or `[data-canvas-chrome]`. The
+ * MultiSelectBar wasn't tagged as canvas chrome, so mousedown on its
+ * Group button cleared `selectedElementIds`, the bar re-rendered with
+ * count<2 and unmounted, and the click event never reached the button.
+ *
+ * Fix: tag the MultiSelectBar wrapper with data-canvas-chrome so the
+ * outside-click handler treats it as canvas chrome.
+ */
+test.describe('group renders when added via multi-select bar', () => {
+  test('addGroup followed by selectGroup (programmatic) renders the group', async ({ workspace }) => {
+    await workspace.loadSample()
+    await workspace.page.evaluate(() => (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))
+    await workspace.page.waitForTimeout(300)
+
+    const groupId = await workspace.page.evaluate((ids) => {
+      type S = {
+        addGroup: (n: string, ids: string[]) => string
+        selectGroup: (id: string) => void
+      }
+      const w = window as unknown as { __testStore?: () => S }
+      const store = w.__testStore?.()
+      if (!store) return null
+      const id = store.addGroup('Smoke Group', ids)
+      store.selectGroup(id)
+      return id
+    }, ['customer', 'internetBanking'])
+    expect(groupId).toBeTruthy()
+
+    const groupNode = workspace.page.locator(`[data-id="group-${groupId}"]`)
+    await expect(groupNode).toHaveCount(1, { timeout: 3000 })
+    await expect(groupNode).toBeVisible()
+  })
+
+  test('clicking Group on the multi-select bar in multi-select mode renders the group', async ({ workspace }) => {
+    await workspace.loadSample()
+    await workspace.page.evaluate(() => (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))
+    await workspace.page.waitForTimeout(300)
+
+    // Toggle multi-select mode and click two nodes so the bar appears.
+    await workspace.page.getByRole('button', { name: /Multi-select/ }).click()
+    await workspace.clickNode('Personal Banking Customer')
+    await workspace.clickNode('Internet Banking System')
+    await expect(workspace.page.getByText('2 selected')).toBeVisible()
+
+    // Click the Group button on the bar.
+    await workspace.page.locator('button[title="Group 2 elements"]').click()
+
+    // The new group should render.
+    const groupNodes = workspace.page.locator('.react-flow__node[data-id^="group-"]')
+    await expect(groupNodes).toHaveCount(1, { timeout: 3000 })
+    await expect(groupNodes.first()).toBeVisible()
+
+    // And the store should have the group with both selected elementIds.
+    const storeGroups = await workspace.page.evaluate(() => {
+      const w = window as unknown as { __testGetWorkspace?: () => { model?: { groups?: Array<{ elementIds: string[] }> } } }
+      return w.__testGetWorkspace?.()?.model?.groups ?? []
+    })
+    expect(storeGroups).toHaveLength(1)
+    expect(storeGroups[0].elementIds).toEqual(['customer', 'internetBanking'])
+  })
+})

--- a/src/components/layout/MultiSelectBar.tsx
+++ b/src/components/layout/MultiSelectBar.tsx
@@ -118,16 +118,19 @@ export default function MultiSelectBar() {
   const sep = <div style={{ width: 1, height: 18, background: 'var(--color-border)', flexShrink: 0 }} />
 
   return (
-    <div style={{
-      position: 'fixed',
-      left,
-      top,
-      width: BAR_W,
-      height: BAR_H,
-      zIndex: 52,
-      pointerEvents: 'auto',
-      animation: 'fadeIn 0.15s ease both',
-    }}>
+    <div
+      data-canvas-chrome="multi-select-bar"
+      style={{
+        position: 'fixed',
+        left,
+        top,
+        width: BAR_W,
+        height: BAR_H,
+        zIndex: 52,
+        pointerEvents: 'auto',
+        animation: 'fadeIn 0.15s ease both',
+      }}
+    >
       <div
         className="glass-panel-solid"
         style={{

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,6 +35,7 @@ if (import.meta.env.DEV) {
   ;(window as unknown as Record<string, unknown>).__testAddGroup = (name: string, ids: string[]) => {
     return useWorkspaceStore.getState().addGroup(name, ids)
   }
+  ;(window as unknown as Record<string, unknown>).__testStore = () => useWorkspaceStore.getState()
   ;(window as unknown as Record<string, unknown>).__testDeleteElements = (ids: string[]) => {
     useWorkspaceStore.getState().deleteElements(ids)
   }


### PR DESCRIPTION
## Summary

Clicking the Group button on the multi-select bar in multi-select mode created an empty group, or none at all — the bar's \`onClick\` never fired. The same race affected any button on the bar.

### Root cause

\`FloatingInspector\` attaches a document \`mousedown\` listener that calls \`clearSelection()\` whenever the click target is outside the inspector AND not inside \`.react-flow\` or \`[data-canvas-chrome]\`. The \`MultiSelectBar\` wasn't tagged as canvas chrome, so:

1. User mousedowns on the bar's Group button.
2. \`FloatingInspector\`'s outside-click handler fires → \`clearSelection()\` runs.
3. \`selectedElementIds\` becomes \`[]\` → bar re-renders with \`count<2\` → bar unmounts.
4. The click event never reaches the (now-removed) button.

\`FloatingInspector\` early-returns \`null\` in multi-select mode, but its useEffect still registers the listener (hooks always run). So the listener was clearing selection even when the inspector wasn't visible.

### Fix

Tag the \`MultiSelectBar\` wrapper with \`data-canvas-chrome=\"multi-select-bar\"\` so the outside-click handler treats it as canvas chrome and ignores mousedowns on it.

### Tests

Adds \`e2e/canvas/group-add-render.spec.ts\` with two regressions:
- Programmatic \`addGroup\` + \`selectGroup\` (the same call shape MultiSelectBar uses).
- Real UI flow: multi-select mode → click two nodes → click Group on the bar → verify the group node appears in the DOM and the store has both elementIds.

The second test fails on \`main\` and passes with this fix. All 978 unit tests and 12 group-related e2e tests pass.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:unit\` — 978/978 pass
- [x] \`npm run test:e2e --grep group\` — 12/12 pass (including new tests)
- [ ] Manual: open the sample, multi-select two nodes (M to toggle, then click two), click Group on the bar — group rectangle should appear and the bar should disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)