### PR TITLE
fix(parser): systemContext include * follows container relationships

### DIFF
--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -33,15 +33,32 @@ function expandWildcard(model: Model, view: View): ElementInView[] {
         for (const p of model.people) addId(p.id)
         for (const s of model.softwareSystems) addId(s.id)
     } else if (view.type === 'systemContext' && view.softwareSystemId) {
-        // System context: the scoped system + all elements directly connected to it.
-        // Mirrors the Structurizr spec and the store's addView logic for systemContext.
+        // System context: the scoped system + all people/systems connected to it.
+        // We follow relationships at BOTH the system level AND the container/component
+        // level of the scope system, then promote those to the system context. This
+        // matches Structurizr's "implied relationships" behavior and what users
+        // typically intend — DSL authors usually write relationships at container
+        // granularity, then expect the system context to summarize the system's
+        // collaborators rather than appear empty. (Strict spec without implied
+        // relationships would only follow system-level edges.)
         const scopeId = view.softwareSystemId
         addId(scopeId)
+        const scopeSys = model.softwareSystems.find(s => s.id === scopeId)
+        const scopeInternalIds = new Set<string>([scopeId])
+        if (scopeSys) {
+            for (const c of scopeSys.containers) {
+                scopeInternalIds.add(c.id)
+                for (const comp of c.components) scopeInternalIds.add(comp.id)
+            }
+        }
         const connectedIds = new Set<string>()
         for (const rel of model.relationships) {
-            if (rel.sourceId === scopeId) connectedIds.add(rel.destinationId)
-            if (rel.destinationId === scopeId) connectedIds.add(rel.sourceId)
+            if (scopeInternalIds.has(rel.sourceId)) connectedIds.add(rel.destinationId)
+            if (scopeInternalIds.has(rel.destinationId)) connectedIds.add(rel.sourceId)
         }
+        // Filter the connected set down to just people and OTHER software systems —
+        // never the scope's own containers/components, and never elements inside the
+        // scope. The system context is a system-level view.
         for (const p of model.people) { if (connectedIds.has(p.id)) addId(p.id) }
         for (const s of model.softwareSystems) { if (s.id !== scopeId && connectedIds.has(s.id)) addId(s.id) }
     } else if (view.type === 'container' && view.softwareSystemId) {

--- a/src/lib/dsl/wildcard-expansion.test.ts
+++ b/src/lib/dsl/wildcard-expansion.test.ts
@@ -34,8 +34,10 @@ workspace "Test" {
   })
 
   it('systemContext include * expands to the scoped system plus directly connected elements only', () => {
-    // Structurizr semantics: for a system context view, include * means the scoped system
-    // plus all elements with a direct relationship to it — not the full landscape.
+    // For a system context view, include * means the scoped system plus all
+    // people/systems with a relationship to the scope OR to one of its containers
+    // /components — not the full landscape. (The container-level promotion is the
+    // user-friendly equivalent of Structurizr's "implied relationships".)
     const dsl = `
 workspace "Test" {
   model {
@@ -66,6 +68,56 @@ workspace "Test" {
     // bob and external have no relationship to api — they should NOT appear
     expect(view.elements.some(e => e.id === bobId)).toBe(false)
     expect(view.elements.some(e => e.id === externalId)).toBe(false)
+  })
+
+  it('systemContext include * follows relationships through the scope system\'s containers', () => {
+    // When a DSL author writes relationships at container granularity (the common
+    // pattern), the system context should still summarize the system's collaborators.
+    // Without this, the view would contain only the scope system and look broken.
+    const dsl = `
+workspace "Test" {
+  model {
+    teacher = person "Teacher"
+    author = person "Content Author"
+    ext = softwareSystem "External Service" "External" "External"
+    unrelated = softwareSystem "Unrelated"
+    pubSvc = softwareSystem "Pub Service" {
+      api = container "API"
+      db = container "DB" "Postgres" "Database"
+    }
+    teacher -> api "browses"
+    api -> ext "fetches"
+    api -> db "reads"
+    author -> pubSvc "writes"
+  }
+  views {
+    systemContext pubSvc "ctx" {
+      include *
+    }
+  }
+}
+`
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+    const view = workspace.views.systemContextViews[0]
+    const pubSvcId = workspace.model.softwareSystems.find(s => s.name === 'Pub Service')!.id
+    const teacherId = workspace.model.people.find(p => p.name === 'Teacher')!.id
+    const authorId = workspace.model.people.find(p => p.name === 'Content Author')!.id
+    const extId = workspace.model.softwareSystems.find(s => s.name === 'External Service')!.id
+    const unrelatedId = workspace.model.softwareSystems.find(s => s.name === 'Unrelated')!.id
+    const apiId = workspace.model.softwareSystems.find(s => s.name === 'Pub Service')!.containers.find(c => c.name === 'API')!.id
+    // Scope system itself
+    expect(view.elements.some(e => e.id === pubSvcId)).toBe(true)
+    // Teacher (relates to api container of scope) — promoted to system context
+    expect(view.elements.some(e => e.id === teacherId)).toBe(true)
+    // External service (relates to api container of scope) — promoted
+    expect(view.elements.some(e => e.id === extId)).toBe(true)
+    // Author (relates to scope system directly) — included
+    expect(view.elements.some(e => e.id === authorId)).toBe(true)
+    // Containers of the scope system MUST NOT appear in the system context
+    expect(view.elements.some(e => e.id === apiId)).toBe(false)
+    // Unrelated system has no relationship anywhere — NOT included
+    expect(view.elements.some(e => e.id === unrelatedId)).toBe(false)
   })
 
   it('container include * expands to containers of the scoped system plus related external elements', () => {

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -200,11 +200,25 @@ export function buildInitialViewContent(
     for (const p of model.people) elements.push({ id: p.id })
     for (const sys of model.softwareSystems) elements.push({ id: sys.id })
   } else if (type === 'systemContext' && scopeId) {
+    // Mirror parser's expandWildcard for systemContext: include the scope plus
+    // any people / external systems that have a relationship to the scope OR
+    // to one of its containers/components (the user-friendly equivalent of
+    // Structurizr's "implied relationships"). Without this, DSL files that
+    // express relationships at container granularity produce an empty system
+    // context view.
     elements.push({ id: scopeId })
+    const scopeSys = model.softwareSystems.find((s) => s.id === scopeId)
+    const scopeInternalIds = new Set<string>([scopeId])
+    if (scopeSys) {
+      for (const c of scopeSys.containers) {
+        scopeInternalIds.add(c.id)
+        for (const comp of c.components) scopeInternalIds.add(comp.id)
+      }
+    }
     const related = new Set<string>()
     for (const rel of model.relationships) {
-      if (rel.sourceId === scopeId) related.add(rel.destinationId)
-      if (rel.destinationId === scopeId) related.add(rel.sourceId)
+      if (scopeInternalIds.has(rel.sourceId)) related.add(rel.destinationId)
+      if (scopeInternalIds.has(rel.destinationId)) related.add(rel.sourceId)
     }
     for (const p of model.people) {
       if (related.has(p.id)) elements.push({ id: p.id })


### PR DESCRIPTION
## Summary

DSL files that express their relationships at container granularity (the most common pattern) used to produce a SystemContext view with only the scope system in it — every external collaborator's relationship lived on a container of the scope, and the wildcard expansion only followed system-level edges. Loading such a file made the workspace appear broken: a single lonely box on the canvas.

User-reported repro: a Published Content Service DSL with people, external systems, and a scope system that has 5 containers. All 16 relationships are at container granularity. SystemContext (the first view, default landing) showed just one node — the user assumed the file failed to load.

## Fix

Extend the systemContext \`include *\` expansion to follow relationships that touch any container/component of the scope system, not just the scope itself. Containers/components remain hidden — only the people and external systems they connect to are promoted up to the context view. This matches what users expect from Structurizr's \"implied relationships.\"

Apply the same change to \`buildInitialViewContent\` so creating a systemContext view in the UI behaves identically.

## Limitation (follow-up)

This populates the view's element list, but **arrows for container-level relationships still don't render in SystemContext** — the renderer requires both endpoints to be in the view's element set, and the containers aren't. System-level relationships still draw as before. Implied-relationship arrow promotion would require either synthesizing tagged \"implied\" relationships in the model (with serializer filtering) or introducing per-view relationship overrides. Out of scope for this PR; the user-visible improvement (\"the workspace clearly loaded\") justifies shipping just the element fix now.

## Tests

- Existing systemContext wildcard test still passes (direct system-level relationships behave the same).
- New test \`systemContext include * follows relationships through the scope system's containers\` covers the user's case.
- All 979 unit tests pass.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:unit\` — 979/979 pass (1 new)
- [ ] Manual: open the user's DSL → SystemContext view should show pub_content_svc, teacher, author, ctk, ctk_pub, aether, slide_svc, partner_app, hs_science_ui, class_enroll (10 elements) — not just one box.
- [ ] Manual: confirm Container view still renders all 5 containers + the related externals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)