### PR TITLE
fix(multi-select): align actions now persist positions

### DIFF
--- a/src/components/layout/MultiSelectBar.tsx
+++ b/src/components/layout/MultiSelectBar.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useReactFlow } from '@xyflow/react'
 import { useWorkspaceStore } from '@/store/workspace'
-import type { Node } from '@xyflow/react'
 import {
   AlignStartVertical,
   AlignCenterVertical,
@@ -83,25 +82,31 @@ export default function MultiSelectBar() {
       case 'bottom':   refVal = maxY; break
       case 'center-y': refVal = (minY + maxY) / 2; break
     }
-    const alignedPositions: { id: string; x: number; y: number }[] = []
-    reactFlow.setNodes(nodes => nodes.map(n => {
-      if (!selectedElementIds.includes(n.id)) return n
-      const p = positions.find(p => p.id === n.id)!
-      let updated: Node
+    // Compute the aligned positions up front. Earlier the array was
+    // populated INSIDE the reactFlow.setNodes(fn) callback, which RF runs
+    // asynchronously / batched — by the time we read `alignedPositions`
+    // for `updateNodePositions(...)`, it was still empty and the persist
+    // step silently no-op'd.
+    const alignedPositions: { id: string; x: number; y: number }[] = positions.map((p) => {
+      let x = p.x, y = p.y
       switch (mode) {
-        case 'left':     updated = { ...n, position: { ...n.position, x: refVal } }; break
-        case 'right':    updated = { ...n, position: { ...n.position, x: refVal - p.w } }; break
-        case 'center-x': updated = { ...n, position: { ...n.position, x: refVal - p.w / 2 } }; break
-        case 'top':      updated = { ...n, position: { ...n.position, y: refVal } }; break
-        case 'bottom':   updated = { ...n, position: { ...n.position, y: refVal - p.h } }; break
-        case 'center-y': updated = { ...n, position: { ...n.position, y: refVal - p.h / 2 } }; break
-        default:         return n
+        case 'left':     x = refVal; break
+        case 'right':    x = refVal - p.w; break
+        case 'center-x': x = refVal - p.w / 2; break
+        case 'top':      y = refVal; break
+        case 'bottom':   y = refVal - p.h; break
+        case 'center-y': y = refVal - p.h / 2; break
       }
-      alignedPositions.push({ id: n.id, x: updated.position.x, y: updated.position.y })
-      return updated
+      return { id: p.id, x, y }
+    })
+    const alignedById = new Map(alignedPositions.map((p) => [p.id, p]))
+    reactFlow.setNodes((nodes) => nodes.map((n) => {
+      const aligned = alignedById.get(n.id)
+      if (!aligned) return n
+      return { ...n, position: { ...n.position, x: aligned.x, y: aligned.y } }
     }))
-    // Persist aligned positions to the store so they survive re-renders
-    if (alignedPositions.length > 0) updateNodePositions(alignedPositions)
+    // Persist aligned positions to the store so they survive re-renders.
+    updateNodePositions(alignedPositions)
     setAlignOpen(false)
   }
 


### PR DESCRIPTION
## Summary

The multi-select bar's Group action was fixed in #35 (\`data-canvas-chrome\` on the bar wrapper). Align had a different, latent bug that #35 didn't cover: opening the dropdown and clicking any align option closed the menu but did nothing — the canvas didn't re-paint and the store wasn't updated.

### Root cause

\`handleAlign\` relied on \`reactFlow.setNodes(fn)\` invoking its callback synchronously to populate a local \`alignedPositions\` array, which it then passed to \`updateNodePositions\` to persist to the store. React Flow defers/batches the callback, so by the time we reached \`updateNodePositions(alignedPositions)\` the array was empty and the persist step silently no-op'd.

### Fix

Compute the aligned positions up front from the snapshot the function already takes, then hand the same array to **both** \`reactFlow.setNodes\` (visual) and \`updateNodePositions\` (store). No dependency on React Flow's internal callback timing.

## Verification

Programmatic Playwright check on the dev build:

\`\`\`
positions before: [{customer, x:225, y:0}, {internetBanking, x:440, y:400}]
positions after Align top: [{customer, x:225, y:0}, {internetBanking, x:440, y:0}]
positions changed: OK ✓
both nodes share the same y: OK ✓
\`\`\`

Group + Tag Filtering + Highlighter e2e tests: 11/11 still passing.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:e2e --grep \"group renders|highlighter|Tag Filtering\"\` — 11/11
- [ ] Manual: load sample, switch to System Context, multi-select two nodes, click \`Align\` → \`Align top\` → both nodes snap to the same y; the dropdown closes; positions survive a page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)