### PR TITLE
fix(multi-select): align nudges nodes apart instead of stacking them

### DIFF
--- a/src/components/layout/MultiSelectBar.tsx
+++ b/src/components/layout/MultiSelectBar.tsx
@@ -87,7 +87,7 @@ export default function MultiSelectBar() {
     // asynchronously / batched — by the time we read `alignedPositions`
     // for `updateNodePositions(...)`, it was still empty and the persist
     // step silently no-op'd.
-    const alignedPositions: { id: string; x: number; y: number }[] = positions.map((p) => {
+    const aligned: { id: string; x: number; y: number; w: number; h: number }[] = positions.map((p) => {
       let x = p.x, y = p.y
       switch (mode) {
         case 'left':     x = refVal; break
@@ -97,8 +97,29 @@ export default function MultiSelectBar() {
         case 'bottom':   y = refVal - p.h; break
         case 'center-y': y = refVal - p.h / 2; break
       }
-      return { id: p.id, x, y }
+      return { id: p.id, x, y, w: p.w, h: p.h }
     })
+
+    // Aligning collapses one axis. If two nodes happened to share (or be
+    // close on) the OTHER axis, they now sit on top of each other. Sort
+    // by the preserved axis and push later nodes forward by their own
+    // size + a gap whenever they would overlap a predecessor's bbox.
+    // Order is preserved so this feels like a stable nudge, not a shuffle.
+    const GAP = 24
+    const horizontal = mode === 'top' || mode === 'bottom' || mode === 'center-y'
+    const sorted = [...aligned].sort((a, b) => horizontal ? a.x - b.x : a.y - b.y)
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1]
+      const cur = sorted[i]
+      if (horizontal) {
+        const minX = prev.x + prev.w + GAP
+        if (cur.x < minX) cur.x = minX
+      } else {
+        const minY = prev.y + prev.h + GAP
+        if (cur.y < minY) cur.y = minY
+      }
+    }
+    const alignedPositions = aligned.map(({ id, x, y }) => ({ id, x, y }))
     const alignedById = new Map(alignedPositions.map((p) => [p.id, p]))
     reactFlow.setNodes((nodes) => nodes.map((n) => {
       const aligned = alignedById.get(n.id)


### PR DESCRIPTION
## Summary

Aligning along one axis collapses one coordinate of every selected node. Two nodes that happened to share the **other** axis would land directly on top of each other after the align — the exact thing alignment is supposed to make easier to see.

### Fix

After computing each node's aligned position, sort by the preserved axis and walk the list. If a node's bbox would overlap its predecessor along that axis, push it forward by the predecessor's size + a 24px gap. Order is stable, so this feels like a single nudge rather than a redistribute.

- \`top\`/\`bottom\`/\`center-y\`: walk by x, nudge later nodes right.
- \`left\`/\`right\`/\`center-x\`: walk by y, nudge later nodes down.

## Verification

Programmatic Playwright check on the dev build with two nodes seeded close on x (100 vs 110) at different y:

\`\`\`
after Align top:  [customer x=225 y=0, internetBanking x=529 y=0]
shared y: OK ✓
horizontal distance between centers: 304
would overlap (dx < node width): NO ✓
\`\`\`

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: place two nodes near the same x, multi-select, click Align → Align top. They should land on the same y, side by side, NOT stacked.
- [ ] Manual: same with three nodes — they should fan out left-to-right after Align top.
- [ ] Manual: stable order — sort doesn't reshuffle nodes that already had room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)