### PR TITLE
fix(mobile): zoom-to-fit, group pinch-zoom, tap-and-hold; tests

### DIFF
--- a/e2e/canvas/group-add-render.spec.ts
+++ b/e2e/canvas/group-add-render.spec.ts
@@ -40,6 +40,71 @@ test.describe('group renders when added via multi-select bar', () => {
     await expect(groupNode).toBeVisible()
   })
 
+  test('dragging a group moves all its members by the same delta and persists', async ({ workspace }) => {
+    await workspace.loadSample()
+    await workspace.page.evaluate(() => (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))
+    await workspace.page.waitForTimeout(300)
+
+    const groupId = await workspace.page.evaluate((ids) => {
+      type S = {
+        addGroup: (n: string, ids: string[]) => string
+        selectGroup: (id: string) => void
+      }
+      const w = window as unknown as { __testStore?: () => S }
+      const s = w.__testStore?.()
+      const id = s!.addGroup('Drag Test', ids)
+      s!.selectGroup(id)
+      return id
+    }, ['customer', 'internetBanking'])
+    expect(groupId).toBeTruthy()
+    await workspace.page.waitForTimeout(400)
+
+    const before = await workspace.page.evaluate(() => {
+      type WS = { views: { systemContextViews: Array<{ elements: Array<{ id: string; x?: number; y?: number }> }> } }
+      const ws = (window as unknown as { __testGetWorkspace?: () => WS }).__testGetWorkspace?.()
+      return ws!.views.systemContextViews[0].elements
+        .filter((e) => e.id === 'customer' || e.id === 'internetBanking')
+        .map((e) => ({ id: e.id, x: e.x ?? 0, y: e.y ?? 0 }))
+    })
+
+    // Pick up the group by its top-left label corner and drag by (200, 100).
+    const groupNode = workspace.page.locator(`[data-id="group-${groupId}"]`)
+    const gbox = await groupNode.boundingBox()
+    if (!gbox) throw new Error('group node has no bounding box')
+    const startX = gbox.x + 20
+    const startY = gbox.y + 12
+    await workspace.page.mouse.move(startX, startY)
+    await workspace.page.mouse.down()
+    await workspace.page.mouse.move(startX + 200, startY + 100, { steps: 10 })
+    await workspace.page.mouse.up()
+    await workspace.page.waitForTimeout(400)
+
+    const after = await workspace.page.evaluate(() => {
+      type WS = { views: { systemContextViews: Array<{ elements: Array<{ id: string; x?: number; y?: number }> }> } }
+      const ws = (window as unknown as { __testGetWorkspace?: () => WS }).__testGetWorkspace?.()
+      return ws!.views.systemContextViews[0].elements
+        .filter((e) => e.id === 'customer' || e.id === 'internetBanking')
+        .map((e) => ({ id: e.id, x: e.x ?? 0, y: e.y ?? 0 }))
+    })
+
+    const a = before.find((p) => p.id === 'customer')!
+    const a2 = after.find((p) => p.id === 'customer')!
+    const b = before.find((p) => p.id === 'internetBanking')!
+    const b2 = after.find((p) => p.id === 'internetBanking')!
+
+    const dxA = a2.x - a.x
+    const dyA = a2.y - a.y
+    const dxB = b2.x - b.x
+    const dyB = b2.y - b.y
+
+    // Both members translated by IDENTICAL deltas (the whole cluster moved as a unit).
+    expect(Math.abs(dxA - dxB)).toBeLessThan(1)
+    expect(Math.abs(dyA - dyB)).toBeLessThan(1)
+    // And they actually moved.
+    expect(Math.abs(dxA)).toBeGreaterThan(50)
+    expect(Math.abs(dyA)).toBeGreaterThan(25)
+  })
+
   test('clicking Group on the multi-select bar in multi-select mode renders the group', async ({ workspace }) => {
     await workspace.loadSample()
     await workspace.page.evaluate(() => (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))

--- a/e2e/canvas/group-add-render.spec.ts
+++ b/e2e/canvas/group-add-render.spec.ts
@@ -67,12 +67,14 @@ test.describe('group renders when added via multi-select bar', () => {
         .map((e) => ({ id: e.id, x: e.x ?? 0, y: e.y ?? 0 }))
     })
 
-    // Pick up the group by its top-left label corner and drag by (200, 100).
-    const groupNode = workspace.page.locator(`[data-id="group-${groupId}"]`)
-    const gbox = await groupNode.boundingBox()
-    if (!gbox) throw new Error('group node has no bounding box')
-    const startX = gbox.x + 20
-    const startY = gbox.y + 12
+    // Drag must start inside the `.c4-group-handle` label — the rest of the
+    // group node is pointer-events:none so two-finger pinch on mobile can
+    // pass through to React Flow's pan/zoom.
+    const handle = workspace.page.locator(`[data-id="group-${groupId}"] .c4-group-handle`)
+    const hbox = await handle.boundingBox()
+    if (!hbox) throw new Error('group drag handle has no bounding box')
+    const startX = hbox.x + hbox.width / 2
+    const startY = hbox.y + hbox.height / 2
     await workspace.page.mouse.move(startX, startY)
     await workspace.page.mouse.down()
     await workspace.page.mouse.move(startX + 200, startY + 100, { steps: 10 })

--- a/e2e/canvas/multi-select-bar.spec.ts
+++ b/e2e/canvas/multi-select-bar.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../fixtures/workspace'
+
+/**
+ * Regressions covered:
+ *  - PR #39 (multiselect-align-persists): handleAlign relied on
+ *    reactFlow.setNodes(fn) running its callback synchronously to populate
+ *    the alignedPositions array passed to updateNodePositions. RF defers
+ *    the callback, so the persist step silently no-op'd and the canvas
+ *    didn't move.
+ *  - PR #40 (align-prevents-overlap): aligning two nodes that happened to
+ *    share the OTHER axis stacked them on top of each other. After-align
+ *    pass now sorts by the preserved axis and nudges any pair that would
+ *    overlap apart by the predecessor's size + a 24px gap.
+ */
+test.describe('multi-select bar — align', () => {
+  test('Align top makes both selected nodes share the same y AND persists', async ({ workspace }) => {
+    await workspace.loadSample()
+    await workspace.page.evaluate(() => (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))
+    await workspace.page.waitForTimeout(300)
+
+    await workspace.page.getByRole('button', { name: /Multi-select/ }).click()
+    await workspace.clickNode('Personal Banking Customer')
+    await workspace.clickNode('Internet Banking System')
+    await expect(workspace.page.getByText('2 selected')).toBeVisible()
+
+    const before = await readPositions(workspace.page, ['customer', 'internetBanking'])
+    expect(before.find((p) => p.id === 'customer')!.y)
+      .not.toBe(before.find((p) => p.id === 'internetBanking')!.y)
+
+    await workspace.page.locator('button[title="Align elements"]').click()
+    await workspace.page.getByRole('button', { name: 'Align top' }).click()
+    await workspace.page.waitForTimeout(300)
+
+    const after = await readPositions(workspace.page, ['customer', 'internetBanking'])
+    const yA = after.find((p) => p.id === 'customer')!.y
+    const yB = after.find((p) => p.id === 'internetBanking')!.y
+    expect(Math.abs(yA - yB)).toBeLessThan(0.5)
+    // The persist step actually wrote new positions to the store.
+    expect(after).not.toEqual(before)
+  })
+
+  test('Align top spreads two close-x nodes apart so they do not overlap', async ({ workspace }) => {
+    await workspace.loadSample()
+    await workspace.page.evaluate(() => (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))
+    await workspace.page.waitForTimeout(300)
+
+    // Force the two nodes to be very close on the x axis but far on y so
+    // an Align top would naively stack them.
+    await workspace.page.evaluate(() => {
+      type S = { updateNodePositions: (u: { id: string; x: number; y: number }[]) => void }
+      const store = (window as unknown as { __testStore?: () => S }).__testStore?.()
+      store?.updateNodePositions([
+        { id: 'customer', x: 100, y: 50 },
+        { id: 'internetBanking', x: 110, y: 400 },
+      ])
+    })
+    await workspace.page.waitForTimeout(200)
+
+    await workspace.page.getByRole('button', { name: /Multi-select/ }).click()
+    await workspace.clickNode('Personal Banking Customer')
+    await workspace.clickNode('Internet Banking System')
+    await expect(workspace.page.getByText('2 selected')).toBeVisible()
+
+    await workspace.page.locator('button[title="Align elements"]').click()
+    await workspace.page.getByRole('button', { name: 'Align top' }).click()
+    await workspace.page.waitForTimeout(300)
+
+    const after = await readPositions(workspace.page, ['customer', 'internetBanking'])
+    const a = after.find((p) => p.id === 'customer')!
+    const b = after.find((p) => p.id === 'internetBanking')!
+    // Same y after Align top.
+    expect(Math.abs(a.y - b.y)).toBeLessThan(0.5)
+    // But x-distance must be at least the (default) node width so they do
+    // NOT visually overlap. We don't have measured widths in the store, so
+    // assert the distance is more than 100 — the broken behavior would
+    // have left them at x=100 and x=110 (a 10px gap on the same y).
+    expect(Math.abs(a.x - b.x)).toBeGreaterThan(100)
+  })
+})
+
+async function readPositions(page: import('@playwright/test').Page, ids: string[]) {
+  return page.evaluate(({ ids }) => {
+    type WS = { views: { systemContextViews: Array<{ elements: Array<{ id: string; x?: number; y?: number }> }> } }
+    const ws = (window as unknown as { __testGetWorkspace?: () => WS }).__testGetWorkspace?.()
+    const view = ws?.views.systemContextViews[0]
+    return view!.elements
+      .filter((e) => ids.includes(e.id))
+      .map((e) => ({ id: e.id, x: e.x ?? 0, y: e.y ?? 0 }))
+  }, { ids })
+}

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -607,7 +607,17 @@ export default function Canvas() {
       const elementNodes = selectedNodes.filter(n => !n.id.startsWith('group-'))
 
       if (groupNodes.length > 0) {
-        selectGroup(groupNodes[0].id.slice(6)) // strip 'group-' prefix
+        // Defer group selection on the same 120ms / isDragging-cancel pattern
+        // we use for elements. Without this, pressing a group on a phone
+        // immediately pops the inspector — a tap-and-drag (long-press to move
+        // the cluster) selects-then-drags, leaving the inspector flashing
+        // open before the drag suppresses it.
+        const groupId = groupNodes[0].id.slice(6) // strip 'group-' prefix
+        if (inspectorTimer.current) clearTimeout(inspectorTimer.current)
+        inspectorTimer.current = setTimeout(() => {
+          inspectorTimer.current = null
+          if (!isDragging.current) selectGroup(groupId)
+        }, 120)
       } else if (elementNodes.length > 0) {
         const ids = elementNodes.map((n) => n.id)
         // If multiple nodes selected (shift+click or rubber-band), apply immediately — no delay

--- a/src/components/canvas/canvasBuilders.ts
+++ b/src/components/canvas/canvasBuilders.ts
@@ -195,15 +195,22 @@ export function buildGroupNodes(
       id: `group-${group.id}`,
       type: 'group',
       position: { x: minX - PADDING, y: minY - PADDING_TOP },
-      style: { width: (maxX - minX) + PADDING * 2, height: (maxY - minY) + PADDING_TOP + PADDING, backgroundColor: 'transparent' },
+      // pointer-events: none on the React Flow wrapper itself lets pinch /
+      // pan / tap pass through the (often huge) group rectangle to the
+      // canvas pane underneath. The .c4-group-handle inside re-enables
+      // pointer-events so the label still receives the drag.
+      style: { width: (maxX - minX) + PADDING * 2, height: (maxY - minY) + PADDING_TOP + PADDING, backgroundColor: 'transparent', pointerEvents: 'none' },
       data: { label: group.name, elementCount: group.elementIds.length },
       zIndex: -1,
       selectable: true,
-      // Draggable: Canvas's onNodeDragStart/onNodeDrag/onNodeDragStop detect
-      // group drags (id starts with `group-`) and translate every member by
-      // the same delta. The group's own position is then re-derived from the
-      // updated members on the next overlay rebuild.
+      // Drag handler: Canvas's onNodeDragStart/onNodeDrag/onNodeDragStop
+      // detect group drags (id starts with `group-`) and translate every
+      // member by the same delta. The group's own position is then re-
+      // derived from the updated members on the next overlay rebuild.
       draggable: true,
+      // Restrict drag initiation to the small label header so touches on
+      // the body pass through (see pointerEvents above).
+      dragHandle: '.c4-group-handle',
     })
   }
   return groupNodes

--- a/src/components/canvas/nodes/GroupNode.tsx
+++ b/src/components/canvas/nodes/GroupNode.tsx
@@ -9,6 +9,11 @@ interface GroupNodeData {
 
 function GroupNode({ data, selected }: NodeProps & { data: GroupNodeData }) {
   return (
+    // pointerEvents: 'none' on the wrapper so two-finger gestures (pinch-
+    // zoom) and panning aren't trapped by the often-huge group rectangle.
+    // The label header re-enables them so it remains the drag handle and
+    // tappable affordance — RF picks up the drag because the matching
+    // `.c4-group-handle` lives inside this header.
     <div
       className="rounded-xl p-4"
       style={{
@@ -21,9 +26,13 @@ function GroupNode({ data, selected }: NodeProps & { data: GroupNodeData }) {
           : '2px dashed var(--color-border-hover)',
         background: 'var(--color-tint-accent-faint)',
         transition: 'border-color 200ms ease',
+        pointerEvents: 'none',
       }}
     >
-      <div className="flex items-center gap-1.5">
+      <div
+        className="c4-group-handle flex items-center gap-1.5"
+        style={{ pointerEvents: 'auto', cursor: 'grab', touchAction: 'none' }}
+      >
         <FolderOpen size={12} style={{ color: 'var(--canvas-selection, var(--color-accent))', opacity: 0.6 }} />
         <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--canvas-selection, var(--color-accent))', opacity: 0.7 }}>
           {data.label}

--- a/src/components/layout/FloatingToolRail.tsx
+++ b/src/components/layout/FloatingToolRail.tsx
@@ -15,6 +15,7 @@ import {
   MousePointerClick,
 } from 'lucide-react'
 import { useArrowNav } from '@/hooks/useArrowNav'
+import { useBreakpoint } from '@/hooks/useBreakpoint'
 import { useFlyoutFocus } from '@/hooks/useFlyoutFocus'
 import AddElementPanel from '@/components/layout/AddElementPanel'
 import { fitContentNodesToViewport } from '@/lib/fitViewport'
@@ -42,6 +43,12 @@ export default function FloatingToolRail() {
 
 
   const reactFlow = useReactFlow()
+  const breakpoint = useBreakpoint()
+  // The tool rail is a vertical column on the left at desktop sizes and a
+  // horizontal row near the bottom on phones. The Zoom-to-fit math needs
+  // this signal so it reserves space on the correct edge — without it,
+  // mobile fits leave the diagram squeezed into the bottom-right.
+  const fitChromeSide = breakpoint === 'mobile' ? 'bottom' : 'left'
   const multiSelectMode = useWorkspaceStore((s) => s.multiSelectMode)
   const setMultiSelectMode = useWorkspaceStore((s) => s.setMultiSelectMode)
   const addPanelOpen = useWorkspaceStore((s) => s.addElementPanelOpen)
@@ -116,7 +123,7 @@ export default function FloatingToolRail() {
       className="glass-panel"
       role="toolbar"
       aria-label="Canvas tools"
-      data-canvas-fit-chrome="left"
+      data-canvas-fit-chrome={fitChromeSide}
       data-canvas-chrome="tool-rail"
       style={{
         position: 'fixed',


### PR DESCRIPTION
## Summary

Three mobile/touch fixes plus regression tests for the recent multi-select bar work.

### Mobile zoom-to-fit

The floating tool rail is a vertical column on the left at desktop sizes and a horizontal row near the bottom on phones (CSS media query). \`data-canvas-fit-chrome\` was hardcoded to \`\"left\"\`, so on mobile the fit math reserved a left inset roughly equal to half the viewport width — squashing the diagram into the bottom-right corner.

Branch the attribute on \`useBreakpoint()\`: \`\"bottom\"\` on mobile, \`\"left\"\` everywhere else. Verified at 393×852 the fit centers horizontally, ~90% width fill, content sits above the bottom rail.

### Pinch-zoom on a group

The group rectangle is often huge — two-finger pinch always landed on it instead of \`.react-flow__pane\`. Set \`pointerEvents: 'none'\` on the group node's wrapper style and \`dragHandle: '.c4-group-handle'\` so the empty body passes touches through. The header inner element re-enables \`pointer-events: auto\` (with \`cursor: grab\`, \`touch-action: none\`) so it remains the drag handle. Verified via \`elementFromPoint\` on the group corner: returns \`.react-flow__pane draggable\` instead of the group node.

### Tap-and-hold opening the inspector

Group selection used to fire on \`onSelectionChange\` immediately, so a tap-and-drag flashed the inspector open before the drag took over. Move \`selectGroup\` onto the same 120ms / \`isDragging\`-cancel deferred path that already protects elements: a genuine tap still selects, a tap-and-drag suppresses.

### Tests added

- \`e2e/canvas/multi-select-bar.spec.ts\` — Align top makes both selected nodes share the same y AND persists; Align top spreads two close-x nodes apart so they don't overlap.
- \`e2e/canvas/group-add-render.spec.ts\` — dragging a group node moves all its members by the same delta and persists. Updated to start the drag on \`.c4-group-handle\` (the only valid drag region after the dragHandle restriction).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:e2e\` — 128/128 pass (incl. 3 new)
- [ ] Manual on phone: pinch-zoom anywhere in a group rectangle still zooms the canvas.
- [ ] Manual on phone: tap-and-drag a group's label moves the cluster; the inspector does NOT flash open during the drag.
- [ ] Manual on phone: tap-without-moving a group's label still opens the inspector.
- [ ] Manual on phone: zoom-to-fit centers the diagram between the top pill and bottom rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)