### PR TITLE
Redesign delete semantics: separate 'remove from view' from 'delete from model'

### DIFF
--- a/e2e/canvas/delete-semantics.spec.ts
+++ b/e2e/canvas/delete-semantics.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '../fixtures/workspace'
+
+test.describe('Delete semantics', () => {
+  test('Backspace removes peer system from context view but keeps it in the model', async ({ workspace }) => {
+    await workspace.loadSample()
+    // Navigate to a context view that contains a peer system; pick first available
+    const views = await workspace.getViews()
+    const contextView = views.find(v => v.type === 'systemContext')!
+    await workspace.setView(contextView.key)
+
+    const before = await workspace.getWorkspace()
+    const view = before!.views.systemContextViews.find(v => v.key === contextView.key)!
+    const peerId = view.elements.find(e => e.id !== view['softwareSystemId' as keyof typeof view])?.id
+    test.skip(!peerId, 'sample workspace has no peer in this context view')
+
+    // Select that peer node and Backspace
+    // Wait for the inspector after click so the 120ms selection-commit timer has fired.
+    const peer = before!.model.softwareSystems.find(s => s.id === peerId) ?? before!.model.people.find(p => p.id === peerId)!
+    await workspace.clickNode(peer.name)
+    await workspace.expectInspectorFor(peer.name)
+    await workspace.page.keyboard.press('Backspace')
+
+    // No confirm dialog (lightweight action)
+    await expect(workspace.page.getByRole('dialog', { name: /confirm delete/i })).toHaveCount(0)
+    // View shrunk:
+    const after = await workspace.getWorkspace()
+    const viewAfter = after!.views.systemContextViews.find(v => v.key === contextView.key)!
+    expect(viewAfter.elements.find(e => e.id === peerId)).toBeUndefined()
+    // Model intact:
+    expect(
+      after!.model.softwareSystems.find(s => s.id === peerId) ??
+      after!.model.people.find(p => p.id === peerId)
+    ).toBeDefined()
+  })
+
+  test('Shift+Backspace shows impact dialog and cascade-deletes from model', async ({ workspace }) => {
+    await workspace.loadSample()
+    const views = await workspace.getViews()
+    const landscape = views.find(v => v.type === 'systemLandscape')!
+    await workspace.setView(landscape.key)
+
+    const before = await workspace.getWorkspace()
+    // Pick a system that has containers (so we can assert the cascade preview)
+    const sys = before!.model.softwareSystems.find(s => s.containers.length > 0)
+    test.skip(!sys, 'sample workspace has no system with containers')
+
+    await workspace.clickNode(sys!.name)
+    await workspace.expectInspectorFor(sys!.name)
+    await workspace.page.keyboard.press('Shift+Backspace')
+
+    const dialog = workspace.page.getByRole('dialog', { name: /confirm delete/i })
+    await expect(dialog).toBeVisible()
+    // Impact list should mention the actual cascade scope
+    await expect(dialog.getByRole('list', { name: /cascade impact/i })).toBeVisible()
+    await expect(dialog.getByRole('listitem').filter({ hasText: new RegExp(`${sys!.containers.length} container`) })).toBeVisible()
+
+    await dialog.getByRole('button', { name: /delete from model/i }).click()
+
+    const after = await workspace.getWorkspace()
+    expect(after!.model.softwareSystems.find(s => s.id === sys!.id)).toBeUndefined()
+  })
+
+  test('Cmd+Z restores after destructive cascade delete', async ({ workspace }) => {
+    await workspace.loadSample()
+    const views = await workspace.getViews()
+    const landscape = views.find(v => v.type === 'systemLandscape')!
+    await workspace.setView(landscape.key)
+
+    const before = await workspace.getWorkspace()
+    const sys = before!.model.softwareSystems.find(s => s.containers.length > 0)!
+    await workspace.clickNode(sys.name)
+    await workspace.expectInspectorFor(sys.name)
+    await workspace.page.keyboard.press('Shift+Backspace')
+    const undoDialog = workspace.page.getByRole('dialog', { name: /confirm delete/i })
+    await expect(undoDialog).toBeVisible()
+    await undoDialog.getByRole('button', { name: /delete from model/i }).click()
+    await workspace.page.keyboard.press('Control+z')
+
+    const after = await workspace.getWorkspace()
+    const restored = after!.model.softwareSystems.find(s => s.id === sys.id)!
+    expect(restored).toBeDefined()
+    expect(restored.containers.length).toBe(sys.containers.length)
+  })
+
+  test('Backspace on a focal scope element is a no-op', async ({ workspace }) => {
+    await workspace.loadSample()
+    const views = await workspace.getViews()
+    const containerView = views.find(v => v.type === 'container')!
+    await workspace.setView(containerView.key)
+
+    // The focal system is not normally a node on its own container view
+    // (Bug #1 fix), so this is a defense-in-depth assertion: even if we
+    // somehow get a Backspace targeting it, model state must not change.
+    const before = await workspace.getWorkspace()
+    await workspace.page.keyboard.press('Backspace') // nothing selected
+    const after = await workspace.getWorkspace()
+    expect(JSON.stringify(after!.model)).toBe(JSON.stringify(before!.model))
+  })
+
+  test('Re-add via AddElementPanel after Backspace round-trips cleanly', async ({ workspace }) => {
+    await workspace.loadSample()
+    const views = await workspace.getViews()
+    const contextView = views.find(v => v.type === 'systemContext')!
+    await workspace.setView(contextView.key)
+
+    const before = await workspace.getWorkspace()
+    const view = before!.views.systemContextViews.find(v => v.key === contextView.key)!
+    const peerId = view.elements.find(e => e.id !== view['softwareSystemId' as keyof typeof view])?.id
+    test.skip(!peerId, 'sample workspace has no peer in this context view')
+
+    const peerName = (before!.model.softwareSystems.find(s => s.id === peerId) ?? before!.model.people.find(p => p.id === peerId))!.name
+
+    await workspace.clickNode(peerName)
+    await workspace.expectInspectorFor(peerName)
+    await workspace.page.keyboard.press('Backspace')
+
+    // Re-add via the picker
+    await workspace.page.keyboard.press('a')
+    await workspace.page.getByPlaceholder(/filter elements/i).fill(peerName)
+    await workspace.page.locator('.glass-flyout').getByRole('button', { name: new RegExp(peerName) }).click()
+
+    const after = await workspace.getWorkspace()
+    expect(after!.views.systemContextViews.find(v => v.key === contextView.key)!
+      .elements.find(e => e.id === peerId)).toBeDefined()
+  })
+})

--- a/e2e/canvas/elements.spec.ts
+++ b/e2e/canvas/elements.spec.ts
@@ -36,13 +36,13 @@ test.describe('Canvas Elements', () => {
     expect(after).toBe(before + 1)
   })
 
-  test('deleting a selected node removes it after confirmation', async ({ workspace }) => {
+  test('Shift+Backspace on a selected node deletes it from the model after confirmation', async ({ workspace }) => {
     await workspace.loadSample()
     const before = await workspace.getNodeCount()
     await workspace.clickNode('ATM')
     await workspace.expectInspectorFor('ATM')
-    await workspace.page.keyboard.press('Backspace')
-    await workspace.page.getByRole('dialog', { name: 'Confirm delete' }).getByRole('button', { name: 'Delete' }).click()
+    await workspace.page.keyboard.press('Shift+Backspace')
+    await workspace.page.getByRole('dialog', { name: 'Confirm delete' }).getByRole('button', { name: /delete from model/i }).click()
     await expect(await workspace.getNodeByName('ATM')).toHaveCount(0)
     const after = await workspace.getNodeCount()
     expect(after).toBe(before - 1)

--- a/e2e/canvas/multi-select-bar.spec.ts
+++ b/e2e/canvas/multi-select-bar.spec.ts
@@ -98,7 +98,7 @@ test.describe('multi-select bar — delete', () => {
     await workspace.page.keyboard.up('Shift')
 
     // Click "Delete from model" in the toolbar
-    await workspace.page.getByRole('button', { name: /delete from model/i }).first().click()
+    await workspace.page.locator('[data-canvas-chrome="multi-select-bar"]').getByRole('button', { name: /delete from model/i }).click()
 
     // Confirm dialog appears with impact list
     const dialog = workspace.page.getByRole('dialog', { name: /confirm delete/i })

--- a/e2e/canvas/multi-select-bar.spec.ts
+++ b/e2e/canvas/multi-select-bar.spec.ts
@@ -78,6 +78,35 @@ test.describe('multi-select bar — align', () => {
   })
 })
 
+test.describe('multi-select bar — delete', () => {
+  test('Delete from model shows impact-aware confirm dialog', async ({ workspace }) => {
+    await workspace.loadSample()
+    const views = await workspace.getViews()
+    const landscape = views.find(v => v.type === 'systemLandscape')
+    test.skip(!landscape, 'sample workspace has no landscape view')
+    await workspace.setView(landscape!.key)
+
+    // Pick two systems with containers (so cascade is visible)
+    const ws = await workspace.getWorkspace()
+    const systems = ws!.model.softwareSystems.filter(s => s.containers.length > 0).slice(0, 2)
+    test.skip(systems.length < 2, 'sample workspace has fewer than 2 systems with containers')
+
+    // Multi-select via shift-click
+    await workspace.clickNode(systems[0].name)
+    await workspace.page.keyboard.down('Shift')
+    await workspace.clickNode(systems[1].name)
+    await workspace.page.keyboard.up('Shift')
+
+    // Click "Delete from model" in the toolbar
+    await workspace.page.getByRole('button', { name: /delete from model/i }).first().click()
+
+    // Confirm dialog appears with impact list
+    const dialog = workspace.page.getByRole('dialog', { name: /confirm delete/i })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('list', { name: /cascade impact/i })).toBeVisible()
+  })
+})
+
 async function readPositions(page: import('@playwright/test').Page, ids: string[]) {
   return page.evaluate(({ ids }) => {
     type WS = { views: { systemContextViews: Array<{ elements: Array<{ id: string; x?: number; y?: number }> }> } }

--- a/e2e/scenarios/reusable-scenarios.spec.ts
+++ b/e2e/scenarios/reusable-scenarios.spec.ts
@@ -179,13 +179,13 @@ test.describe('Reusable architecture scenarios', () => {
     expect(snapshot?.model.groups).toHaveLength(1)
   })
 
-  test('12. deleting a selected element can be confirmed and undone', async ({ workspace }) => {
+  test('12. Shift+Delete on a selected element can be confirmed and undone', async ({ workspace }) => {
     await workspace.loadBlank()
 
     await workspace.page.keyboard.press('Shift+S')
     await workspace.clickNode('New System')
-    await workspace.page.keyboard.press('Delete')
-    await workspace.page.getByRole('dialog', { name: 'Confirm delete' }).getByRole('button', { name: 'Delete', exact: true }).click()
+    await workspace.page.keyboard.press('Shift+Delete')
+    await workspace.page.getByRole('dialog', { name: 'Confirm delete' }).getByRole('button', { name: /delete/i }).click()
     await workspace.page.waitForTimeout(300)
 
     await expect(workspace.getVisibleNodeByName('New System')).not.toBeVisible()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5544,9 +5544,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,6 +146,7 @@ export default function App() {
       {pendingDelete && (
         <ConfirmDeleteDialog
           message={pendingDelete.message}
+          impact={pendingDelete.impact}
           onConfirm={() => { pendingDelete.onConfirm(); cancelDelete() }}
           onCancel={cancelDelete}
         />

--- a/src/components/layout/AddElementPanel.test.tsx
+++ b/src/components/layout/AddElementPanel.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react'
+import { useWorkspaceStore } from '@/store/workspace'
+import type { Workspace } from '@/types/model'
+import AddElementPanel from './AddElementPanel'
+
+vi.mock('lucide-react', () => ({
+  UserRound: () => null,
+  Globe: () => null,
+  Box: () => null,
+  Puzzle: () => null,
+  Plus: () => null,
+  Search: () => null,
+  Database: () => null,
+  Zap: () => null,
+  GitMerge: () => null,
+  Smartphone: () => null,
+  HardDrive: () => null,
+  Monitor: () => null,
+  ChevronDown: () => null,
+}))
+
+function makeWs(): Workspace {
+  return {
+    name: 'Test',
+    model: {
+      people: [],
+      softwareSystems: [
+        {
+          id: 'focal',
+          type: 'softwareSystem',
+          name: 'Focal System',
+          tags: ['Element', 'Software System'],
+          properties: {},
+          containers: [
+            { id: 'web', type: 'container', name: 'Web', tags: ['Element', 'Container'], properties: {}, components: [] },
+          ],
+        },
+        {
+          id: 'peer',
+          type: 'softwareSystem',
+          name: 'Peer System',
+          tags: ['Element', 'Software System'],
+          properties: {},
+          containers: [],
+        },
+      ],
+      relationships: [],
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [],
+      systemContextViews: [],
+      containerViews: [
+        {
+          type: 'container',
+          key: 'focal-containers',
+          title: 'Focal Containers',
+          softwareSystemId: 'focal',
+          elements: [{ id: 'web' }],
+          relationships: [],
+        },
+      ],
+      componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+beforeEach(() => {
+  useWorkspaceStore.getState().closeWorkspace()
+})
+
+describe('AddElementPanel — focal scope exclusion', () => {
+  it('excludes the focal system from "Add existing" on its own container view', () => {
+    const ws = makeWs()
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('focal-containers')
+
+    render(<AddElementPanel onClose={() => {}} />)
+
+    // Peer system is a legitimate sibling and should appear
+    expect(screen.queryByText('Peer System')).not.toBeNull()
+    // Focal system must NOT appear — adding it would let the user delete the
+    // entire system (and all its containers/components/scoped views) by
+    // "removing" the node from the canvas.
+    expect(screen.queryByText('Focal System')).toBeNull()
+  })
+})

--- a/src/components/layout/AddElementPanel.tsx
+++ b/src/components/layout/AddElementPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useWorkspaceStore, getCreatableTypes, getActiveView, buildElementMap } from '@/store/workspace'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
 import type { ModelElement } from '@/types/model'
@@ -36,6 +36,31 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
   const [search, setSearch] = useState('')
   const [createExpanded, setCreateExpanded] = useState(true)
   const isMobile = useBreakpoint() === 'mobile'
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // ArrowUp/ArrowDown cycle through every focusable control in the panel
+  // (search input + chips + element-list buttons). Tab/Shift+Tab still work
+  // natively; ArrowLeft/Right and Home/End are left alone so they keep doing
+  // text-cursor moves inside the search input.
+  useEffect(() => {
+    const panel = panelRef.current
+    if (!panel) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+      const items = Array.from(
+        panel!.querySelectorAll<HTMLElement>('button:not([disabled]), input[type="text"]'),
+      )
+      if (items.length === 0) return
+      const idx = items.indexOf(document.activeElement as HTMLElement)
+      let next: number
+      if (e.key === 'ArrowDown') next = idx === -1 ? 0 : (idx + 1) % items.length
+      else next = idx <= 0 ? items.length - 1 : idx - 1
+      e.preventDefault()
+      items[next]?.focus()
+    }
+    panel.addEventListener('keydown', handleKeyDown)
+    return () => panel.removeEventListener('keydown', handleKeyDown)
+  }, [])
 
   // On mobile, clear selection after adding so the inspector doesn't auto-open
   const afterAdd = useCallback(() => {
@@ -76,11 +101,20 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
   if (creatableTypes.canCreateContainer !== null) allowedTypes.add('container')
   if (creatableTypes.canCreateComponent !== null) allowedTypes.add('component')
 
-  // Filter existing elements: must be an allowed type AND not already in view.
+  // A scoped view's focal element decomposes *into* the view; it must never
+  // appear as a sibling. Adding it would let the user delete the system from
+  // its own L2 view, which cascades through every container, component,
+  // relationship, and scoped view underneath it.
+  const focalScopeId =
+    view?.type === 'container' ? view.softwareSystemId :
+    view?.type === 'component' ? view.containerId :
+    undefined
+
+  // Filter existing elements: must be an allowed type AND not already in view AND not the focal scope.
   // Sort alphabetically so the list is predictable regardless of creation order.
   const allElements = Array.from(elementMap.values())
   const notInView = allElements
-    .filter((el) => allowedTypes.has(el.type) && !viewElementIds.has(el.id))
+    .filter((el) => allowedTypes.has(el.type) && !viewElementIds.has(el.id) && el.id !== focalScopeId)
     .sort((a, b) => a.name.localeCompare(b.name))
 
   const query = search.toLowerCase().trim()
@@ -161,6 +195,7 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
 
   return (
     <div
+      ref={panelRef}
       className="glass-flyout"
       style={{
         position: 'absolute',

--- a/src/components/layout/MultiSelectBar.tsx
+++ b/src/components/layout/MultiSelectBar.tsx
@@ -243,6 +243,7 @@ export default function MultiSelectBar() {
         {/* Delete from model */}
         <button className="hover-lift" style={{ ...btnStyle, color: 'var(--color-error)', paddingRight: 12 }}
           title={`Delete ${count} elements from the model`}
+          aria-label={`Delete ${count} elements from the model`}
           onClick={() => {
             if (!workspace || !activeViewKey) return
             const ids = selectedElementIds.filter(

--- a/src/components/layout/MultiSelectBar.tsx
+++ b/src/components/layout/MultiSelectBar.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useReactFlow } from '@xyflow/react'
-import { useWorkspaceStore } from '@/store/workspace'
+import { useWorkspaceStore, isFocalScopeElement } from '@/store/workspace'
+import { computeCascadeImpact } from '@/store/workspace-helpers'
+import { formatImpactSummary } from '@/lib/impactMessage'
 import {
   AlignStartVertical,
   AlignCenterVertical,
@@ -19,6 +21,8 @@ export default function MultiSelectBar() {
   const selectGroup = useWorkspaceStore((s) => s.selectGroup)
   const deleteElements = useWorkspaceStore((s) => s.deleteElements)
   const confirmDelete = useWorkspaceStore((s) => s.confirmDelete)
+  const workspace = useWorkspaceStore((s) => s.workspace)
+  const activeViewKey = useWorkspaceStore((s) => s.activeViewKey)
   const updateNodePositions = useWorkspaceStore((s) => s.updateNodePositions)
   const reactFlow = useReactFlow()
   const [alignOpen, setAlignOpen] = useState(false)
@@ -236,13 +240,21 @@ export default function MultiSelectBar() {
 
         {sep}
 
-        {/* Delete */}
+        {/* Delete from model */}
         <button className="hover-lift" style={{ ...btnStyle, color: 'var(--color-error)', paddingRight: 12 }}
-          title={`Delete ${count} elements`}
-          onClick={() => confirmDelete(`Delete ${count} elements?`, () => deleteElements(selectedElementIds))}
+          title={`Delete ${count} elements from the model`}
+          onClick={() => {
+            if (!workspace || !activeViewKey) return
+            const ids = selectedElementIds.filter(
+              (id) => !isFocalScopeElement(workspace, activeViewKey, id),
+            )
+            if (ids.length === 0) return
+            const impact = computeCascadeImpact(workspace, ids)
+            confirmDelete({ message: formatImpactSummary(impact), impact }, () => deleteElements(ids))
+          }}
         >
           <Trash2 size={14} />
-          <span>Delete</span>
+          <span>Delete from model</span>
         </button>
       </div>
     </div>

--- a/src/components/layout/RightPanel.test.tsx
+++ b/src/components/layout/RightPanel.test.tsx
@@ -194,8 +194,8 @@ describe('RightPanel', () => {
     useWorkspaceStore.getState().selectElements(['api'])
     render(<RightPanel />)
 
-    expect(screen.queryByLabelText(/delete element/i)).toBeNull()
-    expect(screen.queryByLabelText(/delete from model/i)).toBeNull()
+    const btn = screen.getByLabelText(/delete from model.*focal scope/i)
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
     expect(screen.getByText(/scopes the current view/i)).toBeTruthy()
   })
 

--- a/src/components/layout/RightPanel.test.tsx
+++ b/src/components/layout/RightPanel.test.tsx
@@ -17,6 +17,7 @@ vi.mock('lucide-react', () => ({
   AlertTriangle: () => null,
   Settings: () => null,
   ChevronDown: () => null,
+  ChevronRight: () => null,
   // elementMeta icons
   UserRound: () => null,
   Globe: () => null,
@@ -163,6 +164,71 @@ describe('RightPanel', () => {
     render(<RightPanel />)
     // Group name appears in an input field
     expect(screen.getByDisplayValue('My Team')).toBeTruthy()
+  })
+
+  it('shows static hint instead of Delete button when selected element is the focal scope of the active view', () => {
+    // Use a custom workspace: 'api' system has a container, plus a container view scoped to 'api'.
+    // When 'api' is selected on its own container view, the trash button must be replaced
+    // with the "scopes the current view" hint.
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [{
+          id: 'api', type: 'softwareSystem', name: 'API', tags: ['Element', 'Software System'], properties: {},
+          containers: [{ id: 'web', type: 'container', name: 'Web', tags: ['Element', 'Container'], properties: {}, components: [] }],
+        }],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [], systemContextViews: [], componentViews: [],
+        containerViews: [{
+          type: 'container', key: 'cont', softwareSystemId: 'api',
+          elements: [{ id: 'web' }], relationships: [],
+        }],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['api'])
+    render(<RightPanel />)
+
+    expect(screen.queryByLabelText(/delete element/i)).toBeNull()
+    expect(screen.queryByLabelText(/delete from model/i)).toBeNull()
+    expect(screen.getByText(/scopes the current view/i)).toBeTruthy()
+  })
+
+  it('routes Delete from model through impact-aware confirmDelete', () => {
+    // Load a system w/ containers and select on landscape view (where the system is NOT focal).
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [{
+          id: 'api', type: 'softwareSystem', name: 'API', tags: ['Element', 'Software System'], properties: {},
+          containers: [
+            { id: 'web', type: 'container', name: 'Web', tags: [], properties: {}, components: [] },
+            { id: 'db',  type: 'container', name: 'DB',  tags: [], properties: {}, components: [] },
+          ],
+        }],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [{ type: 'systemLandscape', key: 'land', elements: [{ id: 'api' }], relationships: [] }],
+        systemContextViews: [], containerViews: [], componentViews: [],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('land')
+    useWorkspaceStore.getState().selectElements(['api'])
+    render(<RightPanel />)
+
+    fireEvent.click(screen.getByLabelText(/delete from model/i))
+    const pd = useWorkspaceStore.getState().pendingDelete
+    expect(pd?.impact?.descendantContainers).toBe(2)
+    expect(pd?.message).toMatch(/Delete "API" from the model/)
   })
 
   it('close button clears selection', async () => {

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -1,5 +1,7 @@
 import { useState, useCallback, useMemo } from 'react'
-import { useWorkspaceStore, getSelectedElement, getRelationshipById, buildElementMap, getAllViews } from '@/store/workspace'
+import { useWorkspaceStore, getSelectedElement, getRelationshipById, buildElementMap, getAllViews, isFocalScopeElement } from '@/store/workspace'
+import { computeCascadeImpact } from '@/store/workspace-helpers'
+import { formatImpactSummary } from '@/lib/impactMessage'
 import type { ModelElement, Container, Component, Person, SoftwareSystem, Relationship, ElementStatus, Location } from '@/types/model'
 import { X, Plus, ArrowRight, ExternalLink, Eye, ChevronRight, Trash2 } from 'lucide-react'
 import { TYPE_COLORS, getElementTypeLabel } from '@/lib/elementMeta'
@@ -72,6 +74,10 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
   const deleteElement = useWorkspaceStore((s) => s.deleteElement)
   const confirmDelete = useWorkspaceStore((s) => s.confirmDelete)
   const workspace = useWorkspaceStore((s) => s.workspace)
+  const activeViewKey = useWorkspaceStore((s) => s.activeViewKey)
+  const isFocal = workspace && activeViewKey
+    ? isFocalScopeElement(workspace, activeViewKey, element.id)
+    : false
   const tech = (element as Container | Component).technology
   const hasTech = element.type === 'container' || element.type === 'component'
   const hasLocation = element.type === 'person' || element.type === 'softwareSystem'
@@ -93,15 +99,29 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
           <div className="text-[11px]" style={{ color: typeColor }}>{getElementTypeLabel(element)}</div>
         </div>
         <div className="flex items-center gap-1">
-          <button
-            onClick={() => confirmDelete(`Delete ${element.name}?`, () => deleteElement(element.id))}
-            className="btn-icon !min-h-7 !min-w-7 !p-1"
-            aria-label="Delete element"
-            title="Delete element"
-            style={{ color: 'var(--color-error-text)' }}
-          >
-            <Trash2 size={14} />
-          </button>
+          {isFocal ? (
+            <span
+              className="text-[11px]"
+              style={{ color: 'var(--color-text-muted)', maxWidth: 220, lineHeight: 1.3 }}
+              title="Open the parent view to delete this element"
+            >
+              Scopes the current view — open parent view to delete
+            </span>
+          ) : (
+            <button
+              onClick={() => {
+                if (!workspace) return
+                const impact = computeCascadeImpact(workspace, [element.id])
+                confirmDelete({ message: formatImpactSummary(impact), impact }, () => deleteElement(element.id))
+              }}
+              className="btn-icon !min-h-7 !min-w-7 !p-1"
+              aria-label="Delete from model"
+              title="Delete from model"
+              style={{ color: 'var(--color-error-text)' }}
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
           <button onClick={onClose} className="btn-icon !min-h-7 !min-w-7 !p-1" aria-label="Close panel"><X size={14} /></button>
         </div>
       </div>

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -75,9 +75,10 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
   const confirmDelete = useWorkspaceStore((s) => s.confirmDelete)
   const workspace = useWorkspaceStore((s) => s.workspace)
   const activeViewKey = useWorkspaceStore((s) => s.activeViewKey)
-  const isFocal = workspace && activeViewKey
-    ? isFocalScopeElement(workspace, activeViewKey, element.id)
-    : false
+  const isFocal = useMemo(
+    () => workspace && activeViewKey ? isFocalScopeElement(workspace, activeViewKey, element.id) : false,
+    [workspace, activeViewKey, element.id],
+  )
   const tech = (element as Container | Component).technology
   const hasTech = element.type === 'container' || element.type === 'component'
   const hasLocation = element.type === 'person' || element.type === 'softwareSystem'
@@ -100,13 +101,15 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
         </div>
         <div className="flex items-center gap-1">
           {isFocal ? (
-            <span
-              className="text-[11px]"
-              style={{ color: 'var(--color-text-muted)', maxWidth: 220, lineHeight: 1.3 }}
-              title="Open the parent view to delete this element"
+            <button
+              disabled
+              aria-label="Delete from model (disabled — focal scope)"
+              title="This element scopes the current view. Open the parent view to delete it."
+              className="btn-icon !min-h-7 !min-w-7 !p-1"
+              style={{ color: 'var(--color-text-muted)', opacity: 0.5, cursor: 'not-allowed' }}
             >
-              Scopes the current view — open parent view to delete
-            </span>
+              <Trash2 size={14} />
+            </button>
           ) : (
             <button
               onClick={() => {
@@ -125,6 +128,21 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
           <button onClick={onClose} className="btn-icon !min-h-7 !min-w-7 !p-1" aria-label="Close panel"><X size={14} /></button>
         </div>
       </div>
+
+      {/* Focal-scope hint banner */}
+      {isFocal && (
+        <div
+          className="px-4 py-2 text-[11px]"
+          style={{
+            background: 'var(--color-surface-2)',
+            color: 'var(--color-text-muted)',
+            borderBottom: '1px solid var(--color-border)',
+            lineHeight: 1.4,
+          }}
+        >
+          Scopes the current view — open the parent view to delete this element.
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="flex border-b px-1" style={{ borderColor: 'var(--color-border)' }} role="tablist" aria-label="Element details">

--- a/src/components/shared/ConfirmDeleteDialog.test.tsx
+++ b/src/components/shared/ConfirmDeleteDialog.test.tsx
@@ -183,4 +183,31 @@ describe('ConfirmDeleteDialog', () => {
     expect(onConfirm).not.toHaveBeenCalled()
     expect(onCancel).not.toHaveBeenCalled()
   })
+
+  it('renders a structured impact list when impact prop is present', () => {
+    render(
+      <ConfirmDeleteDialog
+        message='Delete "Payments API" from the model?'
+        impact={{
+          elementCount: 1, elementNames: ['Payments API'],
+          descendantContainers: 4, descendantComponents: 11,
+          relationships: 7, scopedViews: 2,
+        }}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    )
+    expect(screen.getByRole('list', { name: /cascade impact/i })).toBeTruthy()
+    expect(screen.getByText(/4 containers/)).toBeTruthy()
+    expect(screen.getByText(/11 components/)).toBeTruthy()
+    expect(screen.getByText(/7 relationships/)).toBeTruthy()
+    expect(screen.getByText(/2 dependent views/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: /delete from model/i })).toBeTruthy()
+  })
+
+  it('shows "Delete" label when impact prop is absent', () => {
+    render(<ConfirmDeleteDialog message='Delete this view "Foo"?' onConfirm={() => {}} onCancel={() => {}} />)
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeTruthy()
+    expect(screen.queryByRole('list', { name: /cascade impact/i })).toBeNull()
+  })
 })

--- a/src/components/shared/ConfirmDeleteDialog.test.tsx
+++ b/src/components/shared/ConfirmDeleteDialog.test.tsx
@@ -210,4 +210,21 @@ describe('ConfirmDeleteDialog', () => {
     expect(screen.getByRole('button', { name: /^delete$/i })).toBeTruthy()
     expect(screen.queryByRole('list', { name: /cascade impact/i })).toBeNull()
   })
+
+  it('keeps "Delete" label when impact has all zero counts', () => {
+    render(
+      <ConfirmDeleteDialog
+        message='Delete "Lonely" from the model?'
+        impact={{
+          elementCount: 1, elementNames: ['Lonely'],
+          descendantContainers: 0, descendantComponents: 0,
+          relationships: 0, scopedViews: 0,
+        }}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    )
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeTruthy()
+    expect(screen.queryByRole('list', { name: /cascade impact/i })).toBeNull()
+  })
 })

--- a/src/components/shared/ConfirmDeleteDialog.tsx
+++ b/src/components/shared/ConfirmDeleteDialog.tsx
@@ -137,7 +137,7 @@ export default function ConfirmDeleteDialog({ message, impact, onConfirm, onCanc
               fontSize: 'var(--text-sm)', fontWeight: 600, cursor: 'pointer',
             }}
           >
-            {impact ? 'Delete from model' : 'Delete'}
+            {impactItems.length > 0 ? 'Delete from model' : 'Delete'}
           </button>
         </div>
       </div>

--- a/src/components/shared/ConfirmDeleteDialog.tsx
+++ b/src/components/shared/ConfirmDeleteDialog.tsx
@@ -1,15 +1,26 @@
 import { useEffect, useRef } from 'react'
 import { Trash2 } from 'lucide-react'
+import type { CascadeImpact } from '@/store/workspace-helpers'
 
 interface Props {
   message: string
+  impact?: CascadeImpact
   onConfirm: () => void
   onCancel: () => void
 }
 
-export default function ConfirmDeleteDialog({ message, onConfirm, onCancel }: Props) {
+export default function ConfirmDeleteDialog({ message, impact, onConfirm, onCancel }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const confirmRef = useRef<HTMLButtonElement>(null)
+
+  const impactItems: string[] = []
+  if (impact) {
+    const { descendantContainers: c, descendantComponents: comp, relationships: r, scopedViews: v } = impact
+    if (c > 0) impactItems.push(`${c} ${c === 1 ? 'container' : 'containers'}`)
+    if (comp > 0) impactItems.push(`${comp} ${comp === 1 ? 'component' : 'components'}`)
+    if (r > 0) impactItems.push(`${r} ${r === 1 ? 'relationship' : 'relationships'}`)
+    if (v > 0) impactItems.push(`${v} ${v === 1 ? 'dependent view' : 'dependent views'}`)
+  }
 
   useEffect(() => {
     confirmRef.current?.focus()
@@ -84,6 +95,23 @@ export default function ConfirmDeleteDialog({ message, onConfirm, onCancel }: Pr
             <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
               {message}
             </div>
+            {impactItems.length > 0 && (
+              <ul
+                aria-label="Cascade impact"
+                style={{
+                  listStyle: 'none', padding: 0, margin: '8px 0 0',
+                  display: 'flex', flexDirection: 'column', gap: 4,
+                  fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)',
+                }}
+              >
+                {impactItems.map((item) => (
+                  <li key={item} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ color: 'var(--color-error)', fontSize: 10 }}>●</span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
 
@@ -109,7 +137,7 @@ export default function ConfirmDeleteDialog({ message, onConfirm, onCancel }: Pr
               fontSize: 'var(--text-sm)', fontWeight: 600, cursor: 'pointer',
             }}
           >
-            Delete
+            {impact ? 'Delete from model' : 'Delete'}
           </button>
         </div>
       </div>

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react'
+import { useWorkspaceStore } from '@/store/workspace'
+import { useKeyboardShortcuts } from './useKeyboardShortcuts'
+import type { Workspace } from '@/types/model'
+
+vi.mock('@xyflow/react', () => ({ useReactFlow: () => { throw new Error('not in flow') } }))
+
+function makeWs(): Workspace {
+  return {
+    name: 'T',
+    model: {
+      people: [],
+      softwareSystems: [
+        { id: 'sys', type: 'softwareSystem', name: 'S', tags: [], properties: {},
+          containers: [
+            { id: 'c1', type: 'container', name: 'C1', tags: [], properties: {}, components: [] },
+            { id: 'c2', type: 'container', name: 'C2', tags: [], properties: {}, components: [] },
+          ],
+        },
+        { id: 'peer', type: 'softwareSystem', name: 'Peer', tags: [], properties: {}, containers: [] },
+      ],
+      relationships: [], groups: [],
+    },
+    views: {
+      systemLandscapeViews: [{
+        type: 'systemLandscape', key: 'land', elements: [{ id: 'sys' }, { id: 'peer' }], relationships: [],
+      }],
+      systemContextViews: [],
+      containerViews: [{
+        type: 'container', key: 'cont', softwareSystemId: 'sys',
+        elements: [{ id: 'c1' }, { id: 'c2' }], relationships: [],
+      }],
+      componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+function press(key: string, opts: { shift?: boolean } = {}) {
+  const ev = new KeyboardEvent('keydown', { key, shiftKey: !!opts.shift, bubbles: true })
+  window.dispatchEvent(ev)
+}
+
+beforeEach(() => useWorkspaceStore.getState().closeWorkspace())
+
+describe('useKeyboardShortcuts — delete semantics', () => {
+  it('Backspace removes selected element from the view but keeps it in the model', () => {
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['c2'])
+    renderHook(() => useKeyboardShortcuts())
+
+    press('Backspace')
+
+    const w = useWorkspaceStore.getState().workspace!
+    expect(w.views.containerViews[0].elements.map(e => e.id)).toEqual(['c1'])
+    // Model intact:
+    expect(w.model.softwareSystems[0].containers.map(c => c.id)).toEqual(['c1', 'c2'])
+    // No confirm dialog raised (lightweight action):
+    expect(useWorkspaceStore.getState().pendingDelete).toBeNull()
+  })
+
+  it('Shift+Backspace raises an impact-aware confirm dialog', () => {
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('land')
+    useWorkspaceStore.getState().selectElements(['sys'])
+    renderHook(() => useKeyboardShortcuts())
+
+    press('Backspace', { shift: true })
+
+    const pd = useWorkspaceStore.getState().pendingDelete
+    expect(pd).not.toBeNull()
+    expect(pd!.impact?.descendantContainers).toBe(2)
+    expect(pd!.impact?.scopedViews).toBe(1)             // 'cont' view scoped to 'sys'
+    expect(pd!.message).toMatch(/Delete "S" from the model/)
+  })
+
+  it('Backspace on the focal-scope element of a container view is a no-op', () => {
+    // Defense in depth: the canvas shouldn't show the focal system as a node
+    // on its own container view, but if a future regression lets it be selected,
+    // Backspace must not silently remove or delete it.
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['sys'])
+    renderHook(() => useKeyboardShortcuts())
+
+    press('Backspace')
+    press('Backspace', { shift: true })
+
+    const w = useWorkspaceStore.getState().workspace!
+    // System still in model:
+    expect(w.model.softwareSystems.find(s => s.id === 'sys')).toBeDefined()
+    // No confirm raised:
+    expect(useWorkspaceStore.getState().pendingDelete).toBeNull()
+  })
+})

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -75,6 +75,26 @@ describe('useKeyboardShortcuts — delete semantics', () => {
     expect(pd!.message).toMatch(/Delete "S" from the model/)
   })
 
+  it('Backspace on a mixed selection drops focal-scope IDs and proceeds with the rest', () => {
+    // The user's selection is ['sys', 'c1'] on the container view scoped to 'sys'.
+    // 'sys' is focal — it should be silently filtered out.
+    // 'c1' is not focal — it should be removed from the view.
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['sys', 'c1'])
+    renderHook(() => useKeyboardShortcuts())
+
+    press('Backspace')
+
+    const w = useWorkspaceStore.getState().workspace!
+    // c1 removed from the container view, c2 still there:
+    expect(w.views.containerViews[0].elements.map(e => e.id)).toEqual(['c2'])
+    // sys still in the model (focal scope is never destroyed by this path):
+    expect(w.model.softwareSystems.find(s => s.id === 'sys')).toBeDefined()
+    // No confirm dialog:
+    expect(useWorkspaceStore.getState().pendingDelete).toBeNull()
+  })
+
   it('Backspace on the focal-scope element of a container view is a no-op', () => {
     // Defense in depth: the canvas shouldn't show the focal system as a node
     // on its own container view, but if a future regression lets it be selected,

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 import { useReactFlow } from '@xyflow/react'
-import { useWorkspaceStore, getCreatableTypes, getActiveView } from '@/store/workspace'
+import { useWorkspaceStore, getCreatableTypes, getActiveView, isFocalScopeElement } from '@/store/workspace'
+import { computeCascadeImpact } from '@/store/workspace-helpers'
+import { formatImpactSummary } from '@/lib/impactMessage'
 import { serializeDSL } from '@/lib/dsl'
 import { saveDSLFile, openDSLFile, writeSidecarToHandle } from '@/lib/fileIO'
 import { extractSidecar, serializeSidecar } from '@/lib/sidecar'
@@ -20,6 +22,44 @@ const META_SHORTCUTS: Record<string, KeyHandler> = {
   'mod+f': (store) => {
     store.setSearchOpen(!store.searchOpen)
   },
+}
+
+/**
+ * Factory for Backspace/Delete handlers.
+ * destructive=false → remove from view only (no confirm).
+ * destructive=true  → impact-aware confirm, then deleteElements.
+ * Focal-scope IDs are always filtered out; if only focal-scope IDs were
+ * selected, the key is a no-op.
+ */
+function backspaceLikeHandler(destructive: boolean): KeyHandler {
+  return (store) => {
+    if (store.selectedRelationshipId) {
+      // Relationships are not redesigned in this plan — keep current confirm + delete behavior
+      // for both Backspace and Shift+Backspace on a selected relationship.
+      store.confirmDelete('Delete this relationship?', () => store.deleteRelationship(store.selectedRelationshipId!))
+      return
+    }
+    if (store.selectedElementIds.length === 0) {
+      if (store.viewHistory.length > 0) store.navigateBack()
+      return
+    }
+    if (!store.workspace || !store.activeViewKey) return
+
+    // Filter focal-scope IDs from the operation either way.
+    const ids = store.selectedElementIds.filter(
+      (id) => !isFocalScopeElement(store.workspace!, store.activeViewKey!, id),
+    )
+    if (ids.length === 0) return // selection was *only* focal scope — no-op
+
+    if (!destructive) {
+      store.removeElementsFromView(store.activeViewKey, ids)
+      return
+    }
+
+    const impact = computeCascadeImpact(store.workspace, ids)
+    const message = formatImpactSummary(impact)
+    store.confirmDelete({ message, impact }, () => store.deleteElements(ids))
+  }
 }
 
 /** Shortcuts that only fire when NOT typing in an input */
@@ -66,41 +106,15 @@ const GLOBAL_SHORTCUTS: Record<string, KeyHandler> = {
     if (store.selectedElementIds.length > 0 || store.selectedRelationshipId || store.selectedGroupId) { store.clearSelection(); return }
     if (store.viewHistory.length > 0) { store.navigateBack() }
   },
-  'Backspace': (store) => {
-    if (store.selectedRelationshipId) {
-      store.confirmDelete('Delete this relationship?', () => store.deleteRelationship(store.selectedRelationshipId!))
-      return
-    }
-    if (store.selectedElementIds.length > 0) {
-      const count = store.selectedElementIds.length
-      store.confirmDelete(
-        count === 1 ? 'Delete this element?' : `Delete ${count} elements?`,
-        () => store.deleteElements(store.selectedElementIds)
-      )
-      return
-    }
-    if (store.viewHistory.length > 0) {
-      store.navigateBack()
-    }
-  },
+  'Backspace': backspaceLikeHandler(false),
   'Enter': (store) => {
     if (store.selectedElementIds.length === 1) {
       store.drillInto(store.selectedElementIds[0])
     }
   },
-  'Delete': (store) => {
-    if (store.selectedRelationshipId) {
-      store.confirmDelete('Delete this relationship?', () => store.deleteRelationship(store.selectedRelationshipId!))
-      return
-    }
-    if (store.selectedElementIds.length > 0) {
-      const count = store.selectedElementIds.length
-      store.confirmDelete(
-        count === 1 ? 'Delete this element?' : `Delete ${count} elements?`,
-        () => store.deleteElements(store.selectedElementIds)
-      )
-    }
-  },
+  'Delete': backspaceLikeHandler(false),
+  'shift+Backspace': backspaceLikeHandler(true),
+  'shift+Delete': backspaceLikeHandler(true),
   'shift+G': (store) => {
     if (store.selectedElementIds.length > 0) store.addGroup('New Group', store.selectedElementIds)
   },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -46,17 +46,19 @@ function backspaceLikeHandler(destructive: boolean): KeyHandler {
     if (!store.workspace || !store.activeViewKey) return
 
     // Filter focal-scope IDs from the operation either way.
+    const ws = store.workspace
+    const viewKey = store.activeViewKey
     const ids = store.selectedElementIds.filter(
-      (id) => !isFocalScopeElement(store.workspace!, store.activeViewKey!, id),
+      (id) => !isFocalScopeElement(ws, viewKey, id),
     )
     if (ids.length === 0) return // selection was *only* focal scope — no-op
 
     if (!destructive) {
-      store.removeElementsFromView(store.activeViewKey, ids)
+      store.removeElementsFromView(viewKey, ids)
       return
     }
 
-    const impact = computeCascadeImpact(store.workspace, ids)
+    const impact = computeCascadeImpact(ws, ids)
     const message = formatImpactSummary(impact)
     store.confirmDelete({ message, impact }, () => store.deleteElements(ids))
   }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -6,7 +6,9 @@ import {
   Presentation, FolderOpen, Image, FileCode, Copy, Plus,
   Highlighter, MousePointerClick, RotateCcw,
 } from 'lucide-react'
-import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews } from '@/store/workspace'
+import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews, isFocalScopeElement } from '@/store/workspace'
+import { computeCascadeImpact } from '@/store/workspace-helpers'
+import { formatImpactSummary } from '@/lib/impactMessage'
 import { serializeDSL } from '@/lib/dsl'
 import { saveDSLFile, writeSidecarToHandle } from '@/lib/fileIO'
 import { downloadFile, downloadBlob, exportCanvasAsPNG, exportCanvasAsSVG } from '@/lib/exportUtils'
@@ -140,10 +142,10 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
     },
     {
       id: 'delete-selected',
-      label: 'Delete Selected',
+      label: 'Delete Selected from model',
       category: 'edit',
       icon: Trash2,
-      shortcut: '⌫',
+      shortcut: '⇧⌫',
       keywords: ['remove', 'delete'],
       when: () => store().selectedElementIds.length > 0 || store().selectedRelationshipId !== null,
       execute: () => {
@@ -152,13 +154,16 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
           s.confirmDelete('Delete this relationship?', () => s.deleteRelationship(s.selectedRelationshipId!))
           return
         }
-        if (s.selectedElementIds.length > 0) {
-          const count = s.selectedElementIds.length
-          s.confirmDelete(
-            count === 1 ? 'Delete this element?' : `Delete ${count} elements?`,
-            () => s.deleteElements(s.selectedElementIds),
-          )
-        }
+        if (!s.workspace || !s.activeViewKey) return
+        const ids = s.selectedElementIds.filter(
+          (id) => !isFocalScopeElement(s.workspace!, s.activeViewKey!, id),
+        )
+        if (ids.length === 0) return
+        const impact = computeCascadeImpact(s.workspace, ids)
+        s.confirmDelete(
+          { message: formatImpactSummary(impact), impact },
+          () => s.deleteElements(ids),
+        )
       },
     },
     {

--- a/src/lib/impactMessage.test.ts
+++ b/src/lib/impactMessage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { formatImpactSummary } from './impactMessage'
+
+describe('formatImpactSummary', () => {
+  it('returns a single-element message with no cascade when nothing else falls', () => {
+    const msg = formatImpactSummary({
+      elementCount: 1, elementNames: ['Alice'],
+      descendantContainers: 0, descendantComponents: 0,
+      relationships: 0, scopedViews: 0,
+    })
+    expect(msg).toBe('Delete "Alice" from the model?')
+  })
+
+  it('summarizes a system with descendants, relationships, and dependent views', () => {
+    const msg = formatImpactSummary({
+      elementCount: 1, elementNames: ['Payments API'],
+      descendantContainers: 4, descendantComponents: 11,
+      relationships: 7, scopedViews: 2,
+    })
+    expect(msg).toBe(
+      'Delete "Payments API" from the model? This will also remove ' +
+      '4 containers, 11 components, 7 relationships, and 2 dependent views.'
+    )
+  })
+
+  it('omits zero-count clauses', () => {
+    const msg = formatImpactSummary({
+      elementCount: 1, elementNames: ['Alice'],
+      descendantContainers: 0, descendantComponents: 0,
+      relationships: 3, scopedViews: 0,
+    })
+    expect(msg).toBe('Delete "Alice" from the model? This will also remove 3 relationships.')
+  })
+
+  it('uses singular nouns for counts of 1', () => {
+    const msg = formatImpactSummary({
+      elementCount: 1, elementNames: ['X'],
+      descendantContainers: 1, descendantComponents: 1, relationships: 1, scopedViews: 1,
+    })
+    expect(msg).toBe(
+      'Delete "X" from the model? This will also remove ' +
+      '1 container, 1 component, 1 relationship, and 1 dependent view.'
+    )
+  })
+
+  it('handles multi-element selections without quoting all names', () => {
+    const msg = formatImpactSummary({
+      elementCount: 3, elementNames: ['A', 'B', 'C'],
+      descendantContainers: 0, descendantComponents: 0, relationships: 2, scopedViews: 0,
+    })
+    expect(msg).toBe('Delete 3 elements from the model? This will also remove 2 relationships.')
+  })
+})

--- a/src/lib/impactMessage.ts
+++ b/src/lib/impactMessage.ts
@@ -1,0 +1,31 @@
+import type { CascadeImpact } from '@/store/workspace-helpers'
+
+function pluralize(count: number, singular: string, plural = singular + 's'): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+/**
+ * Build the body of the confirm-delete dialog for a model-level delete.
+ * Always opens with the destructive verb; only adds the "This will also..."
+ * clause when there's actual cascade scope. Pure — no DOM, no store reads.
+ */
+export function formatImpactSummary(impact: CascadeImpact): string {
+  const head = impact.elementCount === 1 && impact.elementNames.length === 1
+    ? `Delete "${impact.elementNames[0]}" from the model?`
+    : `Delete ${impact.elementCount} elements from the model?`
+
+  const clauses: string[] = []
+  if (impact.descendantContainers > 0) clauses.push(pluralize(impact.descendantContainers, 'container'))
+  if (impact.descendantComponents > 0) clauses.push(pluralize(impact.descendantComponents, 'component'))
+  if (impact.relationships > 0) clauses.push(pluralize(impact.relationships, 'relationship'))
+  if (impact.scopedViews > 0) clauses.push(pluralize(impact.scopedViews, 'dependent view'))
+
+  if (clauses.length === 0) return head
+
+  let tail: string
+  if (clauses.length === 1) tail = clauses[0]
+  else if (clauses.length === 2) tail = `${clauses[0]} and ${clauses[1]}`
+  else tail = `${clauses.slice(0, -1).join(', ')}, and ${clauses[clauses.length - 1]}`
+
+  return `${head} This will also remove ${tail}.`
+}

--- a/src/store/slices/ui-slice.ts
+++ b/src/store/slices/ui-slice.ts
@@ -61,6 +61,10 @@ export const createUiSlice: StateCreator<
   setMultiSelectMode: (on) => set({ multiSelectMode: on }),
   setPresentationMode: (on) => set({ presentationMode: on }),
 
-  confirmDelete: (message, onConfirm) => set({ pendingDelete: { message, onConfirm } }),
+  confirmDelete: (payload, onConfirm) => set({
+    pendingDelete: typeof payload === 'string'
+      ? { message: payload, onConfirm }
+      : { message: payload.message, impact: payload.impact, onConfirm },
+  }),
   cancelDelete: () => set({ pendingDelete: null }),
 })

--- a/src/store/slices/view-slice.ts
+++ b/src/store/slices/view-slice.ts
@@ -182,10 +182,11 @@ export const createViewSlice: StateCreator<
     // Defense in depth: never remove the focal scope element from its own view.
     // The keymap layer should already filter these out, but the helper guards
     // again so future callers can't accidentally bypass the rule.
-    const focalId =
+    const focalId: string | undefined =
       view.type === 'systemContext' || view.type === 'container' ? view.softwareSystemId :
       view.type === 'component' ? view.containerId :
-      undefined
+      view.type === 'systemLandscape' ? undefined :
+      ((_: never) => undefined)(view.type)
     const removable = new Set(ids.filter((id) => id !== focalId))
     if (removable.size === 0) return
 

--- a/src/store/slices/view-slice.ts
+++ b/src/store/slices/view-slice.ts
@@ -12,7 +12,7 @@ import { getFirstViewKey } from '../workspace-selectors'
  *  layoutVersion epoch. */
 export type ViewSlice = Pick<WorkspaceState,
   | 'addView' | 'deleteView' | 'renameView' | 'duplicateView'
-  | 'toggleElementInView' | 'setLayoutDirection' | 'resetAndRelayout'
+  | 'toggleElementInView' | 'removeElementsFromView' | 'setLayoutDirection' | 'resetAndRelayout'
   | 'updateNodePosition' | 'updateNodePositions' | 'syncAutoLayoutPositions'
   | 'layoutVersion'
 >
@@ -170,6 +170,32 @@ export const createViewSlice: StateCreator<
       }
       return
     }
+  }),
+
+  removeElementsFromView: (viewKey, ids) => set((s) => {
+    if (!s.workspace) return
+    if (ids.length === 0) return
+    const ws = s.workspace
+    const view = findViewHelper(ws, viewKey)
+    if (!view) return
+
+    // Defense in depth: never remove the focal scope element from its own view.
+    // The keymap layer should already filter these out, but the helper guards
+    // again so future callers can't accidentally bypass the rule.
+    const focalId =
+      view.type === 'systemContext' || view.type === 'container' ? view.softwareSystemId :
+      view.type === 'component' ? view.containerId :
+      undefined
+    const removable = new Set(ids.filter((id) => id !== focalId))
+    if (removable.size === 0) return
+
+    pushUndoSnapshot(s)
+    view.elements = view.elements.filter((e) => !removable.has(e.id))
+    view.relationships = view.relationships.filter((r) => {
+      const rel = ws.model.relationships.find((mr) => mr.id === r.id)
+      if (!rel) return false
+      return !removable.has(rel.sourceId) && !removable.has(rel.destinationId)
+    })
   }),
 
   toggleElementInView: (viewKey, elementId) => set((s) => {

--- a/src/store/slices/view-slice.ts
+++ b/src/store/slices/view-slice.ts
@@ -186,7 +186,7 @@ export const createViewSlice: StateCreator<
       view.type === 'systemContext' || view.type === 'container' ? view.softwareSystemId :
       view.type === 'component' ? view.containerId :
       view.type === 'systemLandscape' ? undefined :
-      ((_: never) => undefined)(view.type)
+      ((vt: never): undefined => { throw new Error(`unhandled view type: ${String(vt)}`) })(view.type)
     const removable = new Set(ids.filter((id) => id !== focalId))
     if (removable.size === 0) return
 

--- a/src/store/workspace-helpers.test.ts
+++ b/src/store/workspace-helpers.test.ts
@@ -38,6 +38,7 @@ describe('computeCascadeImpact', () => {
   it('returns zero impact for empty input', () => {
     const impact = computeCascadeImpact(ws(), [])
     expect(impact.elementCount).toBe(0)
+    expect(impact.elementNames).toHaveLength(0)
     expect(impact.descendantContainers).toBe(0)
     expect(impact.descendantComponents).toBe(0)
     expect(impact.relationships).toBe(0)
@@ -75,5 +76,24 @@ describe('computeCascadeImpact', () => {
     const before = JSON.stringify(w)
     computeCascadeImpact(w, ['sysA'])
     expect(JSON.stringify(w)).toBe(before)
+  })
+
+  it('does not double-count a container whose parent system is also selected', () => {
+    // c1 is a child of sysA. Selecting both should count c1 as user-selected (in
+    // elementNames/elementCount), NOT as a cascade descendant — otherwise the
+    // dialog would tell the user the same container is being removed twice.
+    const impact = computeCascadeImpact(ws(), ['sysA', 'c1'])
+    expect(impact.elementCount).toBe(2)
+    expect(impact.elementNames.sort()).toEqual(['A', 'C1'])
+    expect(impact.descendantContainers).toBe(1) // only c2 is cascade-only
+    expect(impact.descendantComponents).toBe(1) // cmp1 still counted once
+  })
+
+  it('ignores IDs that do not exist in the workspace', () => {
+    const impact = computeCascadeImpact(ws(), ['nonexistent'])
+    expect(impact.elementCount).toBe(0)
+    expect(impact.elementNames).toHaveLength(0)
+    expect(impact.relationships).toBe(0)
+    expect(impact.scopedViews).toBe(0)
   })
 })

--- a/src/store/workspace-helpers.test.ts
+++ b/src/store/workspace-helpers.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { computeCascadeImpact } from './workspace-helpers'
+import type { Workspace } from '@/types/model'
+
+function ws(): Workspace {
+  return {
+    name: 'T',
+    model: {
+      people: [{ id: 'p1', type: 'person', name: 'P', tags: [], properties: {} }],
+      softwareSystems: [
+        { id: 'sysA', type: 'softwareSystem', name: 'A', tags: [], properties: {},
+          containers: [
+            { id: 'c1', type: 'container', name: 'C1', tags: [], properties: {},
+              components: [{ id: 'cmp1', type: 'component', name: 'Cmp', tags: [], properties: {} }] },
+            { id: 'c2', type: 'container', name: 'C2', tags: [], properties: {}, components: [] },
+          ],
+        },
+        { id: 'sysB', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+      ],
+      relationships: [
+        { id: 'r1', sourceId: 'p1', destinationId: 'sysA', tags: [], properties: {} },
+        { id: 'r2', sourceId: 'sysA', destinationId: 'sysB', tags: [], properties: {} },
+        { id: 'r3', sourceId: 'p1', destinationId: 'sysB', tags: [], properties: {} },
+      ],
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [{ type: 'systemLandscape', key: 'land', elements: [], relationships: [] }],
+      systemContextViews: [{ type: 'systemContext', key: 'ctxA', softwareSystemId: 'sysA', elements: [], relationships: [] }],
+      containerViews: [{ type: 'container', key: 'contA', softwareSystemId: 'sysA', elements: [], relationships: [] }],
+      componentViews: [{ type: 'component', key: 'cmpC1', containerId: 'c1', elements: [], relationships: [] }],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+describe('computeCascadeImpact', () => {
+  it('returns zero impact for empty input', () => {
+    const impact = computeCascadeImpact(ws(), [])
+    expect(impact.elementCount).toBe(0)
+    expect(impact.descendantContainers).toBe(0)
+    expect(impact.descendantComponents).toBe(0)
+    expect(impact.relationships).toBe(0)
+    expect(impact.scopedViews).toBe(0)
+  })
+
+  it('counts a system + every container + every component + every dependent view + every touching relationship', () => {
+    const impact = computeCascadeImpact(ws(), ['sysA'])
+    expect(impact.elementCount).toBe(1)
+    expect(impact.descendantContainers).toBe(2)         // c1, c2
+    expect(impact.descendantComponents).toBe(1)         // cmp1
+    expect(impact.relationships).toBe(2)                // r1, r2 (r3 survives)
+    expect(impact.scopedViews).toBe(3)                  // ctxA, contA, cmpC1
+    expect(impact.elementNames).toEqual(['A'])
+  })
+
+  it('counts a person delete with no descendants', () => {
+    const impact = computeCascadeImpact(ws(), ['p1'])
+    expect(impact.elementCount).toBe(1)
+    expect(impact.descendantContainers).toBe(0)
+    expect(impact.descendantComponents).toBe(0)
+    expect(impact.relationships).toBe(2)                // r1, r3
+    expect(impact.scopedViews).toBe(0)
+  })
+
+  it('counts a container delete with descendants and dependent component view', () => {
+    const impact = computeCascadeImpact(ws(), ['c1'])
+    expect(impact.descendantContainers).toBe(0)
+    expect(impact.descendantComponents).toBe(1)
+    expect(impact.scopedViews).toBe(1)                  // cmpC1
+  })
+
+  it('does not mutate the workspace', () => {
+    const w = ws()
+    const before = JSON.stringify(w)
+    computeCascadeImpact(w, ['sysA'])
+    expect(JSON.stringify(w)).toBe(before)
+  })
+})

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -533,12 +533,27 @@ export function computeCascadeImpact(ws: Workspace, ids: Iterable<string>): Casc
   const deletedContainerIds = new Set<string>()
   const deletedComponentIds = new Set<string>()
 
+  // Up-front pass: collect names of every explicitly-selected element exactly once.
+  // This is separated from the cascade traversal below so that a selected child
+  // whose parent is also selected still gets its name recorded (the cascade branch
+  // only sweeps IDs, not names, for children of a selected system).
   for (const p of ws.model.people) {
     if (idSet.has(p.id)) elementNames.push(p.name)
   }
   for (const sys of ws.model.softwareSystems) {
+    if (idSet.has(sys.id)) elementNames.push(sys.name)
+    for (const c of sys.containers) {
+      if (idSet.has(c.id)) elementNames.push(c.name)
+      for (const comp of c.components) {
+        if (idSet.has(comp.id)) elementNames.push(comp.name)
+      }
+    }
+  }
+
+  // SYNC with cascadeDeleteElements traversal — see keep-in-sync note in JSDoc above.
+  // Cascade pass: determine which containers/components get implicitly deleted.
+  for (const sys of ws.model.softwareSystems) {
     if (idSet.has(sys.id)) {
-      elementNames.push(sys.name)
       for (const c of sys.containers) {
         deletedContainerIds.add(c.id)
         for (const comp of c.components) deletedComponentIds.add(comp.id)
@@ -546,15 +561,11 @@ export function computeCascadeImpact(ws: Workspace, ids: Iterable<string>): Casc
     } else {
       for (const c of sys.containers) {
         if (idSet.has(c.id)) {
-          elementNames.push(c.name)
           deletedContainerIds.add(c.id)
           for (const comp of c.components) deletedComponentIds.add(comp.id)
         } else {
           for (const comp of c.components) {
-            if (idSet.has(comp.id)) {
-              elementNames.push(comp.name)
-              deletedComponentIds.add(comp.id)
-            }
+            if (idSet.has(comp.id)) deletedComponentIds.add(comp.id)
           }
         }
       }
@@ -584,7 +595,7 @@ export function computeCascadeImpact(ws: Workspace, ids: Iterable<string>): Casc
   }
 
   return {
-    elementCount: idSet.size,
+    elementCount: elementNames.length,
     elementNames,
     descendantContainers,
     descendantComponents,

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -3,6 +3,8 @@ import type {
   Workspace, View, ModelElement, Person, SoftwareSystem, Container, Component,
   ViewType, ElementInView,
 } from '@/types/model'
+import type { CascadeImpact } from './workspace-types'
+export type { CascadeImpact } from './workspace-types'
 
 /** Deep-clone an object that may be an Immer draft. structuredClone'ing a
  *  draft proxy throws DataCloneError; current() unwraps the draft to a plain
@@ -503,21 +505,6 @@ export function cascadeDeleteElements(ws: Workspace, ids: Iterable<string>): Cas
 
   invalidateElementIndex(ws)
   return { allDeletedIds, deletedContainerIds }
-}
-
-export interface CascadeImpact {
-  /** Top-level elements explicitly selected for deletion. */
-  elementCount: number
-  /** Names of those top-level elements (for the dialog body). */
-  elementNames: string[]
-  /** Containers that get deleted because their parent system is being removed. */
-  descendantContainers: number
-  /** Components that get deleted because their container (or its parent system) is being removed. */
-  descendantComponents: number
-  /** Relationships that lose at least one endpoint and get pruned. */
-  relationships: number
-  /** Scoped views (systemContext / container / component) that get removed because their scope element is gone. */
-  scopedViews: number
 }
 
 /**

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -504,3 +504,91 @@ export function cascadeDeleteElements(ws: Workspace, ids: Iterable<string>): Cas
   invalidateElementIndex(ws)
   return { allDeletedIds, deletedContainerIds }
 }
+
+export interface CascadeImpact {
+  /** Top-level elements explicitly selected for deletion. */
+  elementCount: number
+  /** Names of those top-level elements (for the dialog body). */
+  elementNames: string[]
+  /** Containers that get deleted because their parent system is being removed. */
+  descendantContainers: number
+  /** Components that get deleted because their container (or its parent system) is being removed. */
+  descendantComponents: number
+  /** Relationships that lose at least one endpoint and get pruned. */
+  relationships: number
+  /** Scoped views (systemContext / container / component) that get removed because their scope element is gone. */
+  scopedViews: number
+}
+
+/**
+ * Mutation-free dry run of `cascadeDeleteElements`. Returns counts so a confirm
+ * dialog can warn the user about the actual blast radius before they proceed.
+ *
+ * Mirrors the traversal in `cascadeDeleteElements` exactly — keep the two in
+ * sync. If a delete rule changes there, change it here too.
+ */
+export function computeCascadeImpact(ws: Workspace, ids: Iterable<string>): CascadeImpact {
+  const idSet = new Set(ids)
+  const elementNames: string[] = []
+  const deletedContainerIds = new Set<string>()
+  const deletedComponentIds = new Set<string>()
+
+  for (const p of ws.model.people) {
+    if (idSet.has(p.id)) elementNames.push(p.name)
+  }
+  for (const sys of ws.model.softwareSystems) {
+    if (idSet.has(sys.id)) {
+      elementNames.push(sys.name)
+      for (const c of sys.containers) {
+        deletedContainerIds.add(c.id)
+        for (const comp of c.components) deletedComponentIds.add(comp.id)
+      }
+    } else {
+      for (const c of sys.containers) {
+        if (idSet.has(c.id)) {
+          elementNames.push(c.name)
+          deletedContainerIds.add(c.id)
+          for (const comp of c.components) deletedComponentIds.add(comp.id)
+        } else {
+          for (const comp of c.components) {
+            if (idSet.has(comp.id)) {
+              elementNames.push(comp.name)
+              deletedComponentIds.add(comp.id)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Don't double-count: subtract IDs the caller listed explicitly that also turned up via cascade.
+  const descendantContainers = [...deletedContainerIds].filter((id) => !idSet.has(id)).length
+  const descendantComponents = [...deletedComponentIds].filter((id) => !idSet.has(id)).length
+
+  const allDeletedIds = new Set([...idSet, ...deletedContainerIds, ...deletedComponentIds])
+
+  let relationships = 0
+  for (const r of ws.model.relationships) {
+    if (allDeletedIds.has(r.sourceId) || allDeletedIds.has(r.destinationId)) relationships++
+  }
+
+  let scopedViews = 0
+  for (const v of ws.views.systemContextViews) {
+    if (v.softwareSystemId && idSet.has(v.softwareSystemId)) scopedViews++
+  }
+  for (const v of ws.views.containerViews) {
+    if (v.softwareSystemId && idSet.has(v.softwareSystemId)) scopedViews++
+  }
+  for (const v of ws.views.componentViews) {
+    if (v.containerId && (idSet.has(v.containerId) || deletedContainerIds.has(v.containerId))) scopedViews++
+  }
+
+  return {
+    elementCount: idSet.size,
+    elementNames,
+    descendantContainers,
+    descendantComponents,
+    relationships,
+    scopedViews,
+  }
+}

--- a/src/store/workspace-selectors.test.ts
+++ b/src/store/workspace-selectors.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { isFocalScopeElement } from './workspace-selectors'
+import type { Workspace } from '@/types/model'
+
+function ws(): Workspace {
+  return {
+    name: 'T',
+    model: {
+      people: [],
+      softwareSystems: [
+        { id: 'sys', type: 'softwareSystem', name: 'Sys', tags: [], properties: {},
+          containers: [
+            { id: 'c1', type: 'container', name: 'C1', tags: [], properties: {},
+              components: [{ id: 'cmp1', type: 'component', name: 'Cmp', tags: [], properties: {} }] },
+          ],
+        },
+      ],
+      relationships: [],
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [{ type: 'systemLandscape', key: 'land', elements: [], relationships: [] }],
+      systemContextViews: [{ type: 'systemContext', key: 'ctx', softwareSystemId: 'sys', elements: [{ id: 'sys' }], relationships: [] }],
+      containerViews: [{ type: 'container', key: 'cont', softwareSystemId: 'sys', elements: [{ id: 'c1' }], relationships: [] }],
+      componentViews: [{ type: 'component', key: 'comp', containerId: 'c1', elements: [{ id: 'cmp1' }], relationships: [] }],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+describe('isFocalScopeElement', () => {
+  it('returns false for a landscape view (no focal scope)', () => {
+    expect(isFocalScopeElement(ws(), 'land', 'sys')).toBe(false)
+  })
+  it('flags the focal system on its system context view', () => {
+    expect(isFocalScopeElement(ws(), 'ctx', 'sys')).toBe(true)
+  })
+  it('flags the focal system on its container view', () => {
+    expect(isFocalScopeElement(ws(), 'cont', 'sys')).toBe(true)
+  })
+  it('does not flag a container on its parent system\'s container view', () => {
+    expect(isFocalScopeElement(ws(), 'cont', 'c1')).toBe(false)
+  })
+  it('flags the focal container on its component view', () => {
+    expect(isFocalScopeElement(ws(), 'comp', 'c1')).toBe(true)
+  })
+  it('returns false for unknown view key', () => {
+    expect(isFocalScopeElement(ws(), 'nope', 'sys')).toBe(false)
+  })
+})

--- a/src/store/workspace-selectors.test.ts
+++ b/src/store/workspace-selectors.test.ts
@@ -41,6 +41,9 @@ describe('isFocalScopeElement', () => {
   it('does not flag a container on its parent system\'s container view', () => {
     expect(isFocalScopeElement(ws(), 'cont', 'c1')).toBe(false)
   })
+  it('does not flag a non-scope element on a system context view', () => {
+    expect(isFocalScopeElement(ws(), 'ctx', 'c1')).toBe(false)
+  })
   it('flags the focal container on its component view', () => {
     expect(isFocalScopeElement(ws(), 'comp', 'c1')).toBe(true)
   })

--- a/src/store/workspace-selectors.ts
+++ b/src/store/workspace-selectors.ts
@@ -133,3 +133,28 @@ export function getCreatableTypes(workspace: Workspace, activeViewKey: string | 
 }
 
 export { getFirstViewKey, findChildView as findChildViewHelper }
+
+/**
+ * True when `elementId` is the scope element of the view identified by
+ * `viewKey` — i.e. the system whose context/containers a view shows, or the
+ * container whose components a view shows. Removing the focal scope from
+ * inside its own view is a category error: the view is *defined by* that
+ * element. Use this to gate Backspace/Trash behavior in scoped views.
+ */
+export function isFocalScopeElement(
+  workspace: Workspace,
+  viewKey: string,
+  elementId: string,
+): boolean {
+  const view = getActiveView(workspace, viewKey)
+  if (!view) return false
+  switch (view.type) {
+    case 'systemContext':
+    case 'container':
+      return view.softwareSystemId === elementId
+    case 'component':
+      return view.containerId === elementId
+    default:
+      return false
+  }
+}

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -151,6 +151,7 @@ export interface WorkspaceState extends UndoState {
 
   // View element management
   toggleElementInView: (viewKey: string, elementId: string) => void
+  removeElementsFromView: (viewKey: string, ids: string[]) => void
   setLayoutDirection: (viewKey: string, direction: 'TB' | 'BT' | 'LR' | 'RL') => void
   /** Reset all node positions and optionally change layout direction in a single undo step */
   resetAndRelayout: (viewKey: string, direction?: 'TB' | 'BT' | 'LR' | 'RL') => void

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -3,6 +3,13 @@ import type {
   ViewType, ElementStatus,
 } from '@/types/model'
 import type { ScopeViolation } from '@/lib/scopeValidation'
+import type { CascadeImpact } from './workspace-helpers'
+
+export interface PendingDelete {
+  message: string
+  impact?: CascadeImpact
+  onConfirm: () => void
+}
 
 // ─── Undo History ────────────────────────────────────────────────────
 
@@ -36,8 +43,11 @@ export interface WorkspaceState extends UndoState {
   rightPanelOpen: boolean
   searchOpen: boolean
   commandPaletteOpen: boolean
-  pendingDelete: { message: string; onConfirm: () => void } | null
-  confirmDelete: (message: string, onConfirm: () => void) => void
+  pendingDelete: PendingDelete | null
+  confirmDelete: (
+    payload: string | { message: string; impact?: CascadeImpact },
+    onConfirm: () => void,
+  ) => void
   cancelDelete: () => void
   /** Active zoom-in confirm prompt: shown when the user clicks zoom on an element
    *  that has children but no corresponding child view. */

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -3,7 +3,20 @@ import type {
   ViewType, ElementStatus,
 } from '@/types/model'
 import type { ScopeViolation } from '@/lib/scopeValidation'
-import type { CascadeImpact } from './workspace-helpers'
+export interface CascadeImpact {
+  /** Top-level elements explicitly selected for deletion. */
+  elementCount: number
+  /** Names of those top-level elements (for the dialog body). */
+  elementNames: string[]
+  /** Containers that get deleted because their parent system is being removed. */
+  descendantContainers: number
+  /** Components that get deleted because their container (or its parent system) is being removed. */
+  descendantComponents: number
+  /** Relationships that lose at least one endpoint and get pruned. */
+  relationships: number
+  /** Scoped views (systemContext / container / component) that get removed because their scope element is gone. */
+  scopedViews: number
+}
 
 export interface PendingDelete {
   message: string

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -658,6 +658,20 @@ describe('confirmDelete and pendingDelete', () => {
     useWorkspaceStore.getState().loadWorkspace(makeWorkspace())
     expect(useWorkspaceStore.getState().pendingDelete).toBeNull()
   })
+
+  it('confirmDelete accepts structured payload and stores impact', () => {
+    const fn = vi.fn()
+    useWorkspaceStore.getState().confirmDelete(
+      { message: 'Delete X?', impact: {
+        elementCount: 1, elementNames: ['X'],
+        descendantContainers: 1, descendantComponents: 0, relationships: 0, scopedViews: 0,
+      } },
+      fn,
+    )
+    const pd = useWorkspaceStore.getState().pendingDelete
+    expect(pd?.message).toBe('Delete X?')
+    expect(pd?.impact?.descendantContainers).toBe(1)
+  })
 })
 
 // ─── multiSelectMode ────────────────────────────────────────────────

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -4222,3 +4222,104 @@ describe('zoomInto + pendingZoomConfirm', () => {
     expect(state.createViewDefaults).toBeNull()
   })
 })
+
+describe('removeElementsFromView', () => {
+  beforeEach(() => useWorkspaceStore.getState().closeWorkspace())
+
+  it('removes the listed elements from the view but keeps them in the model', () => {
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'sysA', type: 'softwareSystem', name: 'A', tags: [], properties: {}, containers: [] },
+          { id: 'sysB', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [{ id: 'r1', sourceId: 'sysA', destinationId: 'sysB', tags: [], properties: {} }],
+        groups: [],
+      },
+      views: {
+        systemLandscapeViews: [{
+          type: 'systemLandscape', key: 'land',
+          elements: [{ id: 'sysA' }, { id: 'sysB' }],
+          relationships: [{ id: 'r1' }],
+        }],
+        systemContextViews: [], containerViews: [], componentViews: [],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('land')
+
+    useWorkspaceStore.getState().removeElementsFromView('land', ['sysA'])
+
+    const w = useWorkspaceStore.getState().workspace!
+    // Model intact:
+    expect(w.model.softwareSystems.map(s => s.id)).toEqual(['sysA', 'sysB'])
+    // View shrunk:
+    expect(w.views.systemLandscapeViews[0].elements.map(e => e.id)).toEqual(['sysB'])
+    // Orphaned relationship ref pruned:
+    expect(w.views.systemLandscapeViews[0].relationships).toEqual([])
+  })
+
+  it('skips focal-scope IDs (defense in depth)', () => {
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [{
+          id: 'sys', type: 'softwareSystem', name: 'S', tags: [], properties: {},
+          containers: [{ id: 'c1', type: 'container', name: 'C', tags: [], properties: {}, components: [] }],
+        }],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [], systemContextViews: [], componentViews: [],
+        containerViews: [{
+          type: 'container', key: 'cont', softwareSystemId: 'sys',
+          elements: [{ id: 'c1' }], relationships: [],
+        }],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('cont')
+
+    // Try to remove the focal system from its own container view (not normally selectable, but defense matters)
+    useWorkspaceStore.getState().removeElementsFromView('cont', ['sys', 'c1'])
+
+    const view = useWorkspaceStore.getState().workspace!.views.containerViews[0]
+    // c1 removed, sys ignored (it wasn't in elements anyway, but the action must not have thrown or no-op'd both)
+    expect(view.elements).toEqual([])
+    // System still in model:
+    expect(useWorkspaceStore.getState().workspace!.model.softwareSystems[0].id).toBe('sys')
+  })
+
+  it('records a single undo snapshot for the batch', () => {
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'a', type: 'softwareSystem', name: 'A', tags: [], properties: {}, containers: [] },
+          { id: 'b', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [{
+          type: 'systemLandscape', key: 'land', elements: [{ id: 'a' }, { id: 'b' }], relationships: [],
+        }],
+        systemContextViews: [], containerViews: [], componentViews: [],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+
+    useWorkspaceStore.getState().removeElementsFromView('land', ['a', 'b'])
+    useWorkspaceStore.getState().undo()
+
+    const view = useWorkspaceStore.getState().workspace!.views.systemLandscapeViews[0]
+    expect(view.elements.map(e => e.id).sort()).toEqual(['a', 'b'])
+  })
+})

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -4322,4 +4322,37 @@ describe('removeElementsFromView', () => {
     const view = useWorkspaceStore.getState().workspace!.views.systemLandscapeViews[0]
     expect(view.elements.map(e => e.id).sort()).toEqual(['a', 'b'])
   })
+
+  it('does not push an undo snapshot when the selection is only focal-scope IDs', () => {
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [{
+          id: 'sys', type: 'softwareSystem', name: 'S', tags: [], properties: {},
+          containers: [{ id: 'c1', type: 'container', name: 'C', tags: [], properties: {}, components: [] }],
+        }],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [], systemContextViews: [], componentViews: [],
+        containerViews: [{
+          type: 'container', key: 'cont', softwareSystemId: 'sys',
+          elements: [{ id: 'c1' }], relationships: [],
+        }],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('cont')
+
+    const undoBefore = useWorkspaceStore.getState().undoStack.length
+
+    // Only pass the focal-scope ID — should be a no-op that skips pushUndoSnapshot
+    useWorkspaceStore.getState().removeElementsFromView('cont', ['sys'])
+
+    expect(useWorkspaceStore.getState().undoStack.length).toBe(undoBefore)
+    // View must be unchanged
+    expect(useWorkspaceStore.getState().workspace!.views.containerViews[0].elements).toEqual([{ id: 'c1' }])
+  })
 })

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -27,6 +27,7 @@ export {
   getZoomTarget,
   getBreadcrumb,
   getCreatableTypes,
+  isFocalScopeElement,
 } from './workspace-selectors'
 
 /**


### PR DESCRIPTION
## Summary

Splits the delete affordance into two operations the user previously had to express with one key:

- **Backspace / Delete** — removes selected elements from the *active view* only. Lightweight, no confirm, reversible by re-adding via the AddElementPanel. The model is untouched.
- **Shift+Backspace / Shift+Delete** — opens an impact-aware confirm dialog (e.g. *"Delete \"Payments API\" from the model? This will also remove 4 containers, 11 components, 7 relationships, and 2 dependent views."*) and on confirm, cascade-deletes from the model.
- **Focal-scope guard** — the element a view is *about* (the system on its container view, the container on its component view, the system on its system context view) is filtered out of both operations and from the AddElementPanel "Add existing" picker. Three layers of defense: UI filter, store action guard, and exhaustiveness check that fails the build if a new view type lands without declaring its focal scope.

The inspector and multi-select bar Trash buttons route through the same impact-aware confirm; the inspector shows a disabled button + explanatory banner when targeting focal scope.

Closes the original "deleted one node and lost a system" bug observed on a Container view, where adding the focal system to its own L2 view created a node whose Backspace cascaded through the entire system, all containers, all components, all relationships, and all scoped views.

## Architecture

| Layer | Addition |
| --- | --- |
| Selectors | `isFocalScopeElement(workspace, viewKey, elementId)` |
| Helpers | `computeCascadeImpact(workspace, ids)` — mutation-free dry-run of `cascadeDeleteElements` |
| Lib | `formatImpactSummary(impact)` — pure formatter for the dialog body |
| Store | `removeElementsFromView(viewKey, ids)` action; widened `confirmDelete` accepts `string \| { message, impact? }` |
| UI | `ConfirmDeleteDialog` renders structured impact list, button label flips to "Delete from model" when impact is present |
| Keymap | `useKeyboardShortcuts` rewired with `backspaceLikeHandler(destructive)` factory |
| Call sites updated | `useKeyboardShortcuts`, `RightPanel` inspector, `MultiSelectBar`, command palette `delete-selected`, `AddElementPanel` picker filter |

## What's not in scope

Relationship deletion is unchanged — Backspace on a selected relationship still confirms + deletes from the model. The keymap factory has the hook for it (`destructive` parameter on the relationship branch); a follow-up plan can introduce `removeRelationshipFromView` when we want to extend the same model to relationships.

Mobile users still only have the destructive Trash in the inspector — there's no touch affordance for the lightweight remove-from-view yet.

The behavior change for Backspace is significant for existing users; there's no in-app onboarding hint yet. Worth a separate UX follow-up.

## Test Plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 1012 unit tests pass across 56 files
- [x] `npx playwright test e2e/canvas/delete-semantics.spec.ts` — 5/5 symphony scenarios pass (Backspace removes peer from view; Shift+Backspace shows impact dialog; Cmd+Z restores after destroy; focal-scope no-op; re-add round-trips)
- [x] Migrated 2 pre-existing e2e tests that expected the old confirm-on-Backspace behavior to use Shift+Backspace + the new dialog
- [ ] Manual: walk through original failure scenario (Container view → try to add focal system → confirm it's not in the picker)
- [ ] Manual: visual sanity-check the impact list rendering in `ConfirmDeleteDialog` (light + dark themes)
- [ ] Manual: confirm command palette "Delete Selected from model" (⇧⌫) shows the same dialog as Shift+Backspace

## Plan reference

`docs/superpowers/plans/2026-05-10-cascade-delete-redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)