### PR TITLE
fix(views): restrict Context/Container scope picker to focal system in softwareSystem-scoped workspaces

### DIFF
--- a/src/components/views/CreateViewDialog.test.tsx
+++ b/src/components/views/CreateViewDialog.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react'
+import { useWorkspaceStore } from '@/store/workspace'
+import type { Workspace } from '@/types/model'
+import CreateViewDialog from './CreateViewDialog'
+
+vi.mock('lucide-react', () => ({
+  X: () => null,
+}))
+
+function makeWs(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    name: 'T',
+    model: { people: [], softwareSystems: [], relationships: [], groups: [] },
+    views: {
+      systemLandscapeViews: [],
+      systemContextViews: [],
+      containerViews: [],
+      componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+    ...overrides,
+  }
+}
+
+beforeEach(() => useWorkspaceStore.getState().closeWorkspace())
+
+describe('CreateViewDialog — softwareSystem-scope focal restriction', () => {
+  it('restricts Context view scope to the focal system when the workspace is softwaresystem-scoped', () => {
+    const ws = makeWs({
+      scope: 'softwaresystem',
+      model: {
+        people: [],
+        softwareSystems: [
+          // Focal system — has containers, so the validator considers it the workspace's focal.
+          { id: 'focal', type: 'softwareSystem', name: 'Focal', tags: [], properties: {},
+            containers: [{ id: 'c1', type: 'container', name: 'C1', tags: [], properties: {}, components: [] }] },
+          // External system — no containers; should NOT appear in the Context view scope picker.
+          { id: 'external', type: 'softwareSystem', name: 'External', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+    })
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    // Default view type is the first allowed one in a softwaresystem-scoped workspace
+    // (systemContext). The scope dropdown should list only Focal.
+    const scopeSelect = screen.getByLabelText(/scope/i) as HTMLSelectElement
+    const optionTexts = Array.from(scopeSelect.options).map(o => o.text)
+    expect(optionTexts).toContain('Focal')
+    expect(optionTexts).not.toContain('External')
+  })
+
+  it('shows ALL systems in the picker when no system has containers yet (focal not yet decided)', () => {
+    // Edge case: a fresh softwaresystem-scoped workspace with two systems but no
+    // containers anywhere. The focal hasn't been chosen, so the user must be
+    // allowed to pick. Once one of them gets containers, the picker tightens.
+    const ws = makeWs({
+      scope: 'softwaresystem',
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'a', type: 'softwareSystem', name: 'A', tags: [], properties: {}, containers: [] },
+          { id: 'b', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+    })
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    const scopeSelect = screen.getByLabelText(/scope/i) as HTMLSelectElement
+    const optionTexts = Array.from(scopeSelect.options).map(o => o.text)
+    expect(optionTexts).toContain('A')
+    expect(optionTexts).toContain('B')
+  })
+
+  it('does NOT restrict the picker for landscape-scoped workspaces', () => {
+    const ws = makeWs({
+      scope: 'landscape',
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'a', type: 'softwareSystem', name: 'A', tags: [], properties: {}, containers: [] },
+          { id: 'b', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+    })
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    // In a landscape-scoped workspace, default first view type is systemLandscape,
+    // which has no scope picker. Switch to systemContext to see the picker.
+    const typeSelect = screen.getByLabelText(/type/i) as HTMLSelectElement
+    typeSelect.value = 'systemContext'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const scopeSelect = screen.getByLabelText(/scope/i) as HTMLSelectElement
+    const optionTexts = Array.from(scopeSelect.options).map(o => o.text)
+    expect(optionTexts).toContain('A')
+    expect(optionTexts).toContain('B')
+  })
+
+  it('does NOT restrict the picker for unscoped workspaces', () => {
+    const ws = makeWs({
+      model: {
+        people: [],
+        softwareSystems: [
+          // 'a' has containers (would be focal if scope were softwaresystem)
+          { id: 'a', type: 'softwareSystem', name: 'A', tags: [], properties: {},
+            containers: [{ id: 'c1', type: 'container', name: 'C1', tags: [], properties: {}, components: [] }] },
+          { id: 'b', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+    })
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    // Unscoped workspace defaults to systemLandscape (no scope picker). Switch
+    // to systemContext so the picker renders.
+    const typeSelect = screen.getByLabelText(/type/i) as HTMLSelectElement
+    typeSelect.value = 'systemContext'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const scopeSelect = screen.getByLabelText(/scope/i) as HTMLSelectElement
+    const optionTexts = Array.from(scopeSelect.options).map(o => o.text)
+    expect(optionTexts).toContain('A')
+    expect(optionTexts).toContain('B')
+  })
+})

--- a/src/components/views/CreateViewDialog.tsx
+++ b/src/components/views/CreateViewDialog.tsx
@@ -37,10 +37,24 @@ export default function CreateViewDialog({ onClose }: { onClose: () => void }) {
 
   const needsScope = type === 'systemContext' || type === 'container' || type === 'component'
 
+  // In a softwareSystem-scoped workspace, only one system is allowed to have
+  // containers/components (see scopeValidation.ts) — that system IS the
+  // workspace's focal system. Letting the user create a Context or Container
+  // view scoped to a *different* system silently widens the workspace's
+  // documentation surface beyond the single-system contract. Restrict the
+  // scope picker to the focal system when we can identify it.
+  const focalSystemId = workspace.scope === 'softwaresystem'
+    ? (() => {
+        const withContainers = workspace.model.softwareSystems.filter(s => s.containers.length > 0)
+        return withContainers.length === 1 ? withContainers[0].id : undefined
+      })()
+    : undefined
+
   // Build scope options based on type
   const scopeOptions: { id: string; name: string }[] = []
   if (type === 'systemContext' || type === 'container') {
     for (const sys of workspace.model.softwareSystems) {
+      if (focalSystemId && sys.id !== focalSystemId) continue
       scopeOptions.push({ id: sys.id, name: sys.name })
     }
   } else if (type === 'component') {


### PR DESCRIPTION
## Summary

In a softwareSystem-scoped workspace, only one system can have containers/components (enforced by `scopeValidation.ts:28-36`) — that system IS the workspace's focal system. The Create View dialog was happily listing every system in the model as a Context- or Container-view scope option, letting users build full Context views for *external* systems too. That silently widens the workspace's documentation surface beyond its single-system contract.

When workspace scope is `softwaresystem` and exactly one system has containers, restrict the Context/Container scope picker to just that system. If no system has containers yet (fresh workspace), behavior is unchanged — the user is still picking which system will become focal. Landscape and unscoped workspaces are completely unaffected.

## Test Plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 1033 unit tests pass (4 new in `CreateViewDialog.test.tsx` cover the four scope×scenario combinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)