### PR TITLE
fix(views): block Create View when scope is required but no scope exists

### DIFF
--- a/src/components/views/CreateViewDialog.test.tsx
+++ b/src/components/views/CreateViewDialog.test.tsx
@@ -130,3 +130,59 @@ describe('CreateViewDialog — softwareSystem-scope focal restriction', () => {
     expect(optionTexts).toContain('B')
   })
 })
+
+describe('CreateViewDialog — zero-systems guard', () => {
+  it('disables Create View and surfaces a hint when a scope is required but none exist', () => {
+    // Softwaresystem-scoped workspace with no systems at all. Default type is
+    // systemContext (first allowed type when scope is softwaresystem), which
+    // requires a system scope — but there are none. The Create button must be
+    // disabled and an explanatory alert must be visible.
+    const ws = makeWs({ scope: 'softwaresystem' })
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    const createBtn = screen.getByRole('button', { name: /^create view$/i }) as HTMLButtonElement
+    expect(createBtn.disabled).toBe(true)
+
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/no system exists yet/i)
+  })
+
+  it('disables Create View for a Component view when no containers exist', () => {
+    // Unscoped workspace with one system but no containers. Switch type to
+    // component — there's nothing to scope it to.
+    const ws = makeWs({
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'sys', type: 'softwareSystem', name: 'Sys', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+    })
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    const typeSelect = screen.getByLabelText(/type/i) as HTMLSelectElement
+    typeSelect.value = 'component'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const createBtn = screen.getByRole('button', { name: /^create view$/i }) as HTMLButtonElement
+    expect(createBtn.disabled).toBe(true)
+
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toMatch(/no container exists yet/i)
+  })
+
+  it('does NOT raise the alert for a Landscape view (no scope needed)', () => {
+    const ws = makeWs() // unscoped, no systems
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    render(<CreateViewDialog onClose={() => {}} />)
+
+    // Default first type is systemLandscape (unscoped workspace) — no scope picker,
+    // no alert, button enabled.
+    expect(screen.queryByRole('alert')).toBeNull()
+    const createBtn = screen.getByRole('button', { name: /^create view$/i }) as HTMLButtonElement
+    expect(createBtn.disabled).toBe(false)
+  })
+})

--- a/src/components/views/CreateViewDialog.tsx
+++ b/src/components/views/CreateViewDialog.tsx
@@ -65,8 +65,17 @@ export default function CreateViewDialog({ onClose }: { onClose: () => void }) {
     }
   }
 
+  // A view that needs a scope can't be created without one. The dialog must
+  // refuse to dispatch `addView` with an undefined scope — otherwise we'd end
+  // up with a Context/Container/Component view that has no anchor, which is
+  // invalid data the rest of the app has to defend against forever.
+  const scopeMissing = needsScope && !scopeId
+  const noScopeChoicesAvailable = needsScope && scopeOptions.length === 0
+  const missingScopeKind = type === 'component' ? 'container' : 'system'
+
   const handleCreate = () => {
-    addView(type, needsScope ? scopeId || undefined : undefined, title || undefined)
+    if (scopeMissing) return
+    addView(type, needsScope ? scopeId : undefined, title || undefined)
     setCreateViewDefaults(null) // consume the zoom defaults so the next open starts fresh
     onClose()
   }
@@ -135,9 +144,24 @@ export default function CreateViewDialog({ onClose }: { onClose: () => void }) {
                   className="mt-1 text-[11px]"
                   style={{ color: 'var(--color-error-text)' }}
                 >
-                  Pick a {type === 'component' ? 'container' : 'system'} for this view.
+                  Pick a {missingScopeKind} for this view.
                 </div>
               )}
+            </div>
+          )}
+
+          {noScopeChoicesAvailable && (
+            <div
+              role="alert"
+              className="rounded-lg px-3 py-2 text-[11px]"
+              style={{
+                background: 'var(--color-tint-error)',
+                color: 'var(--color-error-text)',
+                border: '1px solid var(--color-border-error)',
+              }}
+            >
+              Can't create this view — no {missingScopeKind} exists yet to scope it to.
+              {' '}Create a {missingScopeKind} first, then come back.
             </div>
           )}
 
@@ -159,8 +183,8 @@ export default function CreateViewDialog({ onClose }: { onClose: () => void }) {
 
           <button
             onClick={handleCreate}
-            disabled={needsScope && !scopeId && scopeOptions.length > 0}
-            className="w-full rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-40"
+            disabled={scopeMissing}
+            className="w-full rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ background: 'var(--color-accent)', color: 'var(--color-bg-primary)' }}
           >
             Create View


### PR DESCRIPTION
## Summary

Latent papercut in \`CreateViewDialog\`: the Create View button's disabled check was \`needsScope && !scopeId && scopeOptions.length > 0\`. The third clause short-circuited when there were no scope choices, so on a workspace with zero systems you could click Create View for a Context view and produce one with \`softwareSystemId === undefined\` — invalid model data.

Fix:
1. Disable the button whenever scope is required and missing (no length escape hatch).
2. Surface an explanatory alert banner when no scope choices exist, telling the user what to create first.
3. \`handleCreate\` refuses to dispatch \`addView\` with undefined scope as a belt-and-braces guard.

## Test Plan

- [x] \`npm test\` — 1036 tests pass (3 new in \`CreateViewDialog.test.tsx\` for the guard, the per-type messaging, and the negative case for landscape views)
- [x] \`npx tsc -b\` clean
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)