### PR TITLE
feat(canvas): first-selection hint for new Backspace/Shift+Backspace semantics

### DIFF
--- a/src/components/canvas/CanvasHints.test.tsx
+++ b/src/components/canvas/CanvasHints.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { useWorkspaceStore } from '@/store/workspace'
+import type { Workspace } from '@/types/model'
+import CanvasHints from './CanvasHints'
+
+vi.mock('lucide-react', () => ({ X: () => null }))
+
+function makeWs(): Workspace {
+  // 2 containers + 1 relationship between them — populated enough to test
+  // selection, but the relationship suppresses the connect-hint so the
+  // backspace-hint becomes the active one.
+  return {
+    name: 'T',
+    model: {
+      people: [],
+      softwareSystems: [
+        { id: 'sys', type: 'softwareSystem', name: 'S', tags: [], properties: {},
+          containers: [
+            { id: 'c1', type: 'container', name: 'C1', tags: [], properties: {}, components: [] },
+            { id: 'c2', type: 'container', name: 'C2', tags: [], properties: {}, components: [] },
+          ],
+        },
+      ],
+      relationships: [{ id: 'r1', sourceId: 'c1', destinationId: 'c2', tags: [], properties: {} }],
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [],
+      systemContextViews: [],
+      componentViews: [],
+      containerViews: [{
+        type: 'container', key: 'cont', softwareSystemId: 'sys',
+        elements: [{ id: 'c1' }, { id: 'c2' }],
+        relationships: [{ id: 'r1' }],
+      }],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+beforeEach(() => {
+  useWorkspaceStore.getState().closeWorkspace()
+  localStorage.clear()
+})
+
+describe('CanvasHints — Backspace semantics hint', () => {
+  it('does not render the hint when nothing is selected', () => {
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().clearSelection()
+    render(<CanvasHints />)
+    // Wait for the 500ms reveal delay — but the hint shouldn't be there at all
+    expect(screen.queryByText(/Backspace removes from this view/i)).toBeNull()
+  })
+
+  it('renders the hint when at least one element is selected and not yet dismissed', async () => {
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['c1'])
+    render(<CanvasHints />)
+    // The hint reveals after a 500ms delay (matches the existing connect-hint pattern)
+    await act(() => new Promise(r => setTimeout(r, 600)))
+    expect(screen.getByText(/Backspace removes from this view/i)).toBeTruthy()
+    expect(screen.getByText(/Shift\+Backspace deletes from the model/i)).toBeTruthy()
+  })
+
+  it('persists dismissal across remounts via localStorage', async () => {
+    useWorkspaceStore.getState().loadWorkspace(makeWs())
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['c1'])
+    const first = render(<CanvasHints />)
+    await act(() => new Promise(r => setTimeout(r, 600)))
+    fireEvent.click(screen.getByLabelText(/dismiss hint/i))
+    first.unmount()
+
+    // Re-mount with the same selection — hint must NOT come back
+    render(<CanvasHints />)
+    await act(() => new Promise(r => setTimeout(r, 600)))
+    expect(screen.queryByText(/Backspace removes from this view/i)).toBeNull()
+  })
+})

--- a/src/components/canvas/CanvasHints.tsx
+++ b/src/components/canvas/CanvasHints.tsx
@@ -31,6 +31,7 @@ export default function CanvasHints() {
   const relationshipCount = useWorkspaceStore((s) =>
     s.workspace && activeViewKey ? (getActiveView(s.workspace, activeViewKey)?.relationships.length ?? 0) : 0,
   )
+  const selectionCount = useWorkspaceStore((s) => s.selectedElementIds.length)
   const [dismissed, setDismissed] = useState(getDismissed)
 
   function handleDismiss(id: string) {
@@ -45,6 +46,18 @@ export default function CanvasHints() {
     return (
       <Hint id="connect-hint" onDismiss={handleDismiss}>
         Drag from a node edge to another node to create a connection
+      </Hint>
+    )
+  }
+
+  // Delete-semantics hint — shown on first selection so the user discovers
+  // the Backspace/Shift+Backspace split before they instinctively press
+  // Backspace and quietly remove a node from the view (vs. the old behavior
+  // of confirm-and-destroy).
+  if (selectionCount > 0 && !dismissed.has('backspace-semantics-v2')) {
+    return (
+      <Hint id="backspace-semantics-v2" onDismiss={handleDismiss}>
+        Backspace removes from this view · Shift+Backspace deletes from the model
       </Hint>
     )
   }


### PR DESCRIPTION
## Summary

The delete-semantics redesign (#49) changed Backspace from "confirm and destroy" to "remove from view, no confirm." Existing users have no in-app signal that the behavior changed — final reviewer flagged this as a real discoverability gap.

This adds one line to \`CanvasHints\` that fires the first time the user selects an element on the canvas:

> Backspace removes from this view · Shift+Backspace deletes from the model

Same dismissal pattern as the existing connect-hint (X click, persisted in localStorage). The connect-hint takes priority when both would apply.

## Test Plan

- [x] \`npm test\` — 1036 tests pass (3 new in \`CanvasHints.test.tsx\` covering: not shown when no selection, shown on selection, dismissal persists across remounts)
- [x] \`npx tsc -b\` clean
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)