### PR TITLE
feat(inspector): "Remove from view" button — touch parity with Backspace

### DIFF
--- a/src/components/layout/RightPanel.test.tsx
+++ b/src/components/layout/RightPanel.test.tsx
@@ -12,6 +12,7 @@ vi.mock('lucide-react', () => ({
   Sparkles: () => null,
   Loader2: () => null,
   Eye: () => null,
+  EyeOff: () => null,
   Layers: () => null,
   Trash2: () => null,
   AlertTriangle: () => null,
@@ -260,5 +261,106 @@ describe('RightPanel', () => {
       }
     })
     expect(useWorkspaceStore.getState().selectedElementIds).toHaveLength(0)
+  })
+})
+
+describe('RightPanel — Remove from view button (touch parity)', () => {
+  function makeWsWithLandscape(): Workspace {
+    return {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'a', type: 'softwareSystem', name: 'A', tags: [], properties: {}, containers: [] },
+          { id: 'b', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [{
+          type: 'systemLandscape', key: 'land',
+          elements: [{ id: 'a' }, { id: 'b' }], relationships: [],
+        }],
+        systemContextViews: [], containerViews: [], componentViews: [],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+  }
+
+  it('removes the element from the active view without touching the model', () => {
+    useWorkspaceStore.getState().loadWorkspace(makeWsWithLandscape())
+    useWorkspaceStore.getState().setActiveView('land')
+    useWorkspaceStore.getState().selectElements(['a'])
+    render(<RightPanel />)
+
+    fireEvent.click(screen.getByLabelText(/remove from view/i))
+
+    const w = useWorkspaceStore.getState().workspace!
+    // View shrunk to just b
+    expect(w.views.systemLandscapeViews[0].elements.map(e => e.id)).toEqual(['b'])
+    // Model still has both
+    expect(w.model.softwareSystems.map(s => s.id).sort()).toEqual(['a', 'b'])
+    // No confirm dialog
+    expect(useWorkspaceStore.getState().pendingDelete).toBeNull()
+  })
+
+  it('does not render the button when the selected element is the focal scope', () => {
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [{
+          id: 'sys', type: 'softwareSystem', name: 'Sys', tags: [], properties: {},
+          containers: [{ id: 'c1', type: 'container', name: 'C1', tags: [], properties: {}, components: [] }],
+        }],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [], systemContextViews: [], componentViews: [],
+        containerViews: [{
+          type: 'container', key: 'cont', softwareSystemId: 'sys',
+          elements: [{ id: 'c1' }], relationships: [],
+        }],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('cont')
+    useWorkspaceStore.getState().selectElements(['sys'])
+    render(<RightPanel />)
+
+    expect(screen.queryByLabelText(/remove from view/i)).toBeNull()
+  })
+
+  it('does not render the button when the element is not in the active view', () => {
+    // Element exists in the model and is selected, but the active view doesn't
+    // include it (rare cross-view selection state). Nothing to remove from this
+    // view, so the button should be hidden.
+    const ws: Workspace = {
+      name: 'T',
+      model: {
+        people: [],
+        softwareSystems: [
+          { id: 'a', type: 'softwareSystem', name: 'A', tags: [], properties: {}, containers: [] },
+          { id: 'b', type: 'softwareSystem', name: 'B', tags: [], properties: {}, containers: [] },
+        ],
+        relationships: [], groups: [],
+      },
+      views: {
+        systemLandscapeViews: [{
+          type: 'systemLandscape', key: 'land',
+          elements: [{ id: 'a' }],  // b is NOT here
+          relationships: [],
+        }],
+        systemContextViews: [], containerViews: [], componentViews: [],
+        configuration: { styles: { elements: [], relationships: [] } },
+      },
+    }
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    useWorkspaceStore.getState().setActiveView('land')
+    useWorkspaceStore.getState().selectElements(['b'])
+    render(<RightPanel />)
+
+    expect(screen.queryByLabelText(/remove from view/i)).toBeNull()
   })
 })

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -3,7 +3,7 @@ import { useWorkspaceStore, getSelectedElement, getRelationshipById, buildElemen
 import { computeCascadeImpact } from '@/store/workspace-helpers'
 import { formatImpactSummary } from '@/lib/impactMessage'
 import type { ModelElement, Container, Component, Person, SoftwareSystem, Relationship, ElementStatus, Location } from '@/types/model'
-import { X, Plus, ArrowRight, ExternalLink, Eye, ChevronRight, Trash2 } from 'lucide-react'
+import { X, Plus, ArrowRight, ExternalLink, Eye, EyeOff, ChevronRight, Trash2 } from 'lucide-react'
 import { TYPE_COLORS, getElementTypeLabel } from '@/lib/elementMeta'
 import { normalizeSafeExternalUrl } from '@/lib/safeUrl'
 import { FieldLabel, EditableField, TechnologyField, OwnerField } from './right-panel/fields'
@@ -72,6 +72,7 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
   const updateElementLive = useWorkspaceStore((s) => s.updateElementLive)
   const updateTech = useWorkspaceStore((s) => s.updateElementTechnology)
   const deleteElement = useWorkspaceStore((s) => s.deleteElement)
+  const removeElementsFromView = useWorkspaceStore((s) => s.removeElementsFromView)
   const confirmDelete = useWorkspaceStore((s) => s.confirmDelete)
   const workspace = useWorkspaceStore((s) => s.workspace)
   const activeViewKey = useWorkspaceStore((s) => s.activeViewKey)
@@ -90,6 +91,9 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
   const appearsInViews = workspace ? getAllViews(workspace).filter(v =>
     v.elements.some(e => e.id === element.id)
   ) : []
+  const appearsInActiveView = activeViewKey
+    ? appearsInViews.some(v => v.key === activeViewKey)
+    : false
 
   return (
     <div className="flex flex-1 flex-col">
@@ -100,6 +104,23 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
           <div className="text-[11px]" style={{ color: typeColor }}>{getElementTypeLabel(element)}</div>
         </div>
         <div className="flex items-center gap-1">
+          {/* Remove from view — touch-friendly parity with Backspace; hidden on the
+             focal-scope element (can't unproject the element a view is defined by)
+             and when the element isn't actually in the active view. */}
+          {!isFocal && activeViewKey && appearsInActiveView && (
+            <button
+              onClick={() => {
+                if (!activeViewKey) return
+                removeElementsFromView(activeViewKey, [element.id])
+              }}
+              className="btn-icon !min-h-7 !min-w-7 !p-1"
+              aria-label="Remove from view"
+              title="Remove from this view (model unchanged)"
+              style={{ color: 'var(--color-text-muted)' }}
+            >
+              <EyeOff size={14} />
+            </button>
+          )}
           {isFocal ? (
             <button
               disabled


### PR DESCRIPTION
## Summary

After #49, touch users only had the destructive "Delete from model" Trash button in the inspector — no parity with the keyboard's lightweight Backspace=remove-from-view. The final cross-cutting reviewer of #49 called this out as a real UX gap.

This adds an EyeOff icon button to the inspector header, immediately to the left of the Trash. Click removes the element from the active view only (no confirm, undoable via Cmd+Z). Hidden in the two cases where it doesn't make sense: focal-scope element, or element not actually in the active view.

## Test Plan

- [x] \`npm test\` — 1036 tests pass (3 new in \`RightPanel.test.tsx\` covering: removes from view + leaves model intact, hidden when focal, hidden when not in active view)
- [x] \`npx tsc -b\` clean
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)