### PR TITLE
feat(dsl): include element.type==X and element.parent==X expressions

### DIFF
--- a/src/lib/dsl/include-expression.test.ts
+++ b/src/lib/dsl/include-expression.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import { parseDSL, serializeDSL } from './index'
+
+/**
+ * Verifies the Structurizr DSL expression forms for `include`:
+ *   - `include element.type==<typename>`
+ *   - `include element.parent==<ref>`
+ *
+ * Both come from the cookbook recipe at
+ * https://docs.structurizr.com/dsl/cookbook/container-view-multiple-software-systems/
+ *
+ * The simpler explicit-id form (`include c1 c2`) is covered by
+ * multi-system-container-view.test.ts.
+ */
+
+describe('include expression: element.type==X', () => {
+  it('expands to every container across all systems', () => {
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1" {
+            c1 = container "C1"
+            c2 = container "C2"
+          }
+          s2 = softwareSystem "S2" {
+            c3 = container "C3"
+          }
+        }
+        views {
+          container s1 {
+            include element.type==container
+          }
+        }
+      }
+    `.trim()
+
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+
+    const view = workspace.views.containerViews[0]
+    const names = view.elements
+      .map(e => {
+        for (const sys of workspace.model.softwareSystems) {
+          for (const c of sys.containers) {
+            if (c.id === e.id) return c.name
+          }
+        }
+        return e.id
+      })
+      .sort()
+    expect(names).toEqual(['C1', 'C2', 'C3'])
+  })
+
+  it('expands element.type==softwareSystem to every system in the model', () => {
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1"
+          s2 = softwareSystem "S2"
+          s3 = softwareSystem "S3"
+        }
+        views {
+          systemLandscape "Land" {
+            include element.type==softwareSystem
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    expect(workspace.views.systemLandscapeViews[0].elements).toHaveLength(3)
+  })
+
+  it('expands element.type==person to every person', () => {
+    const dsl = `
+      workspace {
+        model {
+          alice = person "Alice"
+          bob = person "Bob"
+          s1 = softwareSystem "S1"
+        }
+        views {
+          systemLandscape "Land" {
+            include element.type==person
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    const view = workspace.views.systemLandscapeViews[0]
+    expect(view.elements).toHaveLength(2)
+  })
+})
+
+describe('include expression: element.parent==X', () => {
+  it('expands to every container of the named system', () => {
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1" {
+            c1 = container "C1"
+            c2 = container "C2"
+          }
+          s2 = softwareSystem "S2" {
+            c3 = container "C3"
+          }
+        }
+        views {
+          container s1 {
+            include element.parent==s1
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+
+    const view = workspace.views.containerViews[0]
+    const names = view.elements
+      .map(e => {
+        for (const sys of workspace.model.softwareSystems) {
+          for (const c of sys.containers) {
+            if (c.id === e.id) return c.name
+          }
+        }
+        return e.id
+      })
+      .sort()
+    // Only S1's containers — c3 (under S2) is excluded because we filtered by parent
+    expect(names).toEqual(['C1', 'C2'])
+  })
+
+  it('combines multiple element.parent expressions on a single include line', () => {
+    // The cookbook recipe explicitly shows: include element.parent==s1 element.parent==s2
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1" {
+            c1 = container "C1"
+          }
+          s2 = softwareSystem "S2" {
+            c2 = container "C2"
+          }
+        }
+        views {
+          container s1 {
+            include element.parent==s1 element.parent==s2
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+
+    const view = workspace.views.containerViews[0]
+    expect(view.elements).toHaveLength(2)
+  })
+})
+
+describe('include expression: round-trip', () => {
+  it('the SERIALIZED output uses explicit refs, not the expression form', () => {
+    // Expressions are parse-time syntactic sugar — we resolve them eagerly
+    // into the view's elements list, so serialization emits the resolved IDs.
+    // Round-tripping is lossless on the resulting element set even though the
+    // textual DSL changes shape.
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1" {
+            c1 = container "C1"
+            c2 = container "C2"
+          }
+        }
+        views {
+          container s1 {
+            include element.type==container
+          }
+        }
+      }
+    `.trim()
+    const first = parseDSL(dsl)
+    const dsl2 = serializeDSL(first.workspace)
+    const second = parseDSL(dsl2)
+    expect(second.errors).toEqual([])
+    // Both containers survive the round trip via the explicit-id form
+    expect(second.workspace.views.containerViews[0].elements).toHaveLength(2)
+  })
+})
+
+describe('include expression: degenerate inputs', () => {
+  it('unknown type name silently expands to zero elements (no parse error)', () => {
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1"
+        }
+        views {
+          systemLandscape "Land" {
+            include element.type==notARealType
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    expect(workspace.views.systemLandscapeViews[0].elements).toEqual([])
+  })
+
+  it('unknown parent ref silently expands to zero elements', () => {
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1" {
+            c1 = container "C1"
+          }
+        }
+        views {
+          container s1 {
+            include element.parent==doesNotExist
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    expect(workspace.views.containerViews[0].elements).toEqual([])
+  })
+
+  it('preserves the explicit-id path when an arg is not an expression', () => {
+    // Mixed include: one explicit ref + one expression on the same line
+    const dsl = `
+      workspace {
+        model {
+          s1 = softwareSystem "S1" {
+            c1 = container "C1"
+            c2 = container "C2"
+          }
+        }
+        views {
+          container s1 {
+            include c1 element.parent==s1
+          }
+        }
+      }
+    `.trim()
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    // c1 added explicitly, then expanded by expression — c1 may appear twice
+    // (we don't dedup; serializer/render layers tolerate duplicates).
+    const ids = workspace.views.containerViews[0].elements.map(e => e.id)
+    expect(ids.length).toBeGreaterThanOrEqual(2)
+    // Both c1 and c2's IDs must be present at least once each
+    const c1 = workspace.model.softwareSystems[0].containers.find(c => c.name === 'C1')!
+    const c2 = workspace.model.softwareSystems[0].containers.find(c => c.name === 'C2')!
+    expect(ids).toContain(c1.id)
+    expect(ids).toContain(c2.id)
+  })
+})

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -10,6 +10,7 @@ export type TokenType =
     | 'RBRACE'
     | 'EQUALS'
     | 'STAR'
+    | 'DOT'
     | 'NEWLINE'
     | 'COMMENT'
     | 'NUMBER'
@@ -318,6 +319,17 @@ export function lex(input: string): LexResult {
         if (ch === '*') {
             advance()
             tokens.push({ type: 'STAR', value: '*', line: startLine, column: startCol })
+            continue
+        }
+
+        if (ch === '.') {
+            // The dot only ever appears in `element.type==X` / `element.parent==X`
+            // expressions inside `include` / `exclude` statements. Bare dots
+            // elsewhere were a lexer error before and still are after parsing
+            // (the parser will report "unexpected DOT" if it sees one outside
+            // an expression).
+            advance()
+            tokens.push({ type: 'DOT', value: '.', line: startLine, column: startCol })
             continue
         }
 

--- a/src/lib/dsl/parser-views.ts
+++ b/src/lib/dsl/parser-views.ts
@@ -5,7 +5,7 @@
 // access viewExcludedIds / the resolveRef map without inheriting the full
 // parser class.
 
-import type { Workspace, View, ViewType, AutoLayout, LayoutDirection } from '@/types/model'
+import type { Workspace, View, ViewType, AutoLayout, LayoutDirection, Model } from '@/types/model'
 import type { ContextAwareParser } from './parser'
 import { parseStylesBody } from './parser-styles'
 
@@ -43,7 +43,7 @@ function ensureViewKey(view: View, viewsContainer: ViewsContainer, elementRef: s
     view.autoKey = true
 }
 
-export function parseViewsBody(p: ContextAwareParser, views: Workspace['views']): void {
+export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'], model: Model): void {
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
         p.skipNewlines()
         if (p.check('RBRACE') || p.peekType() === 'EOF') break
@@ -56,7 +56,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'])
             const kw = token.value.toLowerCase()
 
             if (kw === 'systemlandscape') {
-                const view = parseSystemLandscapeView(p)
+                const view = parseSystemLandscapeView(p, model)
                 if (view) {
                     ensureViewKey(view, views, undefined)
                     views.systemLandscapeViews.push(view)
@@ -64,7 +64,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'])
                 continue
             }
             if (kw === 'systemcontext') {
-                const view = parseElementView(p, 'systemContext')
+                const view = parseElementView(p, 'systemContext', model)
                 if (view) {
                     ensureViewKey(view, views, view.softwareSystemId)
                     views.systemContextViews.push(view)
@@ -72,7 +72,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'])
                 continue
             }
             if (kw === 'container') {
-                const view = parseElementView(p, 'container')
+                const view = parseElementView(p, 'container', model)
                 if (view) {
                     ensureViewKey(view, views, view.softwareSystemId)
                     views.containerViews.push(view)
@@ -80,7 +80,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'])
                 continue
             }
             if (kw === 'component') {
-                const view = parseElementView(p, 'component')
+                const view = parseElementView(p, 'component', model)
                 if (view) {
                     ensureViewKey(view, views, view.containerId)
                     views.componentViews.push(view)
@@ -134,7 +134,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'])
     }
 }
 
-function parseSystemLandscapeView(p: ContextAwareParser): View | null {
+function parseSystemLandscapeView(p: ContextAwareParser, model: Model): View | null {
     p.advance() // consume 'systemLandscape'
     const key = p.readOptionalStringOrIdentifier() ?? ''
     const positionalDescription = p.readOptionalString()
@@ -153,7 +153,7 @@ function parseSystemLandscapeView(p: ContextAwareParser): View | null {
 
     p.skipNewlines()
     if (p.match('LBRACE')) {
-        parseViewBody(p, view)
+        parseViewBody(p, view, model)
         p.skipNewlines()
         p.expect('RBRACE')
     }
@@ -161,7 +161,7 @@ function parseSystemLandscapeView(p: ContextAwareParser): View | null {
     return view
 }
 
-function parseElementView(p: ContextAwareParser, type: ViewType): View | null {
+function parseElementView(p: ContextAwareParser, type: ViewType, model: Model): View | null {
     p.advance() // consume keyword
 
     const elementRef = p.readOptionalStringOrIdentifier()
@@ -188,7 +188,7 @@ function parseElementView(p: ContextAwareParser, type: ViewType): View | null {
 
     p.skipNewlines()
     if (p.match('LBRACE')) {
-        parseViewBody(p, view)
+        parseViewBody(p, view, model)
         p.skipNewlines()
         p.expect('RBRACE')
     }
@@ -196,7 +196,7 @@ function parseElementView(p: ContextAwareParser, type: ViewType): View | null {
     return view
 }
 
-function parseViewBody(p: ContextAwareParser, view: View): void {
+function parseViewBody(p: ContextAwareParser, view: View, model: Model): void {
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
         p.skipNewlines()
         if (p.check('RBRACE') || p.peekType() === 'EOF') break
@@ -213,7 +213,16 @@ function parseViewBody(p: ContextAwareParser, view: View): void {
                 if (p.match('STAR')) {
                     view.elements.push({ id: '*' })
                 } else {
+                    // Each arg is either:
+                    //   - an element ref (IDENTIFIER/STRING/KEYWORD)
+                    //   - an expression: `element.type==X` or `element.parent==X`
+                    //     (Structurizr cookbook: container-view-multiple-software-systems)
                     while (p.check('IDENTIFIER') || p.check('STRING') || p.check('KEYWORD')) {
+                        const expansion = tryParseElementExpression(p, model)
+                        if (expansion) {
+                            for (const id of expansion) view.elements.push({ id })
+                            continue
+                        }
                         const ref = p.advance().value
                         const resolvedId = p.resolveRef(ref)
                         view.elements.push({ id: resolvedId ?? ref })
@@ -302,4 +311,81 @@ function parseViewBody(p: ContextAwareParser, view: View): void {
 
         p.advance()
     }
+}
+
+/**
+ * Attempts to parse a Structurizr expression of the form
+ * `element.<field>==<value>` from the current parser position. Returns the
+ * list of element IDs the expression resolves to, or null if no expression
+ * was found (in which case the caller falls through to the normal element-ref
+ * path and the parser position is unchanged).
+ *
+ * Supported fields:
+ *   - `element.type==<typename>` — every element of that type. Accepts the
+ *     C4 type names: person, softwareSystem, container, component.
+ *   - `element.parent==<ref>`    — every direct child of `<ref>` (containers
+ *     of a system, or components of a container).
+ *
+ * Recognised at parse time inside `include` statements; the cookbook recipe
+ * for "container view for multiple software systems" demonstrates the usage.
+ * https://docs.structurizr.com/dsl/cookbook/container-view-multiple-software-systems/
+ */
+function tryParseElementExpression(p: ContextAwareParser, model: Model): string[] | null {
+    // Lookahead must be: IDENTIFIER('element') DOT IDENTIFIER EQUALS EQUALS <value>
+    if (p.peekValue() !== 'element' || p.tokens[p.pos + 1]?.type !== 'DOT') return null
+    if (p.tokens[p.pos + 2]?.type !== 'IDENTIFIER' && p.tokens[p.pos + 2]?.type !== 'KEYWORD') return null
+    if (p.tokens[p.pos + 3]?.type !== 'EQUALS' || p.tokens[p.pos + 4]?.type !== 'EQUALS') return null
+    const valueTok = p.tokens[p.pos + 5]
+    if (valueTok?.type !== 'IDENTIFIER' && valueTok?.type !== 'STRING' && valueTok?.type !== 'KEYWORD') return null
+
+    const fieldName = p.tokens[p.pos + 2].value
+    const value = valueTok.value
+
+    // Commit: consume all 6 tokens
+    p.advance(); p.advance(); p.advance(); p.advance(); p.advance(); p.advance()
+
+    return resolveExpression(fieldName, value, model, p)
+}
+
+function resolveExpression(field: string, value: string, model: Model, p: ContextAwareParser): string[] {
+    if (field === 'type') {
+        return resolveTypeExpression(value, model)
+    }
+    if (field === 'parent') {
+        return resolveParentExpression(value, model, p)
+    }
+    return []
+}
+
+function resolveTypeExpression(typeName: string, model: Model): string[] {
+    const out: string[] = []
+    const t = typeName.toLowerCase()
+    if (t === 'person' || t === 'people') {
+        for (const person of model.people) out.push(person.id)
+    } else if (t === 'softwaresystem' || t === 'softwaresystems') {
+        for (const sys of model.softwareSystems) out.push(sys.id)
+    } else if (t === 'container' || t === 'containers') {
+        for (const sys of model.softwareSystems) for (const c of sys.containers) out.push(c.id)
+    } else if (t === 'component' || t === 'components') {
+        for (const sys of model.softwareSystems) for (const c of sys.containers) for (const cmp of c.components) out.push(cmp.id)
+    }
+    return out
+}
+
+function resolveParentExpression(parentRef: string, model: Model, p: ContextAwareParser): string[] {
+    const parentId = p.resolveRef(parentRef) ?? parentRef
+    const out: string[] = []
+    for (const sys of model.softwareSystems) {
+        if (sys.id === parentId) {
+            for (const c of sys.containers) out.push(c.id)
+            return out
+        }
+        for (const c of sys.containers) {
+            if (c.id === parentId) {
+                for (const cmp of c.components) out.push(cmp.id)
+                return out
+            }
+        }
+    }
+    return out
 }

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -378,7 +378,7 @@ export class ContextAwareParser {
                     this.advance()
                     this.skipNewlines()
                     if (this.match('LBRACE')) {
-                        parseViewsBody(this, workspace.views)
+                        parseViewsBody(this, workspace.views, workspace.model)
                         this.skipNewlines()
                         this.expect('RBRACE')
                     }


### PR DESCRIPTION
## Summary

Adds parser support for the Structurizr expression form of \`include\` statements:

\`\`\`dsl
container s1 {
  include element.type==container
  include element.parent==s1 element.parent==s2
}
\`\`\`

c4hero used to choke on these — the lexer flagged the dot as "Unexpected character." Imported Structurizr workspaces that used the expression form lost their view content silently. Closes the gap I called out in the multi-system-container-view investigation.

## How

- **Lexer:** new \`DOT\` token type. Only used inside these expressions; bare dots elsewhere were errors before and still are.
- **Parser:** model is now threaded through to the include handler, which looks ahead for the 6-token pattern \`element . field == value\`. Matches resolve against the model:
  - \`element.type==<typename>\` → every element of that C4 type (person, softwareSystem, container, component).
  - \`element.parent==<ref>\` → every direct child of \`<ref>\`.
- Mixed expressions and literal IDs on the same line work. Unknown types/parents expand to zero (no parse error — matches Structurizr's lenient behavior).
- Expressions are eagerly resolved at parse time, so serialize/parse round-trips emit explicit refs (\`include c1\`) rather than the original expression. Equivalent semantically.

## Test Plan

- [x] \`npm test\` — 1042 tests pass (9 new in \`include-expression.test.ts\` covering all type/parent permutations, mixed expressions, round-trip behavior, degenerate inputs)
- [x] \`npx tsc -b\` clean
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)