### PR TITLE
fix(mobile): AddElementPanel pops upward from the bottom-row tool rail

### DIFF
--- a/src/components/layout/AddElementPanel.tsx
+++ b/src/components/layout/AddElementPanel.tsx
@@ -194,6 +194,7 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
     <div
       ref={panelRef}
       className="glass-flyout"
+      data-flyout="add-element"
       style={{
         position: 'absolute',
         left: 56,

--- a/src/index.css
+++ b/src/index.css
@@ -1171,11 +1171,18 @@ body {
   /* Flyouts opened from the bottom-row tool rail must open UPWARD; the
      desktop default places them to the right of a vertical-rail button,
      which would push them off the bottom of the viewport here. */
-  [data-canvas-chrome="tool-rail"] [data-flyout="arrange"] {
+  [data-canvas-chrome="tool-rail"] [data-flyout="arrange"],
+  [data-canvas-chrome="tool-rail"] [data-flyout="add-element"] {
     top: auto !important;
     bottom: calc(100% + 8px) !important;
     left: 50% !important;
     transform: translateX(-50%) !important;
+  }
+  /* AddElementPanel is wider (280px) and taller (up to 420px) than the
+     arrange flyout — cap its height against the viewport so it never
+     extends above the address bar / status notch when it pops upward. */
+  [data-canvas-chrome="tool-rail"] [data-flyout="add-element"] {
+    max-height: calc(100vh - 120px) !important;
   }
   /* Right-side panels (Inspector, Highlighter): full-width below the
      diagram instead of a 280-300px column that would squish the canvas. */


### PR DESCRIPTION
## Summary

On mobile, the tool rail flips from a vertical column on the left to a horizontal row near the bottom of the viewport. The auto-arrange flyout already handled this via a CSS override keyed on \`data-flyout="arrange"\` — pop upward instead of rightward. The AddElementPanel did not have an equivalent attribute, so its desktop-anchored \`top: 0; left: 56\` positioning rendered the panel downward off the bottom of the screen. Only the very top of the "Create new" section was visible (see screenshot in the originating thread).

## Fix

- Tag the AddElementPanel root with \`data-flyout="add-element"\`.
- Extend the existing mobile media-query rule to apply the same upward-pop positioning.
- Cap the panel's max-height to \`calc(100vh - 120px)\` so the (wider, taller) panel never clips above the address bar / status notch.

## Other flyouts audited

| Component | Status |
| --- | --- |
| AddElementPanel | This PR fixes it |
| Auto-arrange flyout | Already fixed |
| MultiSelectBar align flyout | Smart \`top:100%\` / \`bottom:100%\` already handles available space |
| FloatingTopPill hamburger | Flow-positioned via flex; unaffected |
| BottomHighlighterBar | \`position:absolute\` is for input icons, not flyouts |

So the bug is isolated to AddElementPanel.

## Test Plan

- [x] \`npm test\` — 1050 tests pass (unchanged)
- [x] \`npx tsc -b\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: load \`app.c4hero.com\` on a phone, open a workspace, click the \`+\` (Add element) button at the bottom-left of the tool rail, confirm the panel now pops upward and is fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)