### PR TITLE
feat(canvas): per-system boundaries + always-present focal boundary

### DIFF
--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -31,7 +31,7 @@ import {
 import { nodeTypes } from './nodes'
 import type { EdgeTypes } from '@xyflow/react'
 import RelationshipEdge from './edges/RelationshipEdge'
-import { buildNodes, buildEdges, buildGroupNodes, buildBoundaryNode, buildDrillableSet } from './canvasBuilders'
+import { buildNodes, buildEdges, buildGroupNodes, buildBoundaryNodes, buildDrillableSet } from './canvasBuilders'
 
 const edgeTypes: EdgeTypes = {
   relationship: RelationshipEdge,
@@ -227,8 +227,8 @@ export default function Canvas() {
 
     // 4. Build group background nodes and scope boundary using post-layout positions
     const groupNodes = buildGroupNodes(workspace, workspace.model.groups, laidOut)
-    const boundaryNode = buildBoundaryNode(workspace, view, laidOut)
-    const overlayNodes = [...(boundaryNode ? [boundaryNode] : []), ...groupNodes]
+    const boundaryNodes = buildBoundaryNodes(workspace, view, laidOut)
+    const overlayNodes = [...boundaryNodes, ...groupNodes]
     const allNodes = [...overlayNodes, ...laidOut]
 
     // 5. Build final edges using post-layout positions for handle routing
@@ -308,12 +308,12 @@ export default function Canvas() {
     }
     setNodes((prev) => {
       const contentOnly = prev
-        .filter(n => !n.id.startsWith('group-') && n.id !== '__scope_boundary__')
+        .filter(n => !n.id.startsWith('group-') && !n.id.startsWith('__scope_boundary__'))
         .map(n => ({ ...n, measured: measuredById.get(n.id) ?? n.measured }))
       const updatedGroups = buildGroupNodes(ws, ws.model.groups, contentOnly)
-      const updatedBoundary = v ? buildBoundaryNode(ws, v, contentOnly) : null
+      const updatedBoundaries = v ? buildBoundaryNodes(ws, v, contentOnly) : []
       const overlays: typeof prev = []
-      if (updatedBoundary) overlays.push(updatedBoundary as typeof prev[0])
+      overlays.push(...updatedBoundaries as typeof prev)
       overlays.push(...updatedGroups as typeof prev)
       return [...contentOnly, ...overlays]
     })
@@ -507,7 +507,7 @@ export default function Canvas() {
     }
     // When content nodes get measured/resized, rebuild group/boundary overlays
     // so they wrap the actual rendered sizes, not the 200×100 dagre defaults.
-    if (changes.some(c => c.type === 'dimensions' && 'id' in c && !(c.id as string).startsWith('group-') && c.id !== '__scope_boundary__')) {
+    if (changes.some(c => c.type === 'dimensions' && 'id' in c && !(c.id as string).startsWith('group-') && !(c.id as string).startsWith('__scope_boundary__'))) {
       requestAnimationFrame(rebuildOverlays)
     }
   }, [onNodesChange, fitContentNodes, rebuildOverlays])
@@ -677,7 +677,7 @@ export default function Canvas() {
       // Let shift+click go through onSelectionChange (RF handles multi-select natively)
       if (event.shiftKey) return
       if (!multiSelectModeRef.current) return
-      if (node.id.startsWith('group-') || node.id === '__scope_boundary__') return
+      if (node.id.startsWith('group-') || node.id.startsWith('__scope_boundary__')) return
       event.stopPropagation()
       // Toggle this node in both RF state and store
       setNodes((prev) =>
@@ -733,9 +733,9 @@ export default function Canvas() {
         setNodes(prev => {
           const contentOnly = prev.filter(n => n.type !== 'group' && n.type !== 'boundary')
           const updatedGroups = buildGroupNodes(ws, ws.model.groups, contentOnly)
-          const updatedBoundary = v ? buildBoundaryNode(ws, v, contentOnly) : null
+          const updatedBoundaries = v ? buildBoundaryNodes(ws, v, contentOnly) : []
           const overlays: typeof prev = []
-          if (updatedBoundary) overlays.push(updatedBoundary as typeof prev[0])
+          overlays.push(...updatedBoundaries as typeof prev)
           overlays.push(...updatedGroups as typeof prev)
           return [...contentOnly, ...overlays]
         })

--- a/src/components/canvas/buildBoundaryNodes.test.ts
+++ b/src/components/canvas/buildBoundaryNodes.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import type { Node } from '@xyflow/react'
+import type { Workspace, View } from '@/types/model'
+import { buildBoundaryNodes } from './canvasBuilders'
+
+function el(id: string, x: number, y: number): Node {
+  return {
+    id,
+    type: 'c4',
+    position: { x, y },
+    measured: { width: 200, height: 100 },
+    data: {},
+  } as unknown as Node
+}
+
+function ws(): Workspace {
+  return {
+    name: 'T',
+    model: {
+      people: [],
+      softwareSystems: [
+        {
+          id: 'sysA', type: 'softwareSystem', name: 'System A', tags: [], properties: {},
+          containers: [
+            { id: 'a1', type: 'container', name: 'A1', tags: [], properties: {}, components: [] },
+            { id: 'a2', type: 'container', name: 'A2', tags: [], properties: {}, components: [] },
+          ],
+        },
+        {
+          id: 'sysB', type: 'softwareSystem', name: 'System B', tags: [], properties: {},
+          containers: [
+            { id: 'b1', type: 'container', name: 'B1', tags: [], properties: {}, components: [] },
+          ],
+        },
+      ],
+      relationships: [], groups: [],
+    },
+    views: {
+      systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+describe('buildBoundaryNodes', () => {
+  it('draws one boundary per system whose containers appear in a Container view', () => {
+    const view: View = {
+      type: 'container', key: 'cont', softwareSystemId: 'sysA',
+      elements: [{ id: 'a1' }, { id: 'a2' }, { id: 'b1' }], relationships: [],
+    }
+    const laidOut = [el('a1', 0, 0), el('a2', 250, 0), el('b1', 600, 0)]
+    const result = buildBoundaryNodes(ws(), view, laidOut)
+    expect(result).toHaveLength(2)
+    const names = result.map(n => (n.data as { name: string }).name).sort()
+    expect(names).toEqual(['System A', 'System B'])
+  })
+
+  it('draws an empty focal boundary when the Container view has zero containers in it yet', () => {
+    const view: View = {
+      type: 'container', key: 'cont', softwareSystemId: 'sysA',
+      elements: [], relationships: [],
+    }
+    const result = buildBoundaryNodes(ws(), view, [])
+    expect(result).toHaveLength(1)
+    const b = result[0]
+    expect((b.data as { name: string }).name).toBe('System A')
+    // Default placement at origin so newly-added containers land inside it
+    expect(b.position).toEqual({ x: 0, y: 0 })
+    expect(b.style?.width).toBeGreaterThan(0)
+  })
+
+  it('does NOT double-emit the focal boundary when it already has containers', () => {
+    const view: View = {
+      type: 'container', key: 'cont', softwareSystemId: 'sysA',
+      elements: [{ id: 'a1' }], relationships: [],
+    }
+    const laidOut = [el('a1', 0, 0)]
+    const result = buildBoundaryNodes(ws(), view, laidOut)
+    expect(result).toHaveLength(1)
+    expect((result[0].data as { name: string }).name).toBe('System A')
+    // Sized to the container, not the empty default
+    expect(result[0].style?.width).not.toBe(400)
+  })
+
+  it('emits no boundaries on a Landscape view (no scope concept)', () => {
+    const view: View = {
+      type: 'systemLandscape', key: 'land',
+      elements: [{ id: 'sysA' }, { id: 'sysB' }], relationships: [],
+    }
+    const laidOut = [el('sysA', 0, 0), el('sysB', 250, 0)]
+    expect(buildBoundaryNodes(ws(), view, laidOut)).toEqual([])
+  })
+
+  it('draws an empty focal boundary for a fresh Component view', () => {
+    // Add one container with components to the model so we have a focal
+    const w = ws()
+    w.model.softwareSystems[0].containers[0].components = [
+      { id: 'cmp1', type: 'component', name: 'Cmp1', tags: [], properties: {} },
+    ]
+    const view: View = {
+      type: 'component', key: 'comp', containerId: 'a1',
+      elements: [], relationships: [],
+    }
+    const result = buildBoundaryNodes(w, view, [])
+    expect(result).toHaveLength(1)
+    expect((result[0].data as { name: string }).name).toBe('A1')
+    expect((result[0].data as { typeLabel: string }).typeLabel).toBe('Container')
+  })
+
+  it('uses the prefix __scope_boundary__ for boundary node IDs', () => {
+    // The Canvas filters on this prefix to skip boundaries during layout +
+    // selection. If the prefix changes here, those filters need to update too.
+    const view: View = {
+      type: 'container', key: 'cont', softwareSystemId: 'sysA',
+      elements: [{ id: 'a1' }], relationships: [],
+    }
+    const result = buildBoundaryNodes(ws(), view, [el('a1', 0, 0)])
+    for (const node of result) {
+      expect(node.id.startsWith('__scope_boundary__')).toBe(true)
+    }
+  })
+})

--- a/src/components/canvas/canvasBuilders.ts
+++ b/src/components/canvas/canvasBuilders.ts
@@ -168,7 +168,7 @@ export function buildGroupNodes(
   // Build position+size map from the already-laid-out element nodes
   const nodeMap = new Map<string, { x: number; y: number; w: number; h: number }>()
   for (const n of laidOutNodes) {
-    if (!n.id.startsWith('group-') && n.id !== '__scope_boundary__') {
+    if (!n.id.startsWith('group-') && !n.id.startsWith('__scope_boundary__')) {
       nodeMap.set(n.id, {
         x: n.position.x,
         y: n.position.y,
@@ -217,11 +217,25 @@ export function buildGroupNodes(
 }
 
 /** Build the implicit scope boundary node for container/component views using post-layout positions. */
-export function buildBoundaryNode(
+/**
+ * Build the C4 boundary boxes that wrap members of a parent (system or
+ * container) on the active view. On a Container view we draw one boundary
+ * per software system whose containers appear in the view (the focal system
+ * AND any foreign systems whose containers were added via picker or via the
+ * Structurizr `include element.parent==X` recipe). On a Component view we
+ * do the same per container. Each boundary becomes a non-interactive node
+ * with id `__scope_boundary__<parentId>` and is rendered at z-index -2 so
+ * its members sit on top.
+ *
+ * Foreign-system boundaries are essential for the multi-system container
+ * view recipe — without them, foreign containers float in the view with no
+ * visual indication of which system they belong to.
+ */
+export function buildBoundaryNodes(
   workspace: Workspace,
   view: View,
   laidOutNodes: Node[],
-): Node | null {
+): Node[] {
   const BOUNDARY_PADDING = 32
   // Header has 2 lines (name + type label) + internal padding; needs more
   // headroom than the side/bottom padding so the subtitle isn't covered by the
@@ -229,9 +243,10 @@ export function buildBoundaryNode(
   const BOUNDARY_PADDING_TOP = 64
 
   // Build position+size map from laid-out element nodes only
-  const nodeMap = new Map<string, { x: number; y: number; w: number; h: number }>()
+  type Rect = { x: number; y: number; w: number; h: number }
+  const nodeMap = new Map<string, Rect>()
   for (const n of laidOutNodes) {
-    if (!n.id.startsWith('group-') && n.id !== '__scope_boundary__') {
+    if (!n.id.startsWith('group-') && !n.id.startsWith('__scope_boundary__')) {
       nodeMap.set(n.id, {
         x: n.position.x,
         y: n.position.y,
@@ -241,71 +256,98 @@ export function buildBoundaryNode(
     }
   }
 
-  if (view.type === 'container' && view.softwareSystemId) {
-    const scopeSystem = workspace.model.softwareSystems.find(s => s.id === view.softwareSystemId)
-    if (scopeSystem) {
-      const containerIds = new Set(scopeSystem.containers.map(c => c.id))
-      const internalPositions = Array.from(nodeMap.entries())
-        .filter(([id]) => containerIds.has(id))
-        .map(([, pos]) => pos)
+  // Empty-boundary defaults: when the focal scope has no members in the view
+  // (a fresh L2/L3 the user just created), still draw a labeled boundary so
+  // the user sees what the view is about. The first node added will land
+  // inside the boundary and trigger an auto-resize on the next rebuild.
+  const EMPTY_BOUNDARY_W = 400
+  const EMPTY_BOUNDARY_H = 200
 
-      if (internalPositions.length > 0) {
-        const minX = Math.min(...internalPositions.map(p => p.x))
-        const minY = Math.min(...internalPositions.map(p => p.y))
-        const maxX = Math.max(...internalPositions.map(p => p.x + p.w))
-        const maxY = Math.max(...internalPositions.map(p => p.y + p.h))
-        return {
-          id: '__scope_boundary__',
-          type: 'boundary',
-          position: { x: minX - BOUNDARY_PADDING, y: minY - BOUNDARY_PADDING_TOP },
-          style: {
-            width: (maxX - minX) + BOUNDARY_PADDING * 2,
-            height: (maxY - minY) + BOUNDARY_PADDING_TOP + BOUNDARY_PADDING,
-          },
-          data: { name: scopeSystem.name, typeLabel: 'Software System' },
-          zIndex: -2,
-          selectable: false,
-          draggable: false,
-          focusable: false,
+  function makeBoundary(parentId: string, name: string, typeLabel: string, members: Rect[]): Node {
+    if (members.length === 0) {
+      return {
+        id: `__scope_boundary__${parentId}`,
+        type: 'boundary',
+        position: { x: 0, y: 0 },
+        style: { width: EMPTY_BOUNDARY_W, height: EMPTY_BOUNDARY_H },
+        data: { name, typeLabel },
+        zIndex: -2,
+        selectable: false,
+        draggable: false,
+        focusable: false,
+      }
+    }
+    const minX = Math.min(...members.map(p => p.x))
+    const minY = Math.min(...members.map(p => p.y))
+    const maxX = Math.max(...members.map(p => p.x + p.w))
+    const maxY = Math.max(...members.map(p => p.y + p.h))
+    return {
+      id: `__scope_boundary__${parentId}`,
+      type: 'boundary',
+      position: { x: minX - BOUNDARY_PADDING, y: minY - BOUNDARY_PADDING_TOP },
+      style: {
+        width: (maxX - minX) + BOUNDARY_PADDING * 2,
+        height: (maxY - minY) + BOUNDARY_PADDING_TOP + BOUNDARY_PADDING,
+      },
+      data: { name, typeLabel },
+      zIndex: -2,
+      selectable: false,
+      draggable: false,
+      focusable: false,
+    }
+  }
+
+  const boundaries: Node[] = []
+
+  if (view.type === 'container') {
+    // Track which systems already got a boundary (because they have members)
+    // so we don't double-emit when the focal system is also in the loop.
+    const drawnSystemIds = new Set<string>()
+    for (const sys of workspace.model.softwareSystems) {
+      const members: Rect[] = []
+      for (const c of sys.containers) {
+        const pos = nodeMap.get(c.id)
+        if (pos) members.push(pos)
+      }
+      if (members.length > 0) {
+        boundaries.push(makeBoundary(sys.id, sys.name, 'Software System', members))
+        drawnSystemIds.add(sys.id)
+      }
+    }
+    // Always show the focal-system boundary, even when empty — the user just
+    // created this Container view and needs to see what scope they're filling.
+    if (view.softwareSystemId && !drawnSystemIds.has(view.softwareSystemId)) {
+      const focal = workspace.model.softwareSystems.find(s => s.id === view.softwareSystemId)
+      if (focal) {
+        boundaries.push(makeBoundary(focal.id, focal.name, 'Software System', []))
+      }
+    }
+  } else if (view.type === 'component') {
+    const drawnContainerIds = new Set<string>()
+    for (const sys of workspace.model.softwareSystems) {
+      for (const c of sys.containers) {
+        const members: Rect[] = []
+        for (const comp of c.components) {
+          const pos = nodeMap.get(comp.id)
+          if (pos) members.push(pos)
         }
+        if (members.length > 0) {
+          boundaries.push(makeBoundary(c.id, c.name, 'Container', members))
+          drawnContainerIds.add(c.id)
+        }
+      }
+    }
+    if (view.containerId && !drawnContainerIds.has(view.containerId)) {
+      const focal = workspace.model.softwareSystems
+        .flatMap(s => s.containers)
+        .find(c => c.id === view.containerId)
+      if (focal) {
+        boundaries.push(makeBoundary(focal.id, focal.name, 'Container', []))
       }
     }
   }
 
-  if (view.type === 'component' && view.containerId) {
-    const scopeContainer = workspace.model.softwareSystems
-      .flatMap(s => s.containers)
-      .find(c => c.id === view.containerId)
-    if (scopeContainer) {
-      const componentIds = new Set(scopeContainer.components.map(c => c.id))
-      const internalPositions = Array.from(nodeMap.entries())
-        .filter(([id]) => componentIds.has(id))
-        .map(([, pos]) => pos)
-
-      if (internalPositions.length > 0) {
-        const minX = Math.min(...internalPositions.map(p => p.x))
-        const minY = Math.min(...internalPositions.map(p => p.y))
-        const maxX = Math.max(...internalPositions.map(p => p.x + p.w))
-        const maxY = Math.max(...internalPositions.map(p => p.y + p.h))
-        return {
-          id: '__scope_boundary__',
-          type: 'boundary',
-          position: { x: minX - BOUNDARY_PADDING, y: minY - BOUNDARY_PADDING_TOP },
-          style: {
-            width: (maxX - minX) + BOUNDARY_PADDING * 2,
-            height: (maxY - minY) + BOUNDARY_PADDING_TOP + BOUNDARY_PADDING,
-          },
-          data: { name: scopeContainer.name, typeLabel: 'Container' },
-          zIndex: -2,
-          selectable: false,
-          draggable: false,
-          focusable: false,
-        }
-      }
-    }
-  }
-
-  return null
+  return boundaries
 }
 
 /** Distribute multiple edges on the same side across 3 slots (a–c) */

--- a/src/lib/fitViewport.ts
+++ b/src/lib/fitViewport.ts
@@ -39,7 +39,7 @@ interface FitOptions {
 export const CANVAS_FIT_CHROME_ATTRIBUTE = 'data-canvas-fit-chrome'
 
 export function isContentFitNode(node: Pick<Node, 'id'>): boolean {
-  return node.id !== '__scope_boundary__' && !node.id.startsWith('group-')
+  return !node.id.startsWith('__scope_boundary__') && !node.id.startsWith('group-')
 }
 
 export function fitContentNodesToViewport(


### PR DESCRIPTION
## Summary

Two related boundary-rendering improvements:

1. **Foreign-system containers get their own boundary.** When you add a container from System B to a Container view scoped to System A (the multi-system container view recipe — supported by parser since #51/#56), it used to float without any visual indication of which system it belongs to. Now it sits inside a "System B — Software System" boundary, just like System A's containers do.

2. **Empty L2/L3 views show the focal scope's boundary.** A freshly-created Container or Component view used to have nothing on the canvas (the focal boundary only appeared once you added a container/component). Now the labeled focal boundary is visible immediately, so you can see what the view is *about* before you start filling it.

Same logic for Component views: per-container boundaries, including the focal even when empty.

## How

Refactored \`buildBoundaryNode\` (returns one) into \`buildBoundaryNodes\` (returns a list). One boundary per parent (system on a Container view, container on a Component view) whose members appear in the view. Plus an explicit "always show the focal" pass at the end. Boundary IDs went from the literal \`__scope_boundary__\` to prefix-based \`__scope_boundary__<parentId>\` — all 8 filter sites updated to use \`startsWith\`.

## Test Plan

- [x] \`npm test\` — 1065 tests pass (6 new in \`buildBoundaryNodes.test.ts\` covering: multi-system Container view, empty focal Container view, no double-emit when focal already populated, no boundaries on Landscape, empty focal Component view, ID prefix invariant)
- [x] \`npx tsc -b\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: open the bigBank sample, navigate to the Containers view of "Internet Banking System", add a container from another system via the Add picker, confirm the foreign container sits inside its own labeled boundary
- [ ] Manual: create a brand-new Container view scoped to a system, confirm the empty boundary is visible immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)