### PR TITLE
Release v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c4hero",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c4hero",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c4hero",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Local-first visual architecture modelling for the C4 model. Edit visually, save as Structurizr DSL — your architecture lives in your repo.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Patch release **v0.2.1**.

Bumps \`package.json\` (and lockfile) \`0.2.0 → 0.2.1\` so the app footer and Sentry release tag reflect the shipped changes.

Changes since v0.2.0:
- Fix PNG and SVG canvas exports (#72)
- Dependency + build updates: vite 8 / esbuild (#71), prod-deps (#68), dev-deps (#73)

A GitHub Release \`v0.2.1\` and the c4hero-landing changelog entry accompany this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)