### PR TITLE
chore(ci): allowlist secret-scan false positives on the AI test fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+title = "c4hero gitleaks config"
+
+# Keep the full built-in gitleaks ruleset active; we only add targeted
+# allowlists below. Without this, a config file replaces the defaults and
+# silently disables all secret detection.
+[extend]
+useDefault = true
+
+[allowlist]
+  description = """
+    Test fixtures and regex patterns for the credential-detection feature.
+    repoScan.ts defines a regex *pattern* that matches PEM private-key blocks
+    (it is not itself a key). repoScan.test.ts uses intentionally fake tokens
+    (ghp_abc…, sk-abc…, BEGIN PRIVATE KEY…) to verify the redactSensitiveContent
+    function strips them before any data leaves the browser.
+  """
+  paths = [
+    '''src/lib/ai/repoScan\.ts''',
+    '''src/lib/ai/repoScan\.test\.ts''',
+  ]


### PR DESCRIPTION
## What

Adds `.gitleaks.toml` so the `secret-scan` CI job stops failing on intentional test fixtures.

The job runs `gitleaks detect` over cross-branch history, so the credential-detection feature's fake tokens in `src/lib/ai/repoScan.ts` and `repoScan.test.ts` (they exist to verify `redactSensitiveContent` strips secrets before anything leaves the browser) get flagged as real secrets on **every** PR targeting `main`.

The config keeps the **full default gitleaks ruleset active** (`[extend] useDefault = true`) and allowlists only those two fixture paths — real secret detection stays on; the known fixtures stop failing CI.

## Why now

`secret-scan` is a required check, so this red X blocks every PR to `main` (including the open Dependabot updates #85/#86). This unblocks them.

> Note: originally opened as the TEA-41 dependency-pin PR, but those vulns (undici/js-yaml/@babel) already landed on `main` via #79. Reduced to just the secret-scan fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YpYkKDTcrVzvVQSXcZSFK
