### PR TITLE
Fix design-system token drift and chip/button metric inconsistencies

### DIFF
--- a/src/components/canvas/edges/RelationshipEdge.tsx
+++ b/src/components/canvas/edges/RelationshipEdge.tsx
@@ -267,7 +267,17 @@ function RelationshipEdge({
             {relationship.tags.filter(t => t !== 'Relationship').length > 0 && (
               <div className="flex flex-wrap gap-1 mt-1">
                 {relationship.tags.filter(t => t !== 'Relationship').map(tag => (
-                  <span key={tag} className="text-[9px] rounded px-1 py-0.5" style={{ background: 'var(--color-surface-3)', color: 'var(--color-text-muted)' }}>
+                  <span
+                    key={tag}
+                    className="c4-type-chip"
+                    style={{
+                      background: 'var(--color-surface-3)',
+                      color: 'var(--color-text-muted)',
+                      fontWeight: 600,
+                      textTransform: 'none',
+                      letterSpacing: 'normal',
+                    }}
+                  >
                     {tag}
                   </span>
                 ))}

--- a/src/components/layout/right-panel/GroupProperties.tsx
+++ b/src/components/layout/right-panel/GroupProperties.tsx
@@ -52,15 +52,15 @@ export default function GroupProperties({ group, onClose }: { group: Group; onCl
         </span>
         <button
           onClick={() => confirmDelete(`Delete group "${group.name}"?`, () => { deleteGroup(group.id); onClose() })}
-          className="btn-icon !min-h-6 !min-w-6 !p-1"
+          className="btn-icon !min-h-7 !min-w-7 !p-1"
           title="Delete group"
           aria-label="Delete group"
           style={{ color: 'var(--color-text-muted)' }}
         >
-          <Trash2 size={12} />
+          <Trash2 size={14} />
         </button>
-        <button onClick={onClose} className="btn-icon !min-h-6 !min-w-6 !p-1" title="Close" aria-label="Close panel">
-          <X size={12} />
+        <button onClick={onClose} className="btn-icon !min-h-7 !min-w-7 !p-1" title="Close" aria-label="Close panel">
+          <X size={14} />
         </button>
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -1316,8 +1316,8 @@ body {
 
 .glass-panel-solid {
   background: var(--glass-bg-heavy);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--glass-shadow);
@@ -1333,8 +1333,8 @@ body {
 /* Shade panels that drop down from the top pill */
 .shade-panel {
   background: var(--glass-bg-heavy);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
   border: 1px solid var(--color-border);
   border-top: none;
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
@@ -1510,7 +1510,7 @@ body {
 .hover-surface[data-active="true"],
 .hover-lift[data-active="true"],
 .btn-icon[data-active="true"] {
-  background: rgba(88, 166, 255, 0.12);
+  background: var(--color-accent-active);
   color: var(--color-accent);
 }
 
@@ -2071,8 +2071,8 @@ body {
   width: 22px;
   height: 22px;
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-overlay-sm);
+  background: var(--glass-overlay-xs);
   cursor: pointer;
   transition: background 150ms ease, border-color 150ms ease;
   padding: 0;


### PR DESCRIPTION
## Summary
Audited the app for genuine design-system inconsistencies (not assumptions — every finding verified against the actual source). Fixed 5 real issues:

- **`GroupProperties` close/delete buttons were smaller than every other panel's** (`!min-h-6 !min-w-6`, 12px icons) vs. `ElementProperties`/`RelationshipProperties` (`!min-h-7 !min-w-7`, 14px icons), despite rendering in the identical top-right corner of the identical `RightPanel` container. Selecting a group vs. an element made the close button visibly jump 4px.
- **Relationship tooltip mixed two chip styles** — the technology chip used the shared `.c4-type-chip` class, but the tags row 8 lines below used a one-off `text-[9px] rounded px-1 py-0.5` pattern found nowhere else in the codebase, giving the two chip rows different height/radius/weight in the same popover.
- **`.c4-node-action-btn`** hand-typed `rgba(255,255,255,0.08)`/`0.04`, exact duplicates of `--glass-overlay-sm`/`-xs`, instead of referencing the tokens.
- **`.btn-icon[data-active]` / `.hover-*[data-active]`** hardcoded `rgba(88,166,255,0.12)` instead of `var(--color-accent-active)`, while ~9 other call sites use the token correctly for the same active-tint role.
- **`.glass-panel-solid` / `.shade-panel`** hardcoded `blur(20px)` instead of `var(--glass-blur)`, two lines from sibling glass classes (`.glass-panel`, `.glass-flyout`) that reference it correctly.

All are currently invisible-or-barely-visible bugs except the close button sizing, which is directly observable. The token fixes prevent silent desync if those design tokens are ever tuned.

## Test plan
- [x] `npm run check` (lint + typecheck + 1103 unit tests + build) passes
- [x] Visually verified via a headless-browser pass against the sample workspace: `GroupProperties` and `ElementProperties` close buttons now measure identically (28×28px)
- [x] Visually verified the relationship tooltip: technology chip and tag chip now share the same box metrics
- [x] CSS token substitutions are value-identical, confirmed via build output diff

https://claude.ai/code/session_0129j6B6SPj2df17LNkzwxBA