### PR TITLE
Fix overlapping/nested group selection

### DIFF
--- a/e2e/canvas/nested-group-selection.spec.ts
+++ b/e2e/canvas/nested-group-selection.spec.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from '../fixtures/workspace'
+
+/**
+ * Regression (GH #84): when one group is fully nested inside another
+ * (every element of the inner group also belongs to the outer group), the
+ * outer group's background sat at the same z-index as the inner group's, so
+ * ties were broken by array order — whichever group came later always won
+ * every click within the overlap, regardless of size.
+ *
+ * Fix: group nodes now get a z-index offset by nesting depth
+ * (canvasBuilders.ts `groupNestingDepth`), so a group nested inside another
+ * renders — and hit-tests — above its container.
+ */
+
+type TestStore = {
+  addGroup: (name: string, ids: string[]) => string
+  selectedGroupId: string | null
+}
+
+function getStore(page: Page) {
+  return page.evaluate(() => (window as unknown as { __testStore?: () => TestStore }).__testStore?.())
+}
+
+async function getGroupBackgroundPoint(page: Page, groupId: string) {
+  return page.evaluate((id) => {
+    const node = document.querySelector(`[data-id="group-${id}"]`) as HTMLElement | null
+    if (!node) throw new Error(`group node not found: ${id}`)
+    const rect = node.getBoundingClientRect()
+    const candidates = [
+      { x: rect.left + 12, y: rect.top + 40 },
+      { x: rect.right - 12, y: rect.top + 40 },
+      { x: rect.left + rect.width / 2, y: rect.top + 40 },
+      { x: rect.left + 12, y: rect.bottom - 12 },
+    ]
+    for (const point of candidates) {
+      const target = document.elementFromPoint(point.x, point.y) as HTMLElement | null
+      if (target?.closest(`[data-id="group-${id}"]`)) return point
+    }
+    return candidates[0]
+  }, groupId)
+}
+
+test.describe('nested/overlapping group selection', () => {
+  test('clicking the inner group selects it, not the outer container', async ({ workspace }) => {
+    await workspace.loadSample()
+    await workspace.page.evaluate(() =>
+      (window as unknown as { __testSetView?: (k: string) => void }).__testSetView?.('SystemContext'))
+    await workspace.page.waitForTimeout(300)
+
+    const ids = await workspace.page.evaluate(() => {
+      const store = (window as unknown as { __testStore?: () => TestStore }).__testStore?.()
+      if (!store) throw new Error('no store')
+      const innerId = store.addGroup('Inner', ['customer', 'internetBanking'])
+      const outerId = store.addGroup('Outer', ['customer', 'internetBanking', 'supportStaff', 'atm'])
+      return { innerId, outerId }
+    })
+    expect(ids.innerId).toBeTruthy()
+    expect(ids.outerId).toBeTruthy()
+    await workspace.page.waitForTimeout(300)
+
+    const innerNode = workspace.page.locator(`[data-id="group-${ids.innerId}"]`)
+    const outerNode = workspace.page.locator(`[data-id="group-${ids.outerId}"]`)
+    await expect(innerNode).toBeVisible()
+    await expect(outerNode).toBeVisible()
+
+    const innerBox = await innerNode.boundingBox()
+    const outerBox = await outerNode.boundingBox()
+    if (!innerBox || !outerBox) throw new Error('missing bounding boxes')
+    // Sanity check the fixture actually reproduces overlap before asserting the fix.
+    expect(innerBox.x).toBeGreaterThanOrEqual(outerBox.x)
+    expect(innerBox.y).toBeGreaterThanOrEqual(outerBox.y)
+    expect(innerBox.x + innerBox.width).toBeLessThanOrEqual(outerBox.x + outerBox.width)
+    expect(innerBox.y + innerBox.height).toBeLessThanOrEqual(outerBox.y + outerBox.height)
+
+    const point = await getGroupBackgroundPoint(workspace.page, ids.innerId)
+    await workspace.page.mouse.click(point.x, point.y)
+    await workspace.page.waitForTimeout(200)
+
+    const store = await getStore(workspace.page)
+    expect(store?.selectedGroupId).toBe(ids.innerId)
+  })
+})

--- a/src/components/canvas/canvasBuilders.ts
+++ b/src/components/canvas/canvasBuilders.ts
@@ -196,6 +196,13 @@ export function buildNodes(
 type OverlayRect = { x: number; y: number; w: number; h: number }
 type ModelGroup = Workspace['model']['groups'][number]
 
+// Group nodes sit below element nodes (which default to z 0) and above scope
+// boundaries (BOUNDARY_Z). Nesting depth is added on top of GROUP_BASE_Z so a
+// group fully contained by another gets a higher (less negative) z-index than
+// its container, keeping plenty of headroom before either neighbor.
+const GROUP_BASE_Z = -50
+const BOUNDARY_Z = -100
+
 function nodeRect(node: Node): OverlayRect {
   return {
     x: node.position.x,
@@ -212,6 +219,14 @@ function groupIsNestedInside(
   if (child.id === parent.id || child.elementIds.length >= parent.elementIds.length) return false
   const parentIds = new Set(parent.elementIds)
   return child.elementIds.every((id) => parentIds.has(id))
+}
+
+/** Number of other groups that fully contain `group` — used so a group nested
+ *  inside another renders (and hit-tests) above its container instead of the
+ *  reverse. Without this, overlapping groups tied on the same z-index and the
+ *  one later in array order silently won every click within the overlap. */
+function groupNestingDepth(group: ModelGroup, groups: ModelGroup[]): number {
+  return groups.filter((candidate) => groupIsNestedInside(group, candidate)).length
 }
 
 /** Build group background nodes using post-layout element positions. */
@@ -291,7 +306,7 @@ export function buildGroupNodes(
       measured: { width: rect.w, height: rect.h },
       style: { width: rect.w, height: rect.h, backgroundColor: 'transparent', pointerEvents: 'auto' },
       data: { label: group.name, elementCount: group.elementIds.length },
-      zIndex: -1,
+      zIndex: GROUP_BASE_Z + groupNestingDepth(group, groups),
       selectable: true,
       // Drag handler: Canvas's onNodeDragStart/onNodeDrag/onNodeDragStop
       // detect group drags (id starts with `group-`) and translate every
@@ -367,7 +382,7 @@ export function buildBoundaryNodes(
         measured: { width: EMPTY_BOUNDARY_W, height: EMPTY_BOUNDARY_H },
         style: { width: EMPTY_BOUNDARY_W, height: EMPTY_BOUNDARY_H, pointerEvents: 'none' },
         data: { name, typeLabel, empty: true },
-        zIndex: -2,
+        zIndex: BOUNDARY_Z,
         selectable: false,
         draggable: false,
         focusable: false,
@@ -391,7 +406,7 @@ export function buildBoundaryNodes(
         pointerEvents: 'none',
       },
       data: { name, typeLabel },
-      zIndex: -2,
+      zIndex: BOUNDARY_Z,
       selectable: false,
       draggable: false,
       focusable: false,


### PR DESCRIPTION
## Summary

Fixes #84.

- `buildGroupNodes` (`src/components/canvas/canvasBuilders.ts`) gave every group overlay node the same hardcoded `zIndex: -1`. When one group's bounding box fully enclosed another's (e.g. a smaller group grouped again into a bigger one), both nodes tied on z-index, so the browser fell back to array/DOM order for both painting and hit-testing — whichever group happened to sit later in `workspace.model.groups` always won every click in the overlap region, regardless of which one was actually smaller/"inner".
- Fix: reuse the existing `groupIsNestedInside` containment check to compute each group's nesting depth (how many other groups fully contain it), and offset its z-index by that depth (`GROUP_BASE_Z + depth`). A group nested inside another now renders — and hit-tests — above its container. Widened the gap between boundary nodes (`BOUNDARY_Z`) and group nodes to leave headroom for the depth offset without approaching element nodes' default z (0).
- No other behavior changes — non-nested groups keep the same relative stacking against boundaries/elements as before.

## Test plan
- [x] Added `e2e/canvas/nested-group-selection.spec.ts`: creates an inner group and an outer group that fully contains it, clicks a background point inside the inner group's rect, and asserts `selectedGroupId` is the inner group's id.
- [x] Verified the new test fails on the pre-fix code (selects the outer group) and passes with the fix — confirmed it's a real regression check, not a false positive.
- [x] Full existing group e2e suite (`group-add-render`, `group-layout-bug`, `multi-select-bar`) still passes.
- [x] `npm run check` (lint + typecheck + 1103 unit tests + build) passes.

https://claude.ai/code/session_0129j6B6SPj2df17LNkzwxBA