### PR TITLE
fix(ai): center assistant panel on mobile + always allow deep-review re-run

### DIFF
--- a/src/components/ai/ReviewBody.tsx
+++ b/src/components/ai/ReviewBody.tsx
@@ -167,9 +167,14 @@ export function ReviewBody({
           <div style={{ padding: '2px 16px 6px' }}>
             <DeepReviewCard onClick={onRunReview} />
           </div>
-        ) : reviewRan && findings.length === 0 && !allClear ? (
+        ) : reviewRan && !allClear ? (
+          // A deep review has run for this scope. Always offer a re-run — the
+          // model may have changed, or the user may just want a fresh pass —
+          // whether or not it surfaced findings this time.
           <div style={{ padding: '9px 16px 4px', borderTop: '1px solid rgba(88,166,255,0.08)', display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ flex: 1, fontSize: 12, color: C.muted2 }}>No findings in this scope.</span>
+            <span style={{ flex: 1, fontSize: 12, color: C.muted2 }}>
+              {findings.length === 0 ? 'No findings in this scope.' : `Deep review of ${scope === 'view' ? 'this view' : 'the whole model'} complete.`}
+            </span>
             <button onClick={onRunReview} className="c4ai-link" style={{ ...TEXT_LINK, color: C.accent }}>Re-run</button>
           </div>
         ) : null}
@@ -197,10 +202,13 @@ export function ReviewBody({
             <div style={{ marginTop: 3 }}>
               <ScopeToggle scope={scope} onToggle={onToggleScope} />
             </div>
-            {!reviewRan && (
+            {!reviewRan ? (
               <div style={{ width: '100%', marginTop: 14, textAlign: 'left' }}>
                 <DeepReviewCard onClick={onRunReview} />
               </div>
+            ) : (
+              // Already reviewed and clean — still let the user run it again.
+              <button onClick={onRunReview} className="c4ai-link" style={{ ...TEXT_LINK, color: C.accent, marginTop: 2 }}>Re-run deep review</button>
             )}
           </div>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -1209,6 +1209,16 @@ body {
     width: calc(100vw - 28px) !important;
     max-width: 360px !important;
   }
+  /* AI assistant: on desktop it docks against the left tool rail (left: 64).
+     On phones that rail moves to the bottom centre, so the panel has nothing
+     to dock against — centre it horizontally instead and lift its bottom edge
+     clear of the bottom-docked rail. Overrides the inline docked style. */
+  .c4ai {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%) !important;
+    bottom: max(72px, calc(env(safe-area-inset-bottom, 0px) + 72px)) !important;
+  }
   /* Fallback button on the welcome screen for browsers without folder
      access — keep its CTA from running off the edge. */
   .welcome-fallback {


### PR DESCRIPTION
## What & why

Two small AI-assistant fixes.

### 1. Center the assistant panel on small screens
The panel is docked at `left: 64` (tucked against the left tool rail) via inline style, with no responsive override. On phones (`max-width: 760px`) the rail flips to a **bottom-centered row** — but the panel stayed pinned to the left edge, off-center.

Added a `.c4ai` mobile override that centers it horizontally and lifts its bottom clear of the now-bottom rail, mirroring the existing `tool-rail-wrap` centering (`left: 50%` + `translateX(-50%)`).

### 2. Always allow a deep review to be re-run
The "Re-run" link only appeared in one narrow case (a run that produced **zero** findings). The controller (`runReview()`) already fully supports re-running — it clears the scope's prior findings and re-streams — the UI just wasn't offering it.

The re-run affordance now shows in **every** post-run state:
- Findings present → *"Deep review of this view complete. **Re-run**"*
- No findings → *"No findings in this scope. **Re-run**"*
- All caught up → *"Re-run deep review"* link below the scope toggle

Re-run stays per scope+view, matching the existing `review.ran` tracking.

## Testing
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 1755 passed ✅
- `npm run build` ✅

Not driven at a mobile breakpoint for a visual confirm; the centering reuses the same mechanism already proven by the tool-rail flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bdKgEp4Rtfypy2pZZjRiz