### PR TITLE
fix(ai): preserve structural tags on same-plan edits + scope view context to drawn relationships (TEA-60)

### DIFF
--- a/src/lib/ai/context.test.ts
+++ b/src/lib/ai/context.test.ts
@@ -83,6 +83,18 @@ describe('viewLabel / serializeViewContext', () => {
     expect(text).toContain('r2 | Web App -> Database')
   })
 
+  it('omits a relationship whose endpoints are both on screen but which the view does not draw', () => {
+    // web and db are both shown, but the view's relationship list is empty — the
+    // canvas wouldn't draw r2, so the context must not report it as on screen.
+    const v: View = {
+      type: 'container', key: 'c', softwareSystemId: 'shop',
+      elements: [{ id: 'web' }, { id: 'db' }], relationships: [],
+    }
+    const text = serializeViewContext(makeWorkspace(), v)
+    expect(text).not.toContain('r2 | Web App -> Database')
+    expect(text).toMatch(/RELATIONSHIPS ON SCREEN[\s\S]*\(none\)/)
+  })
+
   it('reports an empty view', () => {
     const empty: View = { type: 'systemLandscape', key: 'l', elements: [], relationships: [] }
     expect(serializeViewContext(makeWorkspace(), empty)).toContain('the view is empty')

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -224,8 +224,13 @@ export function serializeViewContext(ws: Workspace, view: View): string {
 
   lines.push('')
   lines.push('RELATIONSHIPS ON SCREEN (id | source -> destination | description):')
+  // A relationship is drawn only when it's in the view's explicit relationship list
+  // AND both endpoints are shown — the canvas renderer intersects the two (see
+  // canvasBuilders). Endpoints-present alone would surface links the view
+  // intentionally omits, grounding the assistant on relationships the user can't see.
+  const viewRelIds = new Set(view.relationships.map((r) => r.id))
   const onScreenRels = ws.model.relationships.filter(
-    (r) => viewElementIds.has(r.sourceId) && viewElementIds.has(r.destinationId),
+    (r) => viewRelIds.has(r.id) && viewElementIds.has(r.sourceId) && viewElementIds.has(r.destinationId),
   )
   if (onScreenRels.length === 0) {
     lines.push('  (none)')

--- a/src/lib/ai/operations.test.ts
+++ b/src/lib/ai/operations.test.ts
@@ -353,6 +353,21 @@ describe('applyEditPlan — tags / status / owner (TEA-45)', () => {
     expect(patch).toHaveProperty('owner', 'Platform')
   })
 
+  it('merges tags onto the structural base when updating an element added in the same plan', () => {
+    // addContainer seeds the store's ['Element','Container']; a follow-up
+    // updateElement targeting that new ref by tags must MERGE onto it, not
+    // replace it with an empty base (which would drop the structural tags).
+    const ws = makeWorkspace()
+    const actions = fakeActions()
+    applyEditPlan({ operations: [
+      { op: 'addContainer', ref: 'q', parent: 'shop', name: 'Queue' },
+      { op: 'updateElement', id: 'q', tags: ['MessageBus'] },
+    ] }, actions, ws)
+    // ref 'q' resolved to 'gen1'; tags patch keeps Element/Container.
+    const call = vi.mocked(actions.updateElement).mock.calls.find(([id]) => id === 'gen1')!
+    expect(call[1].tags).toEqual(['Element', 'Container', 'MessageBus'])
+  })
+
   it('does not emit a tags key when every proposed tag already exists (no-op, no phantom undo)', () => {
     const ws = makeWorkspace()
     ws.model.softwareSystems[0].containers[1].tags = ['Element', 'Container', 'Database']

--- a/src/lib/ai/operations.test.ts
+++ b/src/lib/ai/operations.test.ts
@@ -368,6 +368,20 @@ describe('applyEditPlan — tags / status / owner (TEA-45)', () => {
     expect(call[1].tags).toEqual(['Element', 'Container', 'MessageBus'])
   })
 
+  it('accumulates tags across two same-plan updates to a newly-added element', () => {
+    // A second tags op on the same new element merges onto the first update's
+    // result, not the pristine structural base.
+    const ws = makeWorkspace()
+    const actions = fakeActions()
+    applyEditPlan({ operations: [
+      { op: 'addContainer', ref: 'q', parent: 'shop', name: 'Queue' },
+      { op: 'updateElement', id: 'q', tags: ['MessageBus'] },
+      { op: 'updateElement', id: 'q', tags: ['Critical'] },
+    ] }, actions, ws)
+    const calls = vi.mocked(actions.updateElement).mock.calls.filter(([id]) => id === 'gen1')
+    expect(calls[calls.length - 1][1].tags).toEqual(['Element', 'Container', 'MessageBus', 'Critical'])
+  })
+
   it('does not emit a tags key when every proposed tag already exists (no-op, no phantom undo)', () => {
     const ws = makeWorkspace()
     ws.model.softwareSystems[0].containers[1].tags = ['Element', 'Container', 'Database']

--- a/src/lib/ai/operations.ts
+++ b/src/lib/ai/operations.ts
@@ -269,6 +269,9 @@ export function applyEditPlan(
           // from the model must not reach the store.
           location: op.location === 'External' || op.location === 'Internal' ? op.location : undefined,
         })
+        // Keep the merged tags as the new base, so a second same-plan tags op on
+        // this element merges onto them rather than the pre-update set.
+        if (tags) tagsById.set(id, tags)
         ok(op)
         break
       }

--- a/src/lib/ai/operations.ts
+++ b/src/lib/ai/operations.ts
@@ -118,8 +118,10 @@ export function applyEditPlan(
   const relIds = new Set(ws.model.relationships.map((r) => r.id))
   // Current tags per element, so an updateElement.tags op can MERGE (add) rather
   // than replace — see mergeTags. Built from the raw model (flattenElements drops
-  // tags). Newly-created elements aren't included: updateElement addresses real
-  // ids only, so a same-batch add never needs merging here.
+  // tags). Newly-created elements ARE seeded too (see register): the edit prompt
+  // lets an updateElement target a same-plan ref, so a tags op on a just-added
+  // element must merge onto its structural base (Element/Container …) instead of
+  // replacing it via an empty base and wiping the store's built-in tags.
   const tagsById = new Map<string, string[]>()
   for (const p of ws.model.people) tagsById.set(p.id, p.tags)
   for (const sys of ws.model.softwareSystems) {
@@ -137,9 +139,13 @@ export function applyEditPlan(
   const applied: AppliedOp[] = []
 
   // Register a newly-created element so later ops can target it by ref, id, or name.
-  const register = (ref: string, id: string, name: string) => {
+  // `tags` are the structural defaults the store assigned at creation (Element/
+  // Container …); seeding them lets a same-plan updateElement.tags op merge rather
+  // than clobber them (see tagsById / mergeTags).
+  const register = (ref: string, id: string, name: string, tags: string[]) => {
     refMap.set(ref, id)
     validIds.add(id)
+    tagsById.set(id, tags)
     const key = name.trim().toLowerCase()
     // Don't let a newly-created element hijack name resolution for an existing
     // element of the same name — keep the first (existing) mapping so a later
@@ -182,7 +188,7 @@ export function applyEditPlan(
       case 'addPerson': {
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addPerson(op.name.trim())
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Person'])
         const desc = optStr(op.description)
         if (desc) actions.updateElement(id, { description: desc })
         ok(op)
@@ -191,7 +197,7 @@ export function applyEditPlan(
       case 'addSoftwareSystem': {
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addSoftwareSystem(op.name.trim(), op.external)
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Software System'])
         systemIds.add(id)
         if (op.external) externalSystemIds.add(id)
         const desc = optStr(op.description)
@@ -206,7 +212,7 @@ export function applyEditPlan(
         if (externalSystemIds.has(parentId)) { skip(op, 'parent is an external system'); break }
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addContainer(parentId, op.name.trim())
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Container'])
         containerIds.add(id)
         const desc = optStr(op.description), tech = optStr(op.technology)
         if (desc || tech) actions.updateElement(id, { description: desc, technology: tech })
@@ -219,7 +225,7 @@ export function applyEditPlan(
         if (!containerIds.has(parentId)) { skip(op, 'parent is not a container'); break }
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addComponent(parentId, op.name.trim())
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Component'])
         const desc = optStr(op.description), tech = optStr(op.technology)
         if (desc || tech) actions.updateElement(id, { description: desc, technology: tech })
         ok(op)


### PR DESCRIPTION
Two P2 correctness fixes surfaced by a codex review of the AI-ops batch (#91).

## 1. Structural tags clobbered on same-plan `updateElement`
When an AI edit plan adds an element (`addContainer`/`addComponent`) and then targets that new element by its same-plan `ref` in an `updateElement` carrying `tags`, `tagsById` had no entry for the freshly-created id — it was built only from the pre-plan model walk. `mergeTags` therefore merged onto an **empty base**, and `applyElementPatch` replaces `el.tags` wholesale, wiping the store's built-in structural tags (`Element`/`Container` …) that drive styling and classification.

Fix: seed `tagsById` with the store's structural defaults at creation time (via `register`), so a same-plan tags op merges onto the correct base. Also corrects the stale comment claiming `updateElement` only addresses real ids (it resolves same-plan refs via `resolveExact`).

## 2. View AI context listed relationships that aren't drawn
`serializeViewContext` reported a relationship as `ON SCREEN` whenever both endpoints were in the view, but the canvas renderer draws only the **intersection** of `view.relationships` (the explicit list) and both-endpoints-present. So a relationship the view intentionally omits was fed to the review/interview prompt as visible — grounding the assistant on links the user can't see.

Fix: intersect with the view's relationship-id set, matching the renderer (and consistent with how elements already use `view.elements`).

## Not changed
Codex's third finding (deep-review re-run reachability) was already fixed by #92 — the current code always surfaces a Re-run affordance post-run. No change needed.

## Testing
- Added regression tests to `operations.test.ts` (tags merge onto structural base for a same-plan-created element) and `context.test.ts` (a relationship omitted from `view.relationships` is not reported on screen).
- `npm run check` passes (lint + typecheck + tests + build); the two affected suites: 60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZqnqmKBihPZERDBTJPM3L