### PR TITLE
fix(ai): address review context follow-ups

### DIFF
--- a/src/lib/ai/context.test.ts
+++ b/src/lib/ai/context.test.ts
@@ -83,6 +83,19 @@ describe('viewLabel / serializeViewContext', () => {
     expect(text).toContain('r2 | Web App -> Database')
   })
 
+  it('does not include model relationships that are not rendered in the view', () => {
+    const hiddenRelationshipView: View = {
+      ...view,
+      relationships: [],
+    }
+    const text = serializeViewContext(makeWorkspace(), hiddenRelationshipView)
+    expect(text).toContain('web | container | Web App')
+    expect(text).toContain('db | container | Database')
+    expect(text).not.toContain('r2 | Web App -> Database')
+    expect(text).toContain('RELATIONSHIPS ON SCREEN')
+    expect(text).toContain('(none)')
+  })
+
   it('reports an empty view', () => {
     const empty: View = { type: 'systemLandscape', key: 'l', elements: [], relationships: [] }
     expect(serializeViewContext(makeWorkspace(), empty)).toContain('the view is empty')

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -224,9 +224,10 @@ export function serializeViewContext(ws: Workspace, view: View): string {
 
   lines.push('')
   lines.push('RELATIONSHIPS ON SCREEN (id | source -> destination | description):')
-  const onScreenRels = ws.model.relationships.filter(
-    (r) => viewElementIds.has(r.sourceId) && viewElementIds.has(r.destinationId),
-  )
+  const relationshipsById = new Map(ws.model.relationships.map((r) => [r.id, r]))
+  const onScreenRels = view.relationships
+    .map((r) => relationshipsById.get(r.id))
+    .filter((r): r is Relationship => Boolean(r))
   if (onScreenRels.length === 0) {
     lines.push('  (none)')
   } else {

--- a/src/lib/ai/operations.test.ts
+++ b/src/lib/ai/operations.test.ts
@@ -107,6 +107,17 @@ describe('applyEditPlan', () => {
     expect(actions.updateElement).toHaveBeenCalledWith('gen1', { description: 'Handles payments' })
   })
 
+  it('merges tags onto structural tags for an element created earlier in the same plan', () => {
+    const ws = makeWorkspace()
+    const actions = fakeActions()
+    applyEditPlan({ operations: [
+      { op: 'addContainer', ref: 'new1', parent: 'shop', name: 'Payments' },
+      { op: 'updateElement', id: 'new1', tags: ['Critical'] },
+    ] }, actions, ws)
+
+    expect(actions.updateElement).toHaveBeenCalledWith('gen1', expect.objectContaining({ tags: ['Element', 'Container', 'Critical'] }))
+  })
+
   it('skips self-relationships', () => {
     const ws = makeWorkspace()
     const actions = fakeActions()

--- a/src/lib/ai/operations.ts
+++ b/src/lib/ai/operations.ts
@@ -118,8 +118,7 @@ export function applyEditPlan(
   const relIds = new Set(ws.model.relationships.map((r) => r.id))
   // Current tags per element, so an updateElement.tags op can MERGE (add) rather
   // than replace — see mergeTags. Built from the raw model (flattenElements drops
-  // tags). Newly-created elements aren't included: updateElement addresses real
-  // ids only, so a same-batch add never needs merging here.
+  // tags), then extended as this same batch creates or retags elements.
   const tagsById = new Map<string, string[]>()
   for (const p of ws.model.people) tagsById.set(p.id, p.tags)
   for (const sys of ws.model.softwareSystems) {
@@ -137,9 +136,10 @@ export function applyEditPlan(
   const applied: AppliedOp[] = []
 
   // Register a newly-created element so later ops can target it by ref, id, or name.
-  const register = (ref: string, id: string, name: string) => {
+  const register = (ref: string, id: string, name: string, structuralTags: string[]) => {
     refMap.set(ref, id)
     validIds.add(id)
+    tagsById.set(id, structuralTags)
     const key = name.trim().toLowerCase()
     // Don't let a newly-created element hijack name resolution for an existing
     // element of the same name — keep the first (existing) mapping so a later
@@ -182,7 +182,7 @@ export function applyEditPlan(
       case 'addPerson': {
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addPerson(op.name.trim())
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Person'])
         const desc = optStr(op.description)
         if (desc) actions.updateElement(id, { description: desc })
         ok(op)
@@ -191,7 +191,7 @@ export function applyEditPlan(
       case 'addSoftwareSystem': {
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addSoftwareSystem(op.name.trim(), op.external)
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Software System'])
         systemIds.add(id)
         if (op.external) externalSystemIds.add(id)
         const desc = optStr(op.description)
@@ -206,7 +206,7 @@ export function applyEditPlan(
         if (externalSystemIds.has(parentId)) { skip(op, 'parent is an external system'); break }
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addContainer(parentId, op.name.trim())
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Container'])
         containerIds.add(id)
         const desc = optStr(op.description), tech = optStr(op.technology)
         if (desc || tech) actions.updateElement(id, { description: desc, technology: tech })
@@ -219,7 +219,7 @@ export function applyEditPlan(
         if (!containerIds.has(parentId)) { skip(op, 'parent is not a container'); break }
         if (!op.name?.trim()) { skip(op, 'missing name'); break }
         const id = actions.addComponent(parentId, op.name.trim())
-        register(op.ref, id, op.name)
+        register(op.ref, id, op.name, ['Element', 'Component'])
         const desc = optStr(op.description), tech = optStr(op.technology)
         if (desc || tech) actions.updateElement(id, { description: desc, technology: tech })
         ok(op)
@@ -263,6 +263,7 @@ export function applyEditPlan(
           // from the model must not reach the store.
           location: op.location === 'External' || op.location === 'Internal' ? op.location : undefined,
         })
+        if (tags) tagsById.set(id, tags)
         ok(op)
         break
       }


### PR DESCRIPTION
Fixes the remaining review follow-ups after #92: preserves structural tags when same-plan AI updates target newly created elements, and scopes view AI context to relationships explicitly rendered in the view.\n\nTests: npm test -- src/lib/ai