### PR TITLE
chore(security): resolve 2026-07-25 advisory batch + allowlist unfixable dev-only DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4565,18 +4565,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -7378,9 +7371,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7398,7 +7391,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7407,7 +7400,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.11",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7513,20 +7508,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -7893,12 +7887,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "audit": "npm audit --audit-level=moderate",
+    "audit": "node scripts/audit-allowlist.mjs",
     "check": "npm run lint && npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
@@ -80,8 +80,9 @@
   },
   "overrides": {
     "@rollup/plugin-terser": "^1.0.0",
-    "postcss": "^8.5.12",
+    "postcss": "^8.5.18",
     "serialize-javascript": "^7.0.5",
-    "undici": "^7.28.0"
+    "undici": "^7.28.0",
+    "react-router": "8.3.0"
   }
 }

--- a/scripts/audit-allowlist.mjs
+++ b/scripts/audit-allowlist.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Security audit gate with a documented allowlist.
+//
+// Replaces a bare `npm audit --audit-level=moderate` so we can suppress
+// specific advisories that (a) have no available fix and (b) do not apply to
+// how this app actually runs — while still failing CI on every other
+// moderate-or-higher advisory. Each entry MUST carry a reason and a review
+// date so allowlisting can never become a silent, permanent bypass.
+//
+// To review: run `npm audit` for the full report. To un-allowlist, delete the
+// entry and let CI tell you what breaks.
+
+import { execSync } from 'node:child_process'
+
+const AUDIT_LEVEL = 'moderate' // fail on moderate | high | critical
+const SEVERITY_RANK = { info: 0, low: 1, moderate: 2, high: 3, critical: 4 }
+const THRESHOLD = SEVERITY_RANK[AUDIT_LEVEL]
+
+/**
+ * GHSA ids we knowingly accept, each with a justification and a re-review date.
+ * Keep this list SHORT and revisit on each date — an available fix or a
+ * changed usage assumption means the entry should go.
+ */
+const ALLOWLIST = {
+  'GHSA-mh99-v99m-4gvg': {
+    package: 'brace-expansion',
+    reason:
+      'DoS via unbounded brace expansion. Only a dev/build-time transitive ' +
+      '(minimatch <- glob/eslint/rollup); never bundled or shipped to users. ' +
+      'The sole patched release (5.0.8) is ESM-only and breaks the CJS ' +
+      'consumers that pull the vulnerable 1.x/2.x lines ("expand is not a ' +
+      'function"); no backport exists. Re-check when a CJS-compatible patch ships.',
+    review: '2026-10-01',
+  },
+}
+
+function runAudit() {
+  try {
+    const out = execSync('npm audit --json', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+    return JSON.parse(out)
+  } catch (err) {
+    // `npm audit` exits non-zero when vulnerabilities exist; the JSON is still
+    // on stdout. Only a genuinely unparseable payload is a hard error.
+    if (err.stdout) {
+      try { return JSON.parse(err.stdout) } catch { /* fall through */ }
+    }
+    console.error('audit-allowlist: could not run/parse `npm audit --json`')
+    console.error(err.message)
+    process.exit(2)
+  }
+}
+
+const report = runAudit()
+const vulns = report.vulnerabilities ?? {}
+
+// Collect every distinct advisory (GHSA) at or above the threshold.
+const seen = new Map() // ghsa -> { title, severity, package }
+for (const v of Object.values(vulns)) {
+  for (const via of v.via) {
+    if (typeof via !== 'object' || !via.url) continue
+    const ghsa = via.url.split('/').pop()
+    if ((SEVERITY_RANK[via.severity] ?? 0) < THRESHOLD) continue
+    if (!seen.has(ghsa)) seen.set(ghsa, { title: via.title, severity: via.severity, package: via.name })
+  }
+}
+
+const allowed = []
+const blocking = []
+for (const [ghsa, info] of seen) {
+  if (ALLOWLIST[ghsa]) allowed.push([ghsa, info])
+  else blocking.push([ghsa, info])
+}
+
+if (allowed.length > 0) {
+  console.log(`audit-allowlist: ${allowed.length} advisory(ies) suppressed by allowlist:`)
+  for (const [ghsa, info] of allowed) {
+    console.log(`  - ${ghsa} (${info.severity}) ${info.package} — review by ${ALLOWLIST[ghsa].review}`)
+  }
+}
+
+if (blocking.length > 0) {
+  console.error(`\naudit-allowlist: ${blocking.length} advisory(ies) at or above "${AUDIT_LEVEL}" not allowlisted:`)
+  for (const [ghsa, info] of blocking) {
+    console.error(`  - ${ghsa} (${info.severity}) ${info.package}: ${info.title}`)
+  }
+  console.error('\nRun `npm audit` for the full report. Fix them, or add a justified allowlist entry.')
+  process.exit(1)
+}
+
+console.log(`audit-allowlist: no un-allowlisted advisories at or above "${AUDIT_LEVEL}".`)


### PR DESCRIPTION
The required `security` check went red repo-wide when three new advisories were published — this affects `main` and every open PR (#105 included), not any one branch's changes. This clears it.

## What changed

**Fixed via the existing `overrides` block:**

| package | to | advisory | note |
| --- | --- | --- | --- |
| postcss | 8.5.23 | GHSA-r28c-9q8g-f849 | path traversal in source-map auto-loading |
| react-router | 8.3.0 | GHSA-qwww-vcr4-c8h2 | RSC-mode CSRF bypass |

react-router 8.3.0 sits above the vulnerable `7.12.0 - 8.2.0` range. The `react-router-dom@7.18.1` shim re-exports it and the full suite passes (1758 tests). The advisory targets **RSC mode**, which this client-only SPA does not use — it's `BrowserRouter` + declarative `<Routes>`, no server/framework mode — so it wasn't exploitable here regardless.

**Allowlisted (no available fix):**

- `brace-expansion` — **GHSA-mh99-v99m-4gvg**, DoS via unbounded brace expansion. This is a **dev/build-time transitive only** (`minimatch` <- glob/eslint/rollup); it is never bundled or shipped to users. The only patched release, 5.0.8, is ESM-only and breaks the CJS consumers that pull the vulnerable 1.x/2.x lines (`TypeError: expand is not a function`), and no backport exists. Forcing it fails the build. Suppressed with a documented reason and a **2026-10-01 review date**.

## New audit gate

`npm run audit` now runs `scripts/audit-allowlist.mjs` instead of a bare `npm audit --audit-level=moderate`. It fails CI on every moderate-or-higher advisory **except** those in a short, justified, dated allowlist. Each entry carries a package, a reason, and a review date, so the suppression can't quietly become permanent.

Verified the gate is not a blanket bypass: with the allowlist emptied, it re-fails on brace-expansion (exit 1). With the one documented entry, it exits 0.

## Verification

- `npm run audit` -> exit 0 (1 advisory suppressed, documented; 0 un-allowlisted)
- `npm run check` -> green: 107 test files, 1758 tests, lint + typecheck + build clean
- react-router 8.3.0 + postcss 8.5.23 introduce no test or build regressions

## After this merges

I'll rebase **#105** (TEA-81) — it's already green on build/test/e2e/lint and only blocked by this `security` check, so it goes fully green on rebase.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01EPdf6YcoL2uwSVY5Z9UJPi