### PR TITLE
fix(dsl): emit Structurizr-conformant DSL; add real-parser CI gate (TEA-163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,38 @@ jobs:
           path: coverage/
           retention-days: 7
 
+  # Validates serializer output against the real Structurizr parser. Every
+  # other DSL test checks c4hero against itself, which is why GH #109 (invalid
+  # emitted DSL) passed CI for months.
+  dsl-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - run: npm ci
+      # Pinned deliberately: the encoding rules the serializer targets were
+      # verified against this release (structurizr-java 5.0.2). A parser change
+      # should be an explicit bump, not a silent break on a Monday morning.
+      - name: Install Structurizr CLI
+        run: |
+          STRUCTURIZR_VERSION=2025.11.09
+          curl -sSL -o /tmp/structurizr-cli.zip \
+            "https://github.com/structurizr/cli/releases/download/v${STRUCTURIZR_VERSION}/structurizr-cli.zip"
+          unzip -q /tmp/structurizr-cli.zip -d .structurizr-cli
+          chmod +x .structurizr-cli/structurizr.sh
+          ./.structurizr-cli/structurizr.sh version
+      - name: Verify emitted DSL against the real Structurizr parser
+        env:
+          STRUCTURIZR_CONFORMANCE: '1'
+        run: npm run test:conformance
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
   # emitted DSL) passed CI for months.
   dsl-conformance:
     runs-on: ubuntu-latest
+    env:
+      # Pinned deliberately: the encoding rules the serializer targets were
+      # verified against this release (structurizr-java 5.0.2). A parser change
+      # should be an explicit bump, not a silent break on a Monday morning.
+      # Single source of truth for both the cache key and the download URL.
+      STRUCTURIZR_VERSION: 2025.11.09
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -74,20 +80,16 @@ jobs:
           distribution: temurin
           java-version: 21
       - run: npm ci
-      # Pinned deliberately: the encoding rules the serializer targets were
-      # verified against this release (structurizr-java 5.0.2). A parser change
-      # should be an explicit bump, not a silent break on a Monday morning.
       # Cached by version so a GitHub-releases hiccup can't fail the build.
       - name: Cache Structurizr CLI
         id: structurizr-cache
         uses: actions/cache@v5
         with:
           path: .structurizr-cli
-          key: structurizr-cli-2025.11.09
+          key: structurizr-cli-${{ env.STRUCTURIZR_VERSION }}
       - name: Install Structurizr CLI
         if: steps.structurizr-cache.outputs.cache-hit != 'true'
         run: |
-          STRUCTURIZR_VERSION=2025.11.09
           curl -sSL -o /tmp/structurizr-cli.zip \
             "https://github.com/structurizr/cli/releases/download/v${STRUCTURIZR_VERSION}/structurizr-cli.zip"
           unzip -q /tmp/structurizr-cli.zip -d .structurizr-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,23 @@ jobs:
       # Pinned deliberately: the encoding rules the serializer targets were
       # verified against this release (structurizr-java 5.0.2). A parser change
       # should be an explicit bump, not a silent break on a Monday morning.
+      # Cached by version so a GitHub-releases hiccup can't fail the build.
+      - name: Cache Structurizr CLI
+        id: structurizr-cache
+        uses: actions/cache@v5
+        with:
+          path: .structurizr-cli
+          key: structurizr-cli-2025.11.09
       - name: Install Structurizr CLI
+        if: steps.structurizr-cache.outputs.cache-hit != 'true'
         run: |
           STRUCTURIZR_VERSION=2025.11.09
           curl -sSL -o /tmp/structurizr-cli.zip \
             "https://github.com/structurizr/cli/releases/download/v${STRUCTURIZR_VERSION}/structurizr-cli.zip"
           unzip -q /tmp/structurizr-cli.zip -d .structurizr-cli
           chmod +x .structurizr-cli/structurizr.sh
-          ./.structurizr-cli/structurizr.sh version
+      - name: Report Structurizr CLI version
+        run: ./.structurizr-cli/structurizr.sh version
       - name: Verify emitted DSL against the real Structurizr parser
         env:
           STRUCTURIZR_CONFORMANCE: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Install Structurizr CLI
         if: steps.structurizr-cache.outputs.cache-hit != 'true'
         run: |
-          curl -sSL -o /tmp/structurizr-cli.zip \
+          # -f: fail on an HTTP error instead of saving the error page as the
+          # zip and dying later at unzip with a cryptic signature error.
+          curl -fsSL -o /tmp/structurizr-cli.zip \
             "https://github.com/structurizr/cli/releases/download/v${STRUCTURIZR_VERSION}/structurizr-cli.zip"
           unzip -q /tmp/structurizr-cli.zip -d .structurizr-cli
           chmod +x .structurizr-cli/structurizr.sh

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ scorecard-fixes.md
 *.sln
 *.sw?
 coverage/
+
+# Structurizr CLI used by the DSL conformance tests (see structurizr-conformance.test.ts)
+.structurizr-cli/

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:conformance": "vitest run src/lib/dsl/structurizr-conformance.test.ts",
     "audit": "node scripts/audit-allowlist.mjs",
     "check": "npm run lint && npm run typecheck && npm test && npm run build"
   },

--- a/src/components/canvas/buildGroupNodes.test.ts
+++ b/src/components/canvas/buildGroupNodes.test.ts
@@ -50,4 +50,22 @@ describe('buildGroupNodes', () => {
     expect(outer).toBeTruthy()
     expect(inner!.position.y - outer!.position.y).toBeGreaterThanOrEqual(52)
   })
+
+  it('renders explicit nesting when parent and child have equal members', () => {
+    const workspace = ws()
+    workspace.model.groups = [
+      { id: 'outer', name: 'Outer', elementIds: ['a', 'b'] },
+      { id: 'inner', name: 'Inner', elementIds: ['a', 'b'], parentId: 'outer' },
+    ]
+    const result = buildGroupNodes(workspace, workspace.model.groups, [
+      el('a', 100, 100),
+      el('b', 350, 100),
+    ])
+
+    const inner = result.find((node) => node.id === 'group-inner')
+    const outer = result.find((node) => node.id === 'group-outer')
+    expect(inner).toBeTruthy()
+    expect(outer).toBeTruthy()
+    expect(inner!.position.y - outer!.position.y).toBeGreaterThanOrEqual(52)
+  })
 })

--- a/src/components/canvas/canvasBuilders.ts
+++ b/src/components/canvas/canvasBuilders.ts
@@ -216,7 +216,13 @@ function groupIsNestedInside(
   child: ModelGroup,
   parent: ModelGroup,
 ): boolean {
-  if (child.id === parent.id || child.elementIds.length >= parent.elementIds.length) return false
+  if (child.id === parent.id) return false
+  // Parsed Structurizr DSL can contain a parent whose only contents are one
+  // nested group, so both aggregate member sets are equal. Retain that
+  // explicit hierarchy; strict subset inference remains the back-compat path
+  // for older c4hero workspaces without parentId.
+  if (child.parentId === parent.id) return true
+  if (child.elementIds.length >= parent.elementIds.length) return false
   const parentIds = new Set(parent.elementIds)
   return child.elementIds.every((id) => parentIds.has(id))
 }

--- a/src/components/layout/FloatingTopPill.tsx
+++ b/src/components/layout/FloatingTopPill.tsx
@@ -148,36 +148,50 @@ export default function FloatingTopPill() {
 
   async function handleExport(format: 'dsl' | 'png' | 'svg', theme: ExportTheme = 'dark') {
     if (!workspace) return
-    switch (format) {
-      case 'dsl':
-        await saveDSLFile(serializeDSL(workspace), `${wsName}.dsl`)
-        break
-      case 'png': {
-        const blob = await exportCanvasAsPNG(theme)
-        if (blob) downloadBlob(blob, `${wsName}-${theme}.png`)
-        break
+    try {
+      switch (format) {
+        case 'dsl':
+          await saveDSLFile(serializeDSL(workspace), `${wsName}.dsl`)
+          break
+        case 'png': {
+          const blob = await exportCanvasAsPNG(theme)
+          if (blob) downloadBlob(blob, `${wsName}-${theme}.png`)
+          break
+        }
+        case 'svg': {
+          const svg = exportCanvasAsSVG(theme)
+          if (svg) downloadFile(svg, `${wsName}-${theme}.svg`, 'image/svg+xml')
+          break
+        }
       }
-      case 'svg': {
-        const svg = exportCanvasAsSVG(theme)
-        if (svg) downloadFile(svg, `${wsName}-${theme}.svg`, 'image/svg+xml')
-        break
-      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Export failed'
+      setCopyToast(message)
+      announce(message)
+      setTimeout(() => setCopyToast(null), 4000)
     }
   }
 
   async function handleCopy(type: 'png-dark' | 'png-light' | 'png-current' | 'dsl') {
     if (!workspace) return
-    let ok = false
-    if (type === 'png-dark') ok = await copyCanvasAsPNG('dark')
-    else if (type === 'png-light') ok = await copyCanvasAsPNG('light')
-    else if (type === 'png-current') ok = await copyCanvasAsPNG('current')
-    else if (type === 'dsl') ok = await copyTextToClipboard(serializeDSL(workspace))
-    const themeLabel = type === 'png-dark' ? 'dark' : type === 'png-light' ? 'light' : 'current'
-    const label = type === 'dsl' ? 'DSL' : `PNG (${themeLabel})`
-    const msg = ok ? `Copied ${label}` : 'Copy failed'
-    setCopyToast(msg)
-    announce(msg)
-    setTimeout(() => setCopyToast(null), 2000)
+    try {
+      let ok = false
+      if (type === 'png-dark') ok = await copyCanvasAsPNG('dark')
+      else if (type === 'png-light') ok = await copyCanvasAsPNG('light')
+      else if (type === 'png-current') ok = await copyCanvasAsPNG('current')
+      else if (type === 'dsl') ok = await copyTextToClipboard(serializeDSL(workspace))
+      const themeLabel = type === 'png-dark' ? 'dark' : type === 'png-light' ? 'light' : 'current'
+      const label = type === 'dsl' ? 'DSL' : `PNG (${themeLabel})`
+      const msg = ok ? `Copied ${label}` : 'Copy failed'
+      setCopyToast(msg)
+      announce(msg)
+      setTimeout(() => setCopyToast(null), 2000)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Copy failed'
+      setCopyToast(message)
+      announce(message)
+      setTimeout(() => setCopyToast(null), 4000)
+    }
   }
 
   return (

--- a/src/components/layout/SaveIndicator.tsx
+++ b/src/components/layout/SaveIndicator.tsx
@@ -36,10 +36,11 @@ export default function SaveIndicator() {
     const workspace = useWorkspaceStore.getState().workspace
     if (!workspace) return
     setSaveStatus('saving')
-    const wsName = workspace.name ?? 'workspace'
-    const dsl = serializeDSL(workspace)
-    const ok = await saveDSLFile(dsl, `${wsName}.dsl`)
-    if (ok) {
+    try {
+      const wsName = workspace.name ?? 'workspace'
+      const dsl = serializeDSL(workspace)
+      const ok = await saveDSLFile(dsl, `${wsName}.dsl`)
+      if (!ok) throw new Error('Save failed')
       const n = useWorkspaceStore.getState().undoStack.length
       setSavedUndoLength(n)
       useWorkspaceStore.getState().setLastSavedUndoLength(n)
@@ -47,9 +48,9 @@ export default function SaveIndicator() {
       announce('File saved')
       if (savedFlashTimer.current) clearTimeout(savedFlashTimer.current)
       savedFlashTimer.current = setTimeout(() => setSaveStatus('idle'), 2000)
-    } else {
+    } catch (error) {
       setSaveStatus('error')
-      announce('Save failed')
+      announce(error instanceof Error ? error.message : 'Save failed')
       if (savedFlashTimer.current) clearTimeout(savedFlashTimer.current)
       savedFlashTimer.current = setTimeout(() => setSaveStatus('idle'), 3000)
     }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -4,6 +4,9 @@ import { saveToLocalStorage, getCurrentFileHandle, writeToCurrentHandle, writeSi
 import { getCurrentDirHandle, writeDSLFile, writeSidecarFile } from '@/lib/folderIO'
 import { serializeDSL } from '@/lib/dsl'
 import { extractSidecar, serializeSidecar } from '@/lib/sidecar'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('useAutoSave')
 
 const scheduleIdle = typeof requestIdleCallback === 'function'
   ? requestIdleCallback
@@ -51,20 +54,27 @@ export function useAutoSave() {
         const filename = state.activeWorkspaceFilename
 
         if (hasSingleFile || (dirHandle && filename)) {
-          const dsl = serializeDSL(state.workspace)
-          const sidecar = extractSidecar(state.workspace)
+          try {
+            const dsl = serializeDSL(state.workspace)
+            const sidecar = extractSidecar(state.workspace)
 
-          if (hasSingleFile) {
-            writeToCurrentHandle(dsl)
-            if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))
+            if (hasSingleFile) {
+              writeToCurrentHandle(dsl)
+              if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))
+            }
+
+            if (dirHandle && filename) {
+              writeDSLFile(filename, dsl)
+              if (sidecar) writeSidecarFile(filename, serializeSidecar(sidecar))
+            }
+
+            useWorkspaceStore.getState().setLastSavedUndoLength(state.undoStack.length)
+          } catch (error) {
+            // Manual save/export surfaces the same actionable message. Avoid
+            // turning an invalid legacy overlap into an unhandled idle-task
+            // exception while still leaving the workspace marked unsaved.
+            log.warn('Automatic DSL save blocked', error)
           }
-
-          if (dirHandle && filename) {
-            writeDSLFile(filename, dsl)
-            if (sidecar) writeSidecarFile(filename, serializeSidecar(sidecar))
-          }
-
-          useWorkspaceStore.getState().setLastSavedUndoLength(state.undoStack.length)
         }
       }) as unknown as number
     }, 1000)

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -10,6 +10,7 @@ import { createLogger } from '@/lib/logger'
 import { fitContentNodesToViewport } from '@/lib/fitViewport'
 import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
 import { isCanvasRoute } from '@/lib/routes'
+import { announce } from '@/lib/announce'
 
 const log = createLogger('keyboard')
 
@@ -80,10 +81,14 @@ const GLOBAL_SHORTCUTS: Record<string, KeyHandler> = {
   },
   'mod+s': (store) => {
     if (store.workspace) {
-      const dsl = serializeDSL(store.workspace)
-      saveDSLFile(dsl, `${store.workspace.name ?? 'workspace'}.dsl`)
-      const sidecar = extractSidecar(store.workspace)
-      if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))
+      try {
+        const dsl = serializeDSL(store.workspace)
+        saveDSLFile(dsl, `${store.workspace.name ?? 'workspace'}.dsl`)
+        const sidecar = extractSidecar(store.workspace)
+        if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))
+      } catch (error) {
+        announce(error instanceof Error ? error.message : 'Save failed')
+      }
     }
   },
   'mod+o': (store) => {

--- a/src/lib/ai/dsl.test.ts
+++ b/src/lib/ai/dsl.test.ts
@@ -64,6 +64,25 @@ describe('extractDsl', () => {
     expect(extractDsl(dsl + '\ntrailing prose')).toBe(dsl)
   })
 
+  it('anchor regex agrees with the lexer about a workspace name ending in backslashes', () => {
+    // `workspace "net\\" {` — per the consume-one rule the string swallows
+    // the quote and the brace, so there is no well-formed declaration to
+    // anchor on. extractDsl must fall back to returning everything (letting
+    // the parser report the real error), not pretend it found a block.
+    const text = 'workspace "net\\\\" {\n  model {\n    a = person "A"\n  }\n}\ntrailing prose'
+    expect(extractDsl(text)).toBe(text)
+  })
+
+  it('ignores a brace inside a mid-line # comment, like the lexer does', () => {
+    const dsl = 'workspace {\n  model {\n    a = person "A" # persona {details}\n  }\n}'
+    expect(extractDsl(dsl + '\nafter')).toBe(dsl)
+  })
+
+  it('does not treat a hex color as a # comment', () => {
+    const dsl = 'workspace {\n  views {\n    styles {\n      element "X" {\n        background #ffffff\n      }\n    }\n  }\n}'
+    expect(extractDsl(dsl + '\nmore')).toBe(dsl)
+  })
+
   it('agrees with the lexer that a trailing backslash swallows the closing quote', () => {
     // `"path C:\\"` is the GH #109 case: the tokenizer reads the first
     // backslash as literal and `\"` as an escaped quote, so the string never

--- a/src/lib/ai/dsl.test.ts
+++ b/src/lib/ai/dsl.test.ts
@@ -55,9 +55,22 @@ describe('extractDsl', () => {
     expect(extractDsl(dsl + '\nmore')).toBe(dsl)
   })
 
-  it('handles a string ending in an escaped backslash', () => {
+  it('treats a backslash before a quote the way the lexer does (consume-one)', () => {
+    // In `"see \\"manual\\""` the first backslash is literal and the second
+    // escapes the quote, so the string continues to the final quote. A
+    // two-char-per-backslash scanner would end the string early and
+    // miscount the braces that follow.
+    const dsl = 'workspace {\n  model {\n    a = person "A" "see \\\\"manual\\\\""\n  }\n}'
+    expect(extractDsl(dsl + '\ntrailing prose')).toBe(dsl)
+  })
+
+  it('agrees with the lexer that a trailing backslash swallows the closing quote', () => {
+    // `"path C:\\"` is the GH #109 case: the tokenizer reads the first
+    // backslash as literal and `\"` as an escaped quote, so the string never
+    // closes and the block is unbalanced. extractDsl must fall back to
+    // returning everything rather than pretending the block closed.
     const dsl = 'workspace {\n  model {\n    a = person "A" "path C:\\\\"\n  }\n}'
-    expect(extractDsl(dsl + '\ntrailing')).toBe(dsl)
+    expect(extractDsl(dsl + '\ntrailing')).toBe(dsl + '\ntrailing')
   })
 
   it('does not let a brace in a description truncate the block', () => {

--- a/src/lib/ai/dsl.ts
+++ b/src/lib/ai/dsl.ts
@@ -39,9 +39,16 @@ export function extractDsl(text: string): string {
     // Skip braces inside a quoted string literal (a name/description like
     // "the closing } symbol") — counting them would close the block early.
     if (inString) {
-      // A backslash escapes the next char; consume it so an escaped backslash
-      // (e.g. "C:\\") doesn't make the following quote look escaped and strand us.
-      if (ch === '\\') { i++; continue }
+      // Mirror the DSL lexer's consume-one rule (lexer.ts readString): a
+      // backslash only escapes a following quote; before anything else it is
+      // a literal character and the next char is re-examined, so `\\"` reads
+      // as literal-backslash + escaped quote and the string continues.
+      // Consuming two chars here would end the string where the lexer does
+      // not, and the two would disagree about which braces are inside it.
+      if (ch === '\\') {
+        if (unfenced[i + 1] === '"') i++
+        continue
+      }
       if (ch === '"') inString = false
       lineStart = false
       continue

--- a/src/lib/ai/dsl.ts
+++ b/src/lib/ai/dsl.ts
@@ -2,6 +2,8 @@
 // markdown code fences (```dsl … ``` or ``` … ```) and add a sentence of
 // preamble; this pulls out the workspace block. Pure + unit-tested.
 
+import { scanQuotedString } from '@/lib/dsl/lexer'
+
 /** Strip a single surrounding markdown code fence, if present. */
 export function stripCodeFence(text: string): string {
   const trimmed = text.trim()
@@ -19,8 +21,13 @@ export function extractDsl(text: string): string {
 
   // Anchor on the actual `workspace [ "name" [ "desc" ] ] {` declaration, not a
   // stray mention of the word in prose ("Here is your workspace:") which would
-  // otherwise splice the preamble into the returned DSL.
-  const decl = /\bworkspace\b\s*(?:"(?:[^"\\]|\\.)*"\s*)*\{/.exec(unfenced)
+  // otherwise splice the preamble into the returned DSL. The string pattern
+  // encodes the lexer's consume-one rule deterministically: a backslash
+  // before a quote is ONLY consumable as the `\"` pair (the lookahead keeps
+  // backtracking from reinterpreting it as a lone char), any other backslash
+  // is a lone literal, so the anchor agrees with the parser about where the
+  // name/description strings end.
+  const decl = /\bworkspace\b\s*(?:"(?:\\"|\\(?!")|[^"\\])*"\s*)*\{/.exec(unfenced)
   if (!decl) {
     // No real block — fall back to the first bare mention so the parser can
     // report a precise error, or return everything when there's none.
@@ -32,34 +39,19 @@ export function extractDsl(text: string): string {
   const openIdx = start + decl[0].length - 1
 
   let depth = 0
-  let inString = false
-  let lineStart = true // first non-space on a line — needed for `#` comments
   for (let i = openIdx; i < unfenced.length; i++) {
     const ch = unfenced[i]
-    // Skip braces inside a quoted string literal (a name/description like
-    // "the closing } symbol") — counting them would close the block early.
-    if (inString) {
-      // Mirror the DSL lexer's consume-one rule (lexer.ts readString): a
-      // backslash only escapes a following quote; before anything else it is
-      // a literal character and the next char is re-examined, so `\\"` reads
-      // as literal-backslash + escaped quote and the string continues.
-      // Consuming two chars here would end the string where the lexer does
-      // not, and the two would disagree about which braces are inside it.
-      if (ch === '\\') {
-        if (unfenced[i + 1] === '"') i++
-        continue
-      }
-      if (ch === '"') inString = false
-      lineStart = false
-      continue
-    }
+    // Skip string literals wholesale (a name/description like "the closing }
+    // symbol") — counting their braces would close the block early.
+    // scanQuotedString implements the lexer's consume-one escape rule, so
+    // this scanner and the parser always agree about where a string ends.
+    if (ch === '"') { i = scanQuotedString(unfenced, i) - 1; continue }
     // Skip Structurizr DSL comments — a brace inside one must not be counted.
-    if (ch === '\n') { lineStart = true; continue }
-    if (ch === '/' && unfenced[i + 1] === '/') { const nl = unfenced.indexOf('\n', i); if (nl === -1) break; i = nl; lineStart = true; continue }
-    if (ch === '#' && lineStart) { const nl = unfenced.indexOf('\n', i); if (nl === -1) break; i = nl; lineStart = true; continue }
-    if (ch === '/' && unfenced[i + 1] === '*') { const end = unfenced.indexOf('*/', i + 2); if (end === -1) break; i = end + 1; lineStart = false; continue }
-    if (ch !== ' ' && ch !== '\t') lineStart = false
-    if (ch === '"') { inString = true; continue }
+    if (ch === '/' && unfenced[i + 1] === '/') { const nl = unfenced.indexOf('\n', i); if (nl === -1) break; i = nl; continue }
+    // `#` opens a comment anywhere on a line unless it starts a hex color
+    // like #ffffff — the same disambiguation the lexer uses.
+    if (ch === '#' && !/[0-9a-fA-F]/.test(unfenced[i + 1] ?? '')) { const nl = unfenced.indexOf('\n', i); if (nl === -1) break; i = nl; continue }
+    if (ch === '/' && unfenced[i + 1] === '*') { const end = unfenced.indexOf('*/', i + 2); if (end === -1) break; i = end + 1; continue }
     if (ch === '{') depth++
     else if (ch === '}') {
       depth--

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -21,7 +21,9 @@ workspace "Name" {
   }
 }
 Rules: identifiers are lowercase, no spaces. Wrap multi-word names in quotes.
-A container's third quoted string is its technology. Relationships use ->.`
+A container's third quoted string is its technology. Relationships use ->.
+Inside quoted strings only \\" and \\n are escapes: write a backslash as a
+single literal \\ (never doubled, never \\t) and a tab as a real tab.`
 
 // ─── Generate ───────────────────────────────────────────────────────
 

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -14,6 +14,7 @@ import { saveDSLFile, writeSidecarToHandle } from '@/lib/fileIO'
 import { downloadFile, downloadBlob, exportCanvasAsPNG, exportCanvasAsSVG } from '@/lib/exportUtils'
 import { extractSidecar, serializeSidecar } from '@/lib/sidecar'
 import { fitContentNodesToViewport } from '@/lib/fitViewport'
+import { announce } from '@/lib/announce'
 import type { ReactFlowInstance } from '@xyflow/react'
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
@@ -374,10 +375,14 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
       execute: async () => {
         const s = store()
         if (!s.workspace) return
-        const dsl = serializeDSL(s.workspace)
-        await saveDSLFile(dsl, `${s.workspace.name ?? 'workspace'}.dsl`)
-        const sidecar = extractSidecar(s.workspace)
-        if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))
+        try {
+          const dsl = serializeDSL(s.workspace)
+          await saveDSLFile(dsl, `${s.workspace.name ?? 'workspace'}.dsl`)
+          const sidecar = extractSidecar(s.workspace)
+          if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))
+        } catch (error) {
+          announce(error instanceof Error ? error.message : 'Save failed')
+        }
       },
     },
     {
@@ -389,7 +394,11 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
       execute: async () => {
         const s = store()
         if (!s.workspace) return
-        await saveDSLFile(serializeDSL(s.workspace), `${s.workspace.name ?? 'workspace'}.dsl`)
+        try {
+          await saveDSLFile(serializeDSL(s.workspace), `${s.workspace.name ?? 'workspace'}.dsl`)
+        } catch (error) {
+          announce(error instanceof Error ? error.message : 'Export failed')
+        }
       },
     },
     {

--- a/src/lib/dsl/group-roundtrip.test.ts
+++ b/src/lib/dsl/group-roundtrip.test.ts
@@ -1,101 +1,272 @@
 import { describe, it, expect } from 'vitest'
-import { parseDSL } from '@/lib/dsl'
-import { serialize } from '@/lib/dsl/serializer'
-import type { Workspace } from '@/types/model'
+import { parseDSL, serializeDSL, GroupSerializationError } from '@/lib/dsl'
 
-describe('group roundtrip', () => {
-  it('group block with member references survives serialize → parse', () => {
-    const dsl = `
+describe('Structurizr-conformant group roundtrip', () => {
+  it('emits declarations inside their group instead of post-hoc references', () => {
+    const { workspace, errors } = parseDSL(`
 workspace "Test" {
   model {
-    alice = person "Alice"
-    api = softwareSystem "API"
     group "Frontend Team" {
-      alice
+      alice = person "Alice"
     }
+    api = softwareSystem "API"
   }
   views {}
 }
-`
-    const { workspace, errors } = parseDSL(dsl)
+`)
     expect(errors).toEqual([])
 
-    // Re-serialize and re-parse
-    const dsl2 = serialize(workspace)
-    const { workspace: ws2, errors: errors2 } = parseDSL(dsl2)
-    expect(errors2).toEqual([])
+    const dsl = serializeDSL(workspace)
+    expect(dsl).toContain('group "Frontend Team" {\n            alice = person "Alice"\n        }')
+    expect(dsl.indexOf('group "Frontend Team"')).toBeLessThan(dsl.indexOf('alice = person "Alice"'))
 
-    // Group should be preserved
-    expect(ws2.model.groups).toHaveLength(1)
-    expect(ws2.model.groups[0].name).toBe('Frontend Team')
-
-    // Group should reference Alice by ID
-    const alice = ws2.model.people.find(p => p.name === 'Alice')
-    expect(alice).toBeDefined()
-    expect(ws2.model.groups[0].elementIds).toContain(alice!.id)
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    expect(reparsed.workspace.model.groups).toHaveLength(1)
+    expect(reparsed.workspace.model.groups[0]).toMatchObject({
+      name: 'Frontend Team',
+      elementIds: ['alice'],
+    })
   })
 
-  it('multiple groups with different members survive roundtrip', () => {
-    const dsl = `
+  it('keeps disjoint groups as siblings', () => {
+    const { workspace, errors } = parseDSL(`
 workspace "Multi-group" {
   model {
-    alice = person "Alice"
-    bob = person "Bob"
-    api = softwareSystem "API"
-    store = softwareSystem "Store"
-
     group "Users" {
-      alice
-      bob
+      alice = person "Alice"
+      bob = person "Bob"
     }
     group "Systems" {
-      api
-      store
+      api = softwareSystem "API"
+      store = softwareSystem "Store"
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+
+    const dsl = serializeDSL(workspace)
+    expect(dsl).toContain('group "Users"')
+    expect(dsl).toContain('group "Systems"')
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    expect(reparsed.workspace.model.groups).toHaveLength(2)
+    expect(reparsed.workspace.model.groups.find(g => g.name === 'Users')?.elementIds).toHaveLength(2)
+    expect(reparsed.workspace.model.groups.find(g => g.name === 'Systems')?.elementIds).toHaveLength(2)
+  })
+
+  it('preserves an intentional empty group', () => {
+    const { workspace, errors } = parseDSL(`
+workspace "Test" {
+  model {
+    group "Empty Group" {
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+
+    const dsl = serializeDSL(workspace)
+    expect(dsl).toContain('group "Empty Group" {\n        }')
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    expect(reparsed.workspace.model.groups[0]).toMatchObject({ name: 'Empty Group', elementIds: [] })
+  })
+
+  it('infers nested groups from strict subset membership and emits the separator', () => {
+    const { workspace, errors } = parseDSL(`
+workspace "Nested" {
+  model {
+    properties {
+      "structurizr.groupSeparator" "/"
+    }
+    group "Outer" {
+      c = softwareSystem "C"
+      group "Inner" {
+        a = softwareSystem "A"
+        b = softwareSystem "B"
+      }
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+    expect(workspace.model.groups.find(g => g.name === 'Inner')?.elementIds).toEqual(['a', 'b'])
+    expect(new Set(workspace.model.groups.find(g => g.name === 'Outer')?.elementIds)).toEqual(new Set(['a', 'b', 'c']))
+
+    const dsl = serializeDSL(workspace)
+    expect(dsl).toContain('"structurizr.groupSeparator" "/"')
+    expect(dsl).toMatch(/group "Outer" \{[\s\S]*group "Inner" \{[\s\S]*a = softwareSystem/)
+
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    expect(reparsed.workspace.model.groups.find(g => g.name === 'Inner')?.elementIds).toEqual(['a', 'b'])
+    expect(new Set(reparsed.workspace.model.groups.find(g => g.name === 'Outer')?.elementIds)).toEqual(new Set(['a', 'b', 'c']))
+  })
+
+  it('retains explicit nesting when parent and child have equal aggregate members', () => {
+    const parsed = parseDSL(`
+workspace {
+  model {
+    properties {
+      "structurizr.groupSeparator" "/"
+    }
+    group "Outer" {
+      group "Inner" {
+        a = softwareSystem "A"
+      }
+    }
+  }
+  views {}
+}
+`)
+    expect(parsed.errors).toEqual([])
+    const inner = parsed.workspace.model.groups.find(g => g.name === 'Inner')
+    const outer = parsed.workspace.model.groups.find(g => g.name === 'Outer')
+    expect(inner?.parentId).toBe(outer?.id)
+
+    const dsl = serializeDSL(parsed.workspace)
+    expect(dsl).toMatch(/group "Outer" \{\s+group "Inner" \{\s+a = softwareSystem/s)
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    const reparsedInner = reparsed.workspace.model.groups.find(g => g.name === 'Inner')
+    const reparsedOuter = reparsed.workspace.model.groups.find(g => g.name === 'Outer')
+    expect(reparsedInner?.parentId).toBe(reparsedOuter?.id)
+  })
+
+  it('retains container- and component-level group blocks', () => {
+    const source = `
+workspace "Scoped" {
+  model {
+    sys = softwareSystem "System" {
+      group "Applications" {
+        web = container "Web" {
+          group "Layers" {
+            ui = component "UI"
+            api = component "API"
+          }
+        }
+        db = container "Database"
+      }
     }
   }
   views {}
 }
 `
-    const { workspace, errors } = parseDSL(dsl)
-    expect(errors).toEqual([])
-    expect(workspace.model.groups).toHaveLength(2)
+    const parsed = parseDSL(source)
+    expect(parsed.errors).toEqual([])
+    expect(parsed.workspace.model.groups.find(g => g.name === 'Applications')?.elementIds).toEqual(['web', 'db'])
+    expect(parsed.workspace.model.groups.find(g => g.name === 'Layers')?.elementIds).toEqual(['ui', 'api'])
 
-    const dsl2 = serialize(workspace)
-    const { workspace: ws2, errors: errors2 } = parseDSL(dsl2)
-    expect(errors2).toEqual([])
+    const dsl = serializeDSL(parsed.workspace)
+    expect(dsl).toMatch(/softwareSystem "System" \{[\s\S]*group "Applications" \{[\s\S]*web = container/)
+    expect(dsl).toMatch(/web = container "Web" \{[\s\S]*group "Layers" \{[\s\S]*ui = component/)
 
-    expect(ws2.model.groups).toHaveLength(2)
-    const users = ws2.model.groups.find(g => g.name === 'Users')
-    const systems = ws2.model.groups.find(g => g.name === 'Systems')
-    expect(users).toBeDefined()
-    expect(systems).toBeDefined()
-    expect(users!.elementIds).toHaveLength(2)
-    expect(systems!.elementIds).toHaveLength(2)
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    expect(reparsed.workspace.model.groups.find(g => g.name === 'Applications')?.elementIds).toEqual(['web', 'db'])
+    expect(reparsed.workspace.model.groups.find(g => g.name === 'Layers')?.elementIds).toEqual(['ui', 'api'])
   })
 
-  it('empty group survives serialize → parse', () => {
-    const workspace: Workspace = {
-      name: 'Test',
-      model: {
-        people: [],
-        softwareSystems: [],
-        relationships: [],
-        groups: [{ id: 'g1', name: 'Empty Group', elementIds: [] }],
-      },
-      views: {
-        systemLandscapeViews: [],
-        systemContextViews: [],
-        containerViews: [],
-        componentViews: [],
-        configuration: { styles: { elements: [], relationships: [] } },
-      },
+  it('normalizes an inline component group to a valid group block', () => {
+    const parsed = parseDSL(`
+workspace {
+  model {
+    sys = softwareSystem "System" {
+      web = container "Web" {
+        adapter = component "Adapter" {
+          group "Adapters"
+        }
+      }
     }
-    const dsl = serialize(workspace)
-    expect(dsl).toContain('group "Empty Group" {')
+  }
+  views {}
+}
+`)
+    expect(parsed.errors).toEqual([])
+    expect(parsed.workspace.model.groups.find(g => g.name === 'Adapters')?.elementIds).toEqual(['adapter'])
+    expect(serializeDSL(parsed.workspace)).toMatch(/group "Adapters" \{\s+adapter = component/)
+  })
 
-    const { workspace: reparsed, errors } = parseDSL(dsl)
-    expect(errors).toEqual([])
-    expect(reparsed.model.groups).toHaveLength(1)
-    expect(reparsed.model.groups[0]).toMatchObject({ name: 'Empty Group', elementIds: [] })
+  it('preserves a hierarchy whose parent also has members at another abstraction scope', () => {
+    const parsed = parseDSL(`
+workspace {
+  model {
+    sys = softwareSystem "System" {
+      web = container "Web"
+      api = container "API"
+    }
+  }
+  views {}
+}
+`)
+    expect(parsed.errors).toEqual([])
+    parsed.workspace.model.groups = [
+      { id: 'inner', name: 'Applications', elementIds: ['web', 'api'] },
+      { id: 'outer', name: 'Secure Zone', elementIds: ['sys', 'web', 'api'] },
+    ]
+
+    const dsl = serializeDSL(parsed.workspace)
+    expect(dsl).toMatch(/softwareSystem "System" \{[\s\S]*group "Secure Zone" \{[\s\S]*group "Applications"/)
+    expect(parseDSL(dsl).errors).toEqual([])
+  })
+
+  it('blocks crossing memberships with an actionable error', () => {
+    const parsed = parseDSL(`
+workspace {
+  model {
+    a = softwareSystem "A"
+    b = softwareSystem "B"
+    c = softwareSystem "C"
+  }
+  views {}
+}
+`)
+    parsed.workspace.model.groups = [
+      { id: 'one', name: 'One', elementIds: ['a', 'b'] },
+      { id: 'two', name: 'Two', elementIds: ['b', 'c'] },
+    ]
+
+    expect(() => serializeDSL(parsed.workspace)).toThrow(GroupSerializationError)
+    expect(() => serializeDSL(parsed.workspace)).toThrow(/groups "One" and "Two".*"B" belongs to both/s)
+  })
+
+  it('blocks equal memberships because neither group is a strict parent', () => {
+    const parsed = parseDSL(`
+workspace {
+  model {
+    a = softwareSystem "A"
+  }
+  views {}
+}
+`)
+    parsed.workspace.model.groups = [
+      { id: 'one', name: 'One', elementIds: ['a'] },
+      { id: 'two', name: 'Two', elementIds: ['a'] },
+    ]
+
+    expect(() => serializeDSL(parsed.workspace)).toThrow(/groups "One" and "Two"/)
+  })
+
+  it('blocks separator characters in nested group names', () => {
+    const parsed = parseDSL(`
+workspace {
+  model {
+    a = softwareSystem "A"
+    b = softwareSystem "B"
+  }
+  views {}
+}
+`)
+    parsed.workspace.model.groups = [
+      { id: 'inner', name: 'Inner/Team', elementIds: ['a'] },
+      { id: 'outer', name: 'Outer', elementIds: ['a', 'b'] },
+    ]
+
+    expect(() => serializeDSL(parsed.workspace)).toThrow(/group names may not contain.*separator/s)
   })
 })

--- a/src/lib/dsl/index.ts
+++ b/src/lib/dsl/index.ts
@@ -13,6 +13,7 @@ import { serialize } from './serializer'
 import { generateDefaultViews } from './auto-views'
 
 export type { ParseError }
+export { GroupSerializationError } from './serializer'
 
 export interface ParseDSLResult {
     workspace: Workspace

--- a/src/lib/dsl/interaction-style-roundtrip.test.ts
+++ b/src/lib/dsl/interaction-style-roundtrip.test.ts
@@ -40,7 +40,9 @@ describe('interactionStyle roundtrip', () => {
   it('Asynchronous survives serialize → parse', () => {
     const ws = makeWs({ interactionStyle: 'Asynchronous' })
     const dsl = serializeDSL(ws)
-    expect(dsl).toContain('interactionStyle Asynchronous')
+    // Real Structurizr rejects a bare `interactionStyle` keyword in a
+    // relationship body — it travels as a c4hero.interactionStyle property.
+    expect(dsl).toContain('"c4hero.interactionStyle" "Asynchronous"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined
@@ -50,7 +52,7 @@ describe('interactionStyle roundtrip', () => {
   it('Synchronous survives serialize → parse', () => {
     const ws = makeWs({ interactionStyle: 'Synchronous' })
     const dsl = serializeDSL(ws)
-    expect(dsl).toContain('interactionStyle Synchronous')
+    expect(dsl).toContain('"c4hero.interactionStyle" "Synchronous"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined
@@ -85,7 +87,7 @@ describe('relationship url roundtrip', () => {
     const ws = makeWs({ url: 'https://example.com', interactionStyle: 'Asynchronous' })
     const dsl = serializeDSL(ws)
     expect(dsl).toContain('url "https://example.com"')
-    expect(dsl).toContain('interactionStyle Asynchronous')
+    expect(dsl).toContain('"c4hero.interactionStyle" "Asynchronous"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined
@@ -133,7 +135,9 @@ describe('relationship lineStyle roundtrip', () => {
   it('Curved serializes and parses back', () => {
     const ws = makeWs({ lineStyle: 'Curved' })
     const dsl = serializeDSL(ws)
-    expect(dsl).toContain('lineStyle Curved')
+    // Real Structurizr rejects a bare `lineStyle` keyword in a relationship
+    // body — it travels as a c4hero.lineStyle property.
+    expect(dsl).toContain('"c4hero.lineStyle" "Curved"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined
@@ -143,7 +147,7 @@ describe('relationship lineStyle roundtrip', () => {
   it('Orthogonal serializes and parses back', () => {
     const ws = makeWs({ lineStyle: 'Orthogonal' })
     const dsl = serializeDSL(ws)
-    expect(dsl).toContain('lineStyle Orthogonal')
+    expect(dsl).toContain('"c4hero.lineStyle" "Orthogonal"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined
@@ -153,7 +157,7 @@ describe('relationship lineStyle roundtrip', () => {
   it('Straight serializes and parses back', () => {
     const ws = makeWs({ lineStyle: 'Straight' })
     const dsl = serializeDSL(ws)
-    expect(dsl).toContain('lineStyle Straight')
+    expect(dsl).toContain('"c4hero.lineStyle" "Straight"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined
@@ -174,8 +178,8 @@ describe('relationship lineStyle roundtrip', () => {
   it('lineStyle and interactionStyle both survive roundtrip', () => {
     const ws = makeWs({ lineStyle: 'Curved', interactionStyle: 'Asynchronous' })
     const dsl = serializeDSL(ws)
-    expect(dsl).toContain('lineStyle Curved')
-    expect(dsl).toContain('interactionStyle Asynchronous')
+    expect(dsl).toContain('"c4hero.lineStyle" "Curved"')
+    expect(dsl).toContain('"c4hero.interactionStyle" "Asynchronous"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])
     const rel = workspace.model.relationships[0] as Relationship | undefined

--- a/src/lib/dsl/lexer.gaps.test.ts
+++ b/src/lib/dsl/lexer.gaps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { lex } from './lexer'
+import { lex, scanQuotedString } from './lexer'
 
 // Coverage-gap tests for the lexer: string escapes, comments, unusual
 // tokens, and error positions.
@@ -48,6 +48,26 @@ describe('string escape sequences', () => {
   it('handles an unterminated string ending in a backslash without crashing', () => {
     const { errors } = lex('"abc\\')
     expect(errors.some(e => e.message === 'Unterminated string literal')).toBe(true)
+  })
+})
+
+describe('scanQuotedString', () => {
+  // The exported boundary scanner must end strings exactly where readString
+  // does — extractDsl (ai/dsl.ts) relies on that agreement for brace counting.
+  it('agrees with the lexer on plain, escaped, and missed-escape strings', () => {
+    for (const [input, rest] of [
+      ['"plain" rest', ' rest'],
+      ['"say \\"hi\\"" rest', ' rest'],
+      ['"a\\\\"b" rest', ' rest'],  // the quote after \\ is escaped; string runs on to the quote after b
+      ['"a\\qb" rest', ' rest'],    // unknown escape: backslash literal
+    ] as const) {
+      expect(input.slice(scanQuotedString(input, 0))).toBe(rest)
+    }
+  })
+
+  it('returns input.length for an unterminated string', () => {
+    expect(scanQuotedString('"path C:\\\\"', 0)).toBe('"path C:\\\\"'.length)
+    expect(scanQuotedString('"abc\\', 0)).toBe('"abc\\'.length)
   })
 })
 

--- a/src/lib/dsl/lexer.gaps.test.ts
+++ b/src/lib/dsl/lexer.gaps.test.ts
@@ -22,6 +22,18 @@ describe('string escape sequences', () => {
     expect(tokens[0].value).toBe('a\\qb')
   })
 
+  it('consumes only the backslash on a missed escape, so the next char can start one', () => {
+    // `a\\"b`: the first backslash misses (next char is another backslash) and
+    // is consumed alone; the second then starts the `\"` escape. The real
+    // tokenizer does the same (verified via `export -f json`) — consuming two
+    // chars on a miss would swallow the second backslash and end the string at
+    // the quote.
+    const { tokens, errors } = lex('"a\\\\"b"')
+    expect(errors).toHaveLength(0)
+    expect(tokens[0].type).toBe('STRING')
+    expect(tokens[0].value).toBe('a\\"b')
+  })
+
   it('reports an unterminated string with its start position', () => {
     const { tokens, errors } = lex('model "abc')
     expect(errors).toHaveLength(1)

--- a/src/lib/dsl/lexer.gaps.test.ts
+++ b/src/lib/dsl/lexer.gaps.test.ts
@@ -5,11 +5,15 @@ import { lex } from './lexer'
 // tokens, and error positions.
 
 describe('string escape sequences', () => {
-  it('decodes \\n, \\t, \\" and \\\\ escapes inside strings', () => {
+  // Structurizr's tokenizer (structurizr-java 5.0.2) recognises only \" and
+  // \n. \t and \\ are NOT escapes — the backslash stays verbatim. c4hero used
+  // to decode all four JSON-style, which is why serializer output round-tripped
+  // here but was misread by every other Structurizr tool.
+  it('decodes only \\" and \\n; leaves \\t and \\\\ verbatim', () => {
     const { tokens, errors } = lex('"a\\nb\\tc\\"d\\\\e"')
     expect(errors).toHaveLength(0)
     expect(tokens[0].type).toBe('STRING')
-    expect(tokens[0].value).toBe('a\nb\tc"d\\e')
+    expect(tokens[0].value).toBe('a\nb\\tc"d\\\\e')
   })
 
   it('preserves the backslash for unknown escape sequences', () => {

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -104,6 +104,26 @@ export interface LexResult {
     errors: LexerError[]
 }
 
+/**
+ * Index just past the closing quote of the string literal opening at `start`
+ * (which must point at the opening `"`), or `input.length` if unterminated.
+ * Implements the same consume-one escape rule as readString below — `\"` and
+ * `\n` are the only two-char sequences; any other backslash is a literal
+ * consumed alone. Exported so non-tokenizing scanners (extractDsl in
+ * ai/dsl.ts) share the rule instead of hand-mirroring it.
+ */
+export function scanQuotedString(input: string, start: number): number {
+    let i = start + 1
+    while (i < input.length && input[i] !== '"') {
+        if (input[i] === '\\' && (input[i + 1] === '"' || input[i + 1] === 'n')) {
+            i += 2
+        } else {
+            i++
+        }
+    }
+    return i < input.length ? i + 1 : input.length
+}
+
 export function lex(input: string): LexResult {
     const tokens: Token[] = []
     const errors: LexerError[] = []

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -150,23 +150,25 @@ export function lex(input: string): LexResult {
         let value = ''
         while (pos < input.length && peek() !== '"') {
             if (peek() === '\\') {
-                advance()
-                const escaped = advance()
                 // Mirror Structurizr's tokenizer exactly (structurizr-java 5.0.2):
-                // `\"` and `\n` are the only escapes. `\\` is NOT collapsed and
-                // `\t` is not an escape — both stay verbatim, backslash included.
-                // Diverging here is what let the serializer emit JSON-style
-                // escapes that round-tripped in c4hero but corrupted the value
-                // in every other Structurizr tool.
-                switch (escaped) {
-                    case 'n':
-                        value += '\n'
-                        break
-                    case '"':
-                        value += '"'
-                        break
-                    default:
-                        value += '\\' + escaped
+                // `\"` and `\n` are the only escapes; `\\` is NOT collapsed and
+                // `\t` is not an escape. On a miss, only the backslash itself is
+                // consumed — the next char is re-examined, because it may start
+                // an escape of its own (`a\\"b` is literal-\ then \" → `a\"b`).
+                // Consuming two chars here is what made c4hero disagree with
+                // every other Structurizr tool on backslash-heavy values.
+                const next = peekAt(1)
+                if (next === '"') {
+                    advance()
+                    advance()
+                    value += '"'
+                } else if (next === 'n') {
+                    advance()
+                    advance()
+                    value += '\n'
+                } else {
+                    advance()
+                    value += '\\'
                 }
             } else {
                 value += advance()

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -157,6 +157,9 @@ export function lex(input: string): LexResult {
                 // an escape of its own (`a\\"b` is literal-\ then \" → `a\"b`).
                 // Consuming two chars here is what made c4hero disagree with
                 // every other Structurizr tool on backslash-heavy values.
+                // Known consequence: files saved by pre-TEA-163 c4hero used
+                // JSON-style `\\`/`\t` escapes and now read back literally;
+                // detecting and migrating those legacy files is TEA-167.
                 const next = peekAt(1)
                 if (next === '"') {
                     advance()

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -105,21 +105,26 @@ export interface LexResult {
 }
 
 /**
+ * The consume-one escape rule in one place: the step length at position `i`
+ * inside a quoted string is 2 when a backslash begins one of the two real
+ * escapes (`\"` or `\n`), else 1 — a backslash before anything else is a
+ * literal consumed alone. readString and scanQuotedString both step with
+ * this, so the tokenizer and boundary scanner cannot drift apart.
+ */
+export function escapeStep(input: string, i: number): 1 | 2 {
+    return input[i] === '\\' && (input[i + 1] === '"' || input[i + 1] === 'n') ? 2 : 1
+}
+
+/**
  * Index just past the closing quote of the string literal opening at `start`
  * (which must point at the opening `"`), or `input.length` if unterminated.
- * Implements the same consume-one escape rule as readString below — `\"` and
- * `\n` are the only two-char sequences; any other backslash is a literal
- * consumed alone. Exported so non-tokenizing scanners (extractDsl in
- * ai/dsl.ts) share the rule instead of hand-mirroring it.
+ * Exported so non-tokenizing scanners (extractDsl in ai/dsl.ts) share the
+ * escape rule instead of hand-mirroring it.
  */
 export function scanQuotedString(input: string, start: number): number {
     let i = start + 1
     while (i < input.length && input[i] !== '"') {
-        if (input[i] === '\\' && (input[i + 1] === '"' || input[i + 1] === 'n')) {
-            i += 2
-        } else {
-            i++
-        }
+        i += escapeStep(input, i)
     }
     return i < input.length ? i + 1 : input.length
 }
@@ -169,30 +174,22 @@ export function lex(input: string): LexResult {
         advance() // consume opening "
         let value = ''
         while (pos < input.length && peek() !== '"') {
-            if (peek() === '\\') {
-                // Mirror Structurizr's tokenizer exactly (structurizr-java 5.0.2):
-                // `\"` and `\n` are the only escapes; `\\` is NOT collapsed and
-                // `\t` is not an escape. On a miss, only the backslash itself is
-                // consumed — the next char is re-examined, because it may start
-                // an escape of its own (`a\\"b` is literal-\ then \" → `a\"b`).
-                // Consuming two chars here is what made c4hero disagree with
-                // every other Structurizr tool on backslash-heavy values.
-                // Known consequence: files saved by pre-TEA-163 c4hero used
-                // JSON-style `\\`/`\t` escapes and now read back literally;
-                // detecting and migrating those legacy files is TEA-167.
-                const next = peekAt(1)
-                if (next === '"') {
-                    advance()
-                    advance()
-                    value += '"'
-                } else if (next === 'n') {
-                    advance()
-                    advance()
-                    value += '\n'
-                } else {
-                    advance()
-                    value += '\\'
-                }
+            // Mirror Structurizr's tokenizer exactly (structurizr-java 5.0.2):
+            // `\"` and `\n` are the only escapes; `\\` is NOT collapsed and
+            // `\t` is not an escape. On a miss, only the backslash itself is
+            // consumed — the next char is re-examined, because it may start
+            // an escape of its own (`a\\"b` is literal-\ then \" → `a\"b`).
+            // escapeStep (above) is the single home of that rule; consuming
+            // two chars here is what made c4hero disagree with every other
+            // Structurizr tool on backslash-heavy values.
+            // Known consequence: files saved by pre-TEA-163 c4hero used
+            // JSON-style `\\`/`\t` escapes and now read back literally;
+            // detecting and migrating those legacy files is TEA-167.
+            if (escapeStep(input, pos) === 2) {
+                const escaped = peekAt(1)
+                advance()
+                advance()
+                value += escaped === 'n' ? '\n' : '"'
             } else {
                 value += advance()
             }

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -152,18 +152,18 @@ export function lex(input: string): LexResult {
             if (peek() === '\\') {
                 advance()
                 const escaped = advance()
+                // Mirror Structurizr's tokenizer exactly (structurizr-java 5.0.2):
+                // `\"` and `\n` are the only escapes. `\\` is NOT collapsed and
+                // `\t` is not an escape — both stay verbatim, backslash included.
+                // Diverging here is what let the serializer emit JSON-style
+                // escapes that round-tripped in c4hero but corrupted the value
+                // in every other Structurizr tool.
                 switch (escaped) {
                     case 'n':
                         value += '\n'
                         break
-                    case 't':
-                        value += '\t'
-                        break
                     case '"':
                         value += '"'
-                        break
-                    case '\\':
-                        value += '\\'
                         break
                     default:
                         value += '\\' + escaped

--- a/src/lib/dsl/location-roundtrip.test.ts
+++ b/src/lib/dsl/location-roundtrip.test.ts
@@ -28,7 +28,12 @@ function makeWs(): Workspace {
   }
 }
 
-describe('native location keyword parsing', () => {
+// Structurizr removed the `location` keyword; externality is the `External`
+// tag. c4hero keeps the model field (it drives the canvas — see
+// canvasBuilders.ts:69 and SystemNode/PersonNode) and maps it to the tag on
+// the way out, back to the field on the way in. The bare keyword is still
+// accepted on import so older c4hero files keep loading.
+describe('legacy location keyword parsing (import back-compat)', () => {
   it('person block with location External is parsed correctly', () => {
     const dsl = `
 workspace {
@@ -64,21 +69,22 @@ workspace {
   })
 })
 
-describe('serializer emits native location keyword', () => {
-  it('External person serializes as "location External" not properties block', () => {
-    const ws = makeWs()
-    const dsl = serializeDSL(ws)
-    expect(dsl).toContain('location External')
+describe('serializer emits the External tag, never the location keyword', () => {
+  it('does not emit the removed location keyword', () => {
+    const dsl = serializeDSL(makeWs())
+    expect(dsl).not.toContain('location External')
+    expect(dsl).not.toContain('location Internal')
     expect(dsl).not.toContain('c4hero.location')
   })
 
-  it('External softwareSystem serializes as "location External" not properties block', () => {
-    const ws = makeWs()
-    const dsl = serializeDSL(ws)
-    // Both person Alice and system ExtSys are External; both should use location External
-    const locationCount = (dsl.match(/location External/g) ?? []).length
-    expect(locationCount).toBe(2)
-    expect(dsl).not.toContain('"c4hero.location"')
+  it('tags both External elements and leaves Internal ones untagged', () => {
+    const dsl = serializeDSL(makeWs())
+    expect(dsl).toContain('person "Alice" "" "External"')
+    expect(dsl).toContain('softwareSystem "ExtSys" "" "External"')
+    // Internal is the default and needs no representation.
+    expect(dsl).toContain('person "Bob"')
+    expect(dsl).not.toMatch(/"Bob".*External/)
+    expect(dsl).not.toMatch(/"IntSys".*External/)
   })
 })
 
@@ -108,22 +114,20 @@ describe('External location roundtrip', () => {
 })
 
 describe('serializer does not emit unnecessary empty string placeholders', () => {
-  it('External person with no description serializes without "" before the block', () => {
-    const ws = makeWs()
-    const dsl = serializeDSL(ws)
-    // alice is External so has a block body; she has no description.
-    // The serializer must NOT emit person "Alice" "" { location External }
-    // It should emit person "Alice" { location External }
-    expect(dsl).not.toMatch(/person "Alice" "" \{/)
-    expect(dsl).toMatch(/person "Alice" \{/)
+  it('opens no block body for an element whose only extra is externality', () => {
+    const dsl = serializeDSL(makeWs())
+    // Externality is now a positional tag, so no braces are needed at all.
+    expect(dsl).not.toMatch(/person "Alice"[^\n]*\{/)
+    expect(dsl).not.toMatch(/softwareSystem "ExtSys"[^\n]*\{/)
   })
 
-  it('External softwareSystem with no description serializes without "" before the block', () => {
-    const ws = makeWs()
-    const dsl = serializeDSL(ws)
-    // ExtSys is External so has a block body; it has no description.
-    expect(dsl).not.toMatch(/softwareSystem "ExtSys" "" \{/)
-    expect(dsl).toMatch(/softwareSystem "ExtSys" \{/)
+  it('emits an empty description only where a later positional arg needs it', () => {
+    const dsl = serializeDSL(makeWs())
+    // tags are the 3rd positional arg, so the description slot must be filled
+    // for Alice/ExtSys — but Bob and IntSys have no trailing arg and get none.
+    expect(dsl).toContain('person "Alice" "" "External"')
+    expect(dsl).not.toMatch(/person "Bob" ""/)
+    expect(dsl).not.toMatch(/softwareSystem "IntSys" ""/)
   })
 
   it('External person with no description roundtrips with location and no description', () => {

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -13,12 +13,13 @@ type Element = Person | SoftwareSystem | Container | Component
  * Map Structurizr-native encodings back onto c4hero's model fields.
  *
  * Structurizr has no `location` keyword (externality is the `External` tag)
- * and no `owner` keyword (ownership is a property), so the serializer emits
- * both that way. Undo them here so a round-trip is exact, and so files
- * authored in other Structurizr tools get the same interpretation.
+ * and no `owner` / `status` keywords (both travel as properties — `owner`
+ * bare, `status` as `c4hero.status`), so the serializer emits them that way.
+ * Undo them here so a round-trip is exact, and so files authored in other
+ * Structurizr tools get the same interpretation.
  *
- * The legacy bare `location` / `owner` keywords are still accepted by
- * parseElementPropertyOnElement for back-compat with older c4hero files;
+ * The legacy bare `location` / `owner` / `status` keywords are still accepted
+ * by parseElementPropertyOnElement for back-compat with older c4hero files;
  * this runs afterwards and only fills in what those did not set.
  */
 function applyStructurizrConventions(element: Element): void {
@@ -32,6 +33,15 @@ function applyStructurizrConventions(element: Element): void {
     if (element.properties.owner !== undefined && element.owner === undefined) {
         element.owner = element.properties.owner
         delete element.properties.owner
+    }
+    const status = element.properties['c4hero.status']
+    if (status !== undefined && element.status === undefined) {
+        // Only hoist valid enum members; anything else stays a plain property
+        // so no value is silently lost.
+        if (status === 'Live' || status === 'Planned' || status === 'Deprecated' || status === 'Removed') {
+            element.status = status
+            delete element.properties['c4hero.status']
+        }
     }
 }
 

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -27,8 +27,11 @@ function applyStructurizrConventions(element: Element): void {
     if (element.type === 'person' || element.type === 'softwareSystem') {
         const i = element.tags.indexOf('External')
         // Like every hoist below, only fill an unset field: an explicit legacy
-        // `location Internal` line wins over an External tag, which then stays
-        // in tags[] as an opaque user tag rather than being silently deleted.
+        // `location Internal` line wins over an External tag, which is kept in
+        // the in-memory model. On save the serializer resolves the
+        // contradiction in the field's favour and does not re-emit the tag
+        // (see locationAwareTags) — emitting it would flip the element to
+        // External on the next parse.
         // Known consequence of the hoist: canvas styles keyed on the
         // "External" tag no longer match (style lookup reads tags only, not
         // location) — tracked as TEA-168.

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -3,6 +3,7 @@
 // helpers.
 
 import type { Workspace, Model, Group, Person, SoftwareSystem, Container, Component } from '@/types/model'
+import { isElementStatus } from '@/types/model'
 import type { ContextAwareParser } from './parser'
 import { nextId, MAX_DEPTH } from './parser'
 import { parseRelationship } from './parser-relationship'
@@ -28,6 +29,9 @@ function applyStructurizrConventions(element: Element): void {
         // Like every hoist below, only fill an unset field: an explicit legacy
         // `location Internal` line wins over an External tag, which then stays
         // in tags[] as an opaque user tag rather than being silently deleted.
+        // Known consequence of the hoist: canvas styles keyed on the
+        // "External" tag no longer match (style lookup reads tags only, not
+        // location) — tracked as TEA-168.
         if (i !== -1 && element.location === undefined) {
             element.location = 'External'
             element.tags.splice(i, 1)
@@ -43,7 +47,7 @@ function applyStructurizrConventions(element: Element): void {
     if (status !== undefined && element.status === undefined) {
         // Only hoist valid enum members; anything else stays a plain property
         // so no value is silently lost.
-        if (status === 'Live' || status === 'Planned' || status === 'Deprecated' || status === 'Removed') {
+        if (isElementStatus(status)) {
             element.status = status
             delete element.properties['c4hero.status']
         }
@@ -570,7 +574,7 @@ function parseElementPropertyOnElement(p: ContextAwareParser, element: Element, 
         const val = p.peek()
         if (val.type === 'IDENTIFIER' || val.type === 'KEYWORD' || val.type === 'STRING') {
             const s = p.advance().value
-            if (s === 'Live' || s === 'Planned' || s === 'Deprecated' || s === 'Removed') {
+            if (isElementStatus(s)) {
                 element.status = s
             }
         }

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -57,7 +57,12 @@ function applyStructurizrConventions(element: Element): void {
     }
 }
 
-export function parseModelBody(p: ContextAwareParser, model: Model, groupRefIds?: string[]): void {
+export function parseModelBody(
+    p: ContextAwareParser,
+    model: Model,
+    groupRefIds?: string[],
+    parentGroupId?: string,
+): void {
     p.depth++
     if (p.depth > MAX_DEPTH) { p.addError('Maximum nesting depth exceeded', p.peek()); p.depth--; return }
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
@@ -99,12 +104,13 @@ export function parseModelBody(p: ContextAwareParser, model: Model, groupRefIds?
             if (kw === 'group') {
                 p.advance()
                 const groupName = p.readOptionalString() ?? `Group ${model.groups.length + 1}`
+                const groupId = nextId()
                 p.skipNewlines()
                 if (p.match('LBRACE')) {
                     const memberRefs: string[] = []
                     const beforePeople = model.people.length
                     const beforeSystems = model.softwareSystems.length
-                    parseModelBody(p, model, memberRefs)
+                    parseModelBody(p, model, memberRefs, groupId)
                     p.skipNewlines()
                     p.expect('RBRACE')
                     const definedIds = [
@@ -112,7 +118,8 @@ export function parseModelBody(p: ContextAwareParser, model: Model, groupRefIds?
                         ...model.softwareSystems.slice(beforeSystems).map(s => s.id),
                     ]
                     const allIds = [...new Set([...definedIds, ...memberRefs])]
-                    const group: Group = { id: nextId(), name: groupName, elementIds: allIds }
+                    const group: Group = { id: groupId, name: groupName, elementIds: allIds }
+                    if (parentGroupId) group.parentId = parentGroupId
                     model.groups.push(group)
                 }
                 continue
@@ -278,7 +285,13 @@ function parseSoftwareSystem(p: ContextAwareParser, varName?: string, model?: Mo
     return sys
 }
 
-function parseSoftwareSystemBody(p: ContextAwareParser, sys: SoftwareSystem, model?: Model, path?: string): void {
+function parseSoftwareSystemBody(
+    p: ContextAwareParser,
+    sys: SoftwareSystem,
+    model?: Model,
+    path?: string,
+    parentGroupId?: string,
+): void {
     p.depth++
     if (p.depth > MAX_DEPTH) { p.addError('Maximum nesting depth exceeded', p.peek()); p.depth--; return }
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
@@ -295,12 +308,23 @@ function parseSoftwareSystemBody(p: ContextAwareParser, sys: SoftwareSystem, mod
 
             if (kw === 'group') {
                 p.advance()
-                p.readOptionalString()
+                const groupName = p.readOptionalString() ?? `Group ${(model?.groups.length ?? 0) + 1}`
+                const groupId = nextId()
                 p.skipNewlines()
                 if (p.match('LBRACE')) {
-                    parseSoftwareSystemBody(p, sys, model, path)
+                    const beforeContainers = sys.containers.length
+                    parseSoftwareSystemBody(p, sys, model, path, groupId)
                     p.skipNewlines()
                     p.expect('RBRACE')
+                    if (model) {
+                        const group: Group = {
+                            id: groupId,
+                            name: groupName,
+                            elementIds: sys.containers.slice(beforeContainers).map(container => container.id),
+                        }
+                        if (parentGroupId) group.parentId = parentGroupId
+                        model.groups.push(group)
+                    }
                 }
                 continue
             }
@@ -405,7 +429,13 @@ function parseContainer(p: ContextAwareParser, varName?: string, model?: Model, 
     return container
 }
 
-function parseContainerBody(p: ContextAwareParser, container: Container, model?: Model, path?: string): void {
+function parseContainerBody(
+    p: ContextAwareParser,
+    container: Container,
+    model?: Model,
+    path?: string,
+    parentGroupId?: string,
+): void {
     p.depth++
     if (p.depth > MAX_DEPTH) { p.addError('Maximum nesting depth exceeded', p.peek()); p.depth--; return }
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
@@ -422,18 +452,29 @@ function parseContainerBody(p: ContextAwareParser, container: Container, model?:
 
             if (kw === 'group') {
                 p.advance()
-                p.readOptionalString()
+                const groupName = p.readOptionalString() ?? `Group ${(model?.groups.length ?? 0) + 1}`
+                const groupId = nextId()
                 p.skipNewlines()
                 if (p.match('LBRACE')) {
-                    parseContainerBody(p, container, model, path)
+                    const beforeComponents = container.components.length
+                    parseContainerBody(p, container, model, path, groupId)
                     p.skipNewlines()
                     p.expect('RBRACE')
+                    if (model) {
+                        const group: Group = {
+                            id: groupId,
+                            name: groupName,
+                            elementIds: container.components.slice(beforeComponents).map(component => component.id),
+                        }
+                        if (parentGroupId) group.parentId = parentGroupId
+                        model.groups.push(group)
+                    }
                 }
                 continue
             }
 
             if (kw === 'component') {
-                const comp = parseComponent(p, undefined, path)
+                const comp = parseComponent(p, undefined, path, model)
                 if (comp) container.components.push(comp)
                 continue
             }
@@ -469,7 +510,7 @@ function parseContainerBody(p: ContextAwareParser, container: Container, model?:
                 const vn = token.value
 
                 if (p.check('KEYWORD') && p.peekValue().toLowerCase() === 'component') {
-                    const comp = parseComponent(p, vn, path)
+                    const comp = parseComponent(p, vn, path, model)
                     if (comp) container.components.push(comp)
                 } else {
                     p.skipUnknownDirective()
@@ -488,7 +529,7 @@ function parseContainerBody(p: ContextAwareParser, container: Container, model?:
     p.depth--
 }
 
-function parseComponent(p: ContextAwareParser, varName?: string, parentPath?: string): Component | null {
+function parseComponent(p: ContextAwareParser, varName?: string, parentPath?: string, model?: Model): Component | null {
     p.advance() // consume 'component'
     const name = p.readString()
     const description = p.readOptionalString() || undefined
@@ -511,7 +552,7 @@ function parseComponent(p: ContextAwareParser, varName?: string, parentPath?: st
     p.skipNewlines()
     if (p.check('LBRACE')) {
         p.advance()
-        parseSimpleElementBlock(p, component)
+        parseSimpleElementBlock(p, component, model)
         p.skipNewlines()
         p.expect('RBRACE')
     }
@@ -520,7 +561,7 @@ function parseComponent(p: ContextAwareParser, varName?: string, parentPath?: st
     return component
 }
 
-function parseSimpleElementBlock(p: ContextAwareParser, element: Person | Component): void {
+function parseSimpleElementBlock(p: ContextAwareParser, element: Person | Component, model?: Model): void {
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
         p.skipNewlines()
         if (p.check('RBRACE') || p.peekType() === 'EOF') break
@@ -536,6 +577,14 @@ function parseSimpleElementBlock(p: ContextAwareParser, element: Person | Compon
 
         if (token.type === 'KEYWORD') {
             const kw = token.value.toLowerCase()
+            if (kw === 'group' && element.type === 'component') {
+                p.advance()
+                const groupName = p.readOptionalString()
+                if (groupName && model) {
+                    model.groups.push({ id: nextId(), name: groupName, elementIds: [element.id] })
+                }
+                continue
+            }
             if (kw === 'tags' || kw === 'description' || kw === 'technology' || kw === 'url' || kw === 'properties' || kw === 'perspectives' || kw === 'location' || kw === 'status' || kw === 'owner') {
                 parseElementPropertyOnElement(p, element, kw)
                 continue

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -25,12 +25,17 @@ type Element = Person | SoftwareSystem | Container | Component
 function applyStructurizrConventions(element: Element): void {
     if (element.type === 'person' || element.type === 'softwareSystem') {
         const i = element.tags.indexOf('External')
-        if (i !== -1) {
+        // Like every hoist below, only fill an unset field: an explicit legacy
+        // `location Internal` line wins over an External tag, which then stays
+        // in tags[] as an opaque user tag rather than being silently deleted.
+        if (i !== -1 && element.location === undefined) {
             element.location = 'External'
             element.tags.splice(i, 1)
         }
     }
-    if (element.properties.owner !== undefined && element.owner === undefined) {
+    // Empty values stay plain properties: the serializer only re-emits a
+    // truthy owner field, so hoisting `"owner" ""` would drop it on save.
+    if (element.properties.owner && element.owner === undefined) {
         element.owner = element.properties.owner
         delete element.properties.owner
     }

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -627,8 +627,12 @@ function parsePropertiesBlock(p: ContextAwareParser, element: Element): void {
             if (val === 'External') (element as Person | SoftwareSystem).location = 'External'
             else if (val === 'Internal') (element as Person | SoftwareSystem).location = 'Internal'
         } else {
-            // Generic passthrough to properties map
-            element.properties[key] = val
+            // Generic passthrough to properties map. defineProperty, not
+            // assignment: a "__proto__" key would otherwise set the object's
+            // prototype instead of storing the property.
+            Object.defineProperty(element.properties, key, {
+                value: val, enumerable: true, writable: true, configurable: true,
+            })
         }
     }
 }

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -5,7 +5,7 @@
 import type { Workspace, Model, Group, Person, SoftwareSystem, Container, Component } from '@/types/model'
 import { isElementStatus } from '@/types/model'
 import type { ContextAwareParser } from './parser'
-import { nextId, MAX_DEPTH } from './parser'
+import { nextId, MAX_DEPTH, setUserProperty } from './parser'
 import { parseRelationship } from './parser-relationship'
 
 type Element = Person | SoftwareSystem | Container | Component
@@ -622,17 +622,17 @@ function parsePropertiesBlock(p: ContextAwareParser, element: Element): void {
             val = p.advance().value
         }
         if (val === undefined) continue
-        // Recognized: c4hero.location → element.location for persons/systems
-        if (key === 'c4hero.location' && (element.type === 'person' || element.type === 'softwareSystem')) {
-            if (val === 'External') (element as Person | SoftwareSystem).location = 'External'
-            else if (val === 'Internal') (element as Person | SoftwareSystem).location = 'Internal'
+        // Recognized: c4hero.location → element.location for persons/systems.
+        // Hoist only a valid, hoistable value into a still-unset field; any
+        // other combination stays a plain property so no value is silently
+        // lost (same rule as the c4hero.status hoist).
+        if (key === 'c4hero.location'
+            && (element.type === 'person' || element.type === 'softwareSystem')
+            && (val === 'External' || val === 'Internal')
+            && (element as Person | SoftwareSystem).location === undefined) {
+            (element as Person | SoftwareSystem).location = val
         } else {
-            // Generic passthrough to properties map. defineProperty, not
-            // assignment: a "__proto__" key would otherwise set the object's
-            // prototype instead of storing the property.
-            Object.defineProperty(element.properties, key, {
-                value: val, enumerable: true, writable: true, configurable: true,
-            })
+            setUserProperty(element.properties, key, val)
         }
     }
 }

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -9,6 +9,32 @@ import { parseRelationship } from './parser-relationship'
 
 type Element = Person | SoftwareSystem | Container | Component
 
+/**
+ * Map Structurizr-native encodings back onto c4hero's model fields.
+ *
+ * Structurizr has no `location` keyword (externality is the `External` tag)
+ * and no `owner` keyword (ownership is a property), so the serializer emits
+ * both that way. Undo them here so a round-trip is exact, and so files
+ * authored in other Structurizr tools get the same interpretation.
+ *
+ * The legacy bare `location` / `owner` keywords are still accepted by
+ * parseElementPropertyOnElement for back-compat with older c4hero files;
+ * this runs afterwards and only fills in what those did not set.
+ */
+function applyStructurizrConventions(element: Element): void {
+    if (element.type === 'person' || element.type === 'softwareSystem') {
+        const i = element.tags.indexOf('External')
+        if (i !== -1) {
+            element.location = 'External'
+            element.tags.splice(i, 1)
+        }
+    }
+    if (element.properties.owner !== undefined && element.owner === undefined) {
+        element.owner = element.properties.owner
+        delete element.properties.owner
+    }
+}
+
 export function parseModelBody(p: ContextAwareParser, model: Model, groupRefIds?: string[]): void {
     p.depth++
     if (p.depth > MAX_DEPTH) { p.addError('Maximum nesting depth exceeded', p.peek()); p.depth--; return }
@@ -195,6 +221,7 @@ function parsePerson(p: ContextAwareParser, varName?: string): Person | null {
         p.expect('RBRACE')
     }
 
+    applyStructurizrConventions(person)
     return person
 }
 
@@ -225,6 +252,7 @@ function parseSoftwareSystem(p: ContextAwareParser, varName?: string, model?: Mo
         p.expect('RBRACE')
     }
 
+    applyStructurizrConventions(sys)
     return sys
 }
 
@@ -351,6 +379,7 @@ function parseContainer(p: ContextAwareParser, varName?: string, model?: Model, 
         p.expect('RBRACE')
     }
 
+    applyStructurizrConventions(container)
     return container
 }
 
@@ -465,6 +494,7 @@ function parseComponent(p: ContextAwareParser, varName?: string, parentPath?: st
         p.expect('RBRACE')
     }
 
+    applyStructurizrConventions(component)
     return component
 }
 

--- a/src/lib/dsl/parser-relationship.ts
+++ b/src/lib/dsl/parser-relationship.ts
@@ -164,5 +164,32 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
         p.expect('RBRACE')
     }
 
+    applyRelationshipConventions(rel)
     return rel
+}
+
+/**
+ * Hoist the property-encoded `lineStyle` / `interactionStyle` back onto the
+ * relationship fields. Structurizr rejects both as bare keywords in a
+ * relationship body, so the serializer emits them as `c4hero.lineStyle` /
+ * `c4hero.interactionStyle` properties. The legacy bare keywords are still
+ * accepted by the block parser above and win when both forms appear; only
+ * valid enum members are hoisted — anything else stays a plain property so no
+ * value is silently lost.
+ */
+function applyRelationshipConventions(rel: Relationship): void {
+    const lineStyle = rel.properties['c4hero.lineStyle']
+    if (lineStyle !== undefined && rel.lineStyle === undefined) {
+        if (lineStyle === 'Curved' || lineStyle === 'Straight' || lineStyle === 'Orthogonal') {
+            rel.lineStyle = lineStyle
+            delete rel.properties['c4hero.lineStyle']
+        }
+    }
+    const interactionStyle = rel.properties['c4hero.interactionStyle']
+    if (interactionStyle !== undefined && rel.interactionStyle === undefined) {
+        if (interactionStyle === 'Synchronous' || interactionStyle === 'Asynchronous') {
+            rel.interactionStyle = interactionStyle
+            delete rel.properties['c4hero.interactionStyle']
+        }
+    }
 }

--- a/src/lib/dsl/parser-relationship.ts
+++ b/src/lib/dsl/parser-relationship.ts
@@ -97,7 +97,12 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
                         const key = p.advance().value
                         const valTok = p.peek()
                         if (valTok.type === 'STRING' || valTok.type === 'IDENTIFIER' || valTok.type === 'NUMBER') {
-                            rel.properties[key] = p.advance().value
+                            // defineProperty, not assignment: a "__proto__"
+                            // key would otherwise set the object's prototype
+                            // instead of storing the property.
+                            Object.defineProperty(rel.properties, key, {
+                                value: p.advance().value, enumerable: true, writable: true, configurable: true,
+                            })
                         }
                     }
                     if (p.check('RBRACE')) p.advance()

--- a/src/lib/dsl/parser-relationship.ts
+++ b/src/lib/dsl/parser-relationship.ts
@@ -1,6 +1,7 @@
 // DSL parser — relationship statement (`a -> b "..."`) handling.
 
-import type { Relationship, InteractionStyle, LineStyle } from '@/types/model'
+import type { Relationship } from '@/types/model'
+import { isInteractionStyle, isLineStyle } from '@/types/model'
 import type { ContextAwareParser } from './parser'
 
 export function parseRelationship(p: ContextAwareParser): Relationship | null {
@@ -110,8 +111,8 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
                 const valTok = p.peek()
                 if (valTok.type === 'IDENTIFIER' || valTok.type === 'KEYWORD') {
                     const raw = p.advance().value
-                    if (raw === 'Synchronous' || raw === 'Asynchronous') {
-                        rel.interactionStyle = raw as InteractionStyle
+                    if (isInteractionStyle(raw)) {
+                        rel.interactionStyle = raw
                     }
                 }
                 continue
@@ -144,8 +145,8 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
                 const valTok = p.peek()
                 if (valTok.type === 'IDENTIFIER' || valTok.type === 'KEYWORD') {
                     const raw = p.advance().value
-                    if (raw === 'Curved' || raw === 'Straight' || raw === 'Orthogonal') {
-                        rel.lineStyle = raw as LineStyle
+                    if (isLineStyle(raw)) {
+                        rel.lineStyle = raw
                     }
                 }
                 continue
@@ -179,17 +180,13 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
  */
 function applyRelationshipConventions(rel: Relationship): void {
     const lineStyle = rel.properties['c4hero.lineStyle']
-    if (lineStyle !== undefined && rel.lineStyle === undefined) {
-        if (lineStyle === 'Curved' || lineStyle === 'Straight' || lineStyle === 'Orthogonal') {
-            rel.lineStyle = lineStyle
-            delete rel.properties['c4hero.lineStyle']
-        }
+    if (lineStyle !== undefined && rel.lineStyle === undefined && isLineStyle(lineStyle)) {
+        rel.lineStyle = lineStyle
+        delete rel.properties['c4hero.lineStyle']
     }
     const interactionStyle = rel.properties['c4hero.interactionStyle']
-    if (interactionStyle !== undefined && rel.interactionStyle === undefined) {
-        if (interactionStyle === 'Synchronous' || interactionStyle === 'Asynchronous') {
-            rel.interactionStyle = interactionStyle
-            delete rel.properties['c4hero.interactionStyle']
-        }
+    if (interactionStyle !== undefined && rel.interactionStyle === undefined && isInteractionStyle(interactionStyle)) {
+        rel.interactionStyle = interactionStyle
+        delete rel.properties['c4hero.interactionStyle']
     }
 }

--- a/src/lib/dsl/parser-relationship.ts
+++ b/src/lib/dsl/parser-relationship.ts
@@ -3,6 +3,7 @@
 import type { Relationship } from '@/types/model'
 import { isInteractionStyle, isLineStyle } from '@/types/model'
 import type { ContextAwareParser } from './parser'
+import { setUserProperty } from './parser'
 
 export function parseRelationship(p: ContextAwareParser): Relationship | null {
     // Both endpoints may be qualified paths (`mpng.gatewayApi`,
@@ -97,12 +98,7 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
                         const key = p.advance().value
                         const valTok = p.peek()
                         if (valTok.type === 'STRING' || valTok.type === 'IDENTIFIER' || valTok.type === 'NUMBER') {
-                            // defineProperty, not assignment: a "__proto__"
-                            // key would otherwise set the object's prototype
-                            // instead of storing the property.
-                            Object.defineProperty(rel.properties, key, {
-                                value: p.advance().value, enumerable: true, writable: true, configurable: true,
-                            })
+                            setUserProperty(rel.properties, key, p.advance().value)
                         }
                     }
                     if (p.check('RBRACE')) p.advance()

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -137,6 +137,15 @@ export function nextId(): string {
 
 export const MAX_DEPTH = 50
 
+/**
+ * Store a parsed user property. defineProperty, not assignment: a
+ * "__proto__" key would otherwise set the object's prototype instead of
+ * storing the property. Every properties-block parser must use this.
+ */
+export function setUserProperty(props: Record<string, string>, key: string, value: string): void {
+    Object.defineProperty(props, key, { value, enumerable: true, writable: true, configurable: true })
+}
+
 export class ContextAwareParser {
     tokens: Token[]
     pos = 0

--- a/src/lib/dsl/placeholder-args.test.ts
+++ b/src/lib/dsl/placeholder-args.test.ts
@@ -78,7 +78,9 @@ workspace {
     expect(errors).toEqual([])
     const sys = workspace.model.softwareSystems[0]
     expect(sys.description).toBeUndefined()
-    expect(sys.tags).toContain('External')
+    // `External` is Structurizr's externality marker, so it lands on the
+    // location field rather than staying an opaque tag.
+    expect(sys.location).toBe('External')
   })
 
   it('relationship with empty description placeholder has undefined description', () => {

--- a/src/lib/dsl/serializer.test.ts
+++ b/src/lib/dsl/serializer.test.ts
@@ -199,14 +199,15 @@ describe('Serializer — escaping special characters', () => {
     expect(dsl).toContain('\\"special\\"')
   })
 
-  it('escapes backslash characters in names', () => {
+  it('emits an interior backslash verbatim, not doubled', () => {
     const ws = makeWorkspace()
     ws.model.people.push({
       id: 'bp', type: 'person', name: 'Alice\\Bob', tags: ['Element', 'Person'], properties: {},
     })
     const dsl = serializeDSL(ws)
-    // Backslash must be doubled in the serialized output
-    expect(dsl).toContain('person "Alice\\\\Bob"')
+    // Structurizr does not collapse \\, so doubling would store two
+    // backslashes. A backslash not followed by " or n is literal.
+    expect(dsl).toContain('person "Alice\\Bob"')
   })
 
   it('backslash in name survives serialize → parse roundtrip', () => {

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -121,13 +121,41 @@ class SerializerContext {
     }
 
     /**
-     * Properties to emit. `owner` is not a Structurizr keyword, so it travels
-     * inside the `properties` block; the parser hoists it back to the field.
+     * Properties to emit for an element. `owner` and `status` are not
+     * Structurizr keywords (the real parser rejects them inside an element
+     * block), so they travel inside the `properties` block — `owner` under the
+     * bare `owner` key, `status` under `c4hero.status`; the parser hoists both
+     * back to their fields. Derived keys are emitted first and win over a
+     * colliding user property, so serialize → parse → serialize is
+     * byte-identical.
      */
-    private ownerAwareProperties(
-        el: { owner?: string; properties: Record<string, string> },
+    private elementProperties(
+        el: { owner?: string; status?: string; properties: Record<string, string> },
     ): Record<string, string> {
-        return el.owner ? { ...el.properties, owner: el.owner } : el.properties
+        const props: Record<string, string> = {}
+        if (el.owner) props.owner = el.owner
+        if (el.status) props['c4hero.status'] = el.status
+        for (const [key, val] of Object.entries(el.properties)) {
+            if (!(key in props)) props[key] = val
+        }
+        return props
+    }
+
+    /**
+     * Properties to emit for a relationship. `lineStyle` and `interactionStyle`
+     * are not Structurizr keywords in a relationship body (the real parser
+     * rejects them), so they travel as `c4hero.lineStyle` /
+     * `c4hero.interactionStyle` properties, with the same derived-first,
+     * derived-wins rules as elementProperties().
+     */
+    private relationshipProperties(rel: Relationship): Record<string, string> {
+        const props: Record<string, string> = {}
+        if (rel.lineStyle) props['c4hero.lineStyle'] = rel.lineStyle
+        if (rel.interactionStyle) props['c4hero.interactionStyle'] = rel.interactionStyle
+        for (const [key, val] of Object.entries(rel.properties)) {
+            if (!(key in props)) props[key] = val
+        }
+        return props
     }
 
     /** Emit a `properties { }` block for any user-defined key/value pairs. */
@@ -236,9 +264,9 @@ class SerializerContext {
     private serializePerson(person: Person): void {
         const varName = this.idToVar.get(person.id)
         const extraTags = this.locationAwareTags(person, ['Element', 'Person'])
-        const props = this.ownerAwareProperties(person)
+        const props = this.elementProperties(person)
         const hasProperties = Object.keys(props).length > 0
-        const hasBlock = !!person.url || !!person.status || hasProperties
+        const hasBlock = !!person.url || hasProperties
 
         const parts: string[] = []
         parts.push('person')
@@ -254,7 +282,6 @@ class SerializerContext {
             this.emit(`${prefix}${parts.join(' ')} {`)
             this.depth++
             if (person.url) this.emit(`url "${this.escapeString(person.url)}"`)
-            if (person.status) this.emit(`status ${person.status}`)
             if (hasProperties) this.serializeProperties(props)
             this.depth--
             this.emit('}')
@@ -266,9 +293,9 @@ class SerializerContext {
     private serializeSoftwareSystem(sys: SoftwareSystem): void {
         const varName = this.idToVar.get(sys.id)
         const extraTags = this.locationAwareTags(sys, ['Element', 'Software System'])
-        const props = this.ownerAwareProperties(sys)
+        const props = this.elementProperties(sys)
         const hasProperties = Object.keys(props).length > 0
-        const hasBody = sys.containers.length > 0 || !!sys.url || !!sys.status || hasProperties
+        const hasBody = sys.containers.length > 0 || !!sys.url || hasProperties
 
         const parts: string[] = []
         parts.push('softwareSystem')
@@ -285,7 +312,6 @@ class SerializerContext {
             this.depth++
 
             if (sys.url) this.emit(`url "${this.escapeString(sys.url)}"`)
-            if (sys.status) this.emit(`status ${sys.status}`)
             if (hasProperties) this.serializeProperties(props)
 
             for (let i = 0; i < sys.containers.length; i++) {
@@ -303,9 +329,9 @@ class SerializerContext {
     private serializeContainer(container: Container): void {
         const varName = this.idToVar.get(container.id)
         const extraTags = this.getExtraTags(container.tags, ['Element', 'Container'])
-        const props = this.ownerAwareProperties(container)
+        const props = this.elementProperties(container)
         const hasProperties = Object.keys(props).length > 0
-        const hasBody = container.components.length > 0 || !!container.url || !!container.status || hasProperties
+        const hasBody = container.components.length > 0 || !!container.url || hasProperties
 
         const parts: string[] = []
         parts.push('container')
@@ -325,7 +351,6 @@ class SerializerContext {
             this.depth++
 
             if (container.url) this.emit(`url "${this.escapeString(container.url)}"`)
-            if (container.status) this.emit(`status ${container.status}`)
             if (hasProperties) this.serializeProperties(props)
             for (const comp of container.components) {
                 this.serializeComponent(comp)
@@ -341,9 +366,9 @@ class SerializerContext {
     private serializeComponent(comp: Component): void {
         const varName = this.idToVar.get(comp.id)
         const extraTags = this.getExtraTags(comp.tags, ['Element', 'Component'])
-        const props = this.ownerAwareProperties(comp)
+        const props = this.elementProperties(comp)
         const hasProperties = Object.keys(props).length > 0
-        const hasBlock = !!comp.url || !!comp.status || hasProperties
+        const hasBlock = !!comp.url || hasProperties
 
         const parts: string[] = []
         parts.push('component')
@@ -362,7 +387,6 @@ class SerializerContext {
             this.emit(`${prefix}${parts.join(' ')} {`)
             this.depth++
             if (comp.url) this.emit(`url "${this.escapeString(comp.url)}"`)
-            if (comp.status) this.emit(`status ${comp.status}`)
             if (hasProperties) this.serializeProperties(props)
             this.depth--
             this.emit('}')
@@ -383,17 +407,17 @@ class SerializerContext {
         if (rel.technology) parts.push(`"${this.escapeString(rel.technology)}"`)
 
         const extraTags = this.getExtraTags(rel.tags, ['Relationship'])
-        const hasProperties = Object.keys(rel.properties).length > 0
-        const needsBlock = !!rel.interactionStyle || !!rel.url || !!rel.lineStyle || hasProperties
+        const props = this.relationshipProperties(rel)
+        const hasProperties = Object.keys(props).length > 0
+        const needsBlock = !!rel.url || hasProperties
 
         if (needsBlock) {
-            // Use block form when interactionStyle, url, lineStyle, or properties are present
+            // Use block form when url or properties (including the folded-in
+            // lineStyle/interactionStyle) are present
             this.emit(`${parts.join(' ')} {`)
             this.depth++
             if (rel.url) this.emit(`url "${this.escapeString(rel.url)}"`)
-            if (rel.interactionStyle) this.emit(`interactionStyle ${rel.interactionStyle}`)
-            if (rel.lineStyle) this.emit(`lineStyle ${rel.lineStyle}`)
-            if (hasProperties) this.serializeProperties(rel.properties)
+            if (hasProperties) this.serializeProperties(props)
             if (extraTags) this.emit(`tags "${extraTags}"`)
             this.depth--
             this.emit('}')
@@ -620,14 +644,19 @@ class SerializerContext {
      * Structurizr's tokenizer (verified against structurizr-java 5.0.2)
      * recognises exactly two escapes inside a quoted string: `\"` and `\n`.
      * Every other backslash is kept verbatim — `\\` is NOT collapsed to a
-     * single backslash the way JSON does it. Emitting JSON-style escapes
-     * therefore corrupts the value rather than protecting it.
+     * single backslash the way JSON does it, and after a missed escape the
+     * tokenizer consumes only the backslash, re-examining the next char.
+     * Emitting JSON-style escapes therefore corrupts the value rather than
+     * protecting it.
      *
-     * Because there is no way to escape a backslash, a backslash is
-     * unrepresentable in the two positions where it would be read as the
-     * start of an escape:
+     * A backslash before a quote IS representable: the quote's own `\"`
+     * escape leaves the backslash a literal miss, so raw `a\"b` emits as
+     * `a\\"b` and decodes back exactly. Because there is no way to escape a
+     * backslash itself, it stays unrepresentable in two positions where it
+     * would be read as (part of) an escape:
      *
-     *   - immediately before a `"` or an `n`, and
+     *   - immediately before an `n` (any run length — `\\n` still decodes
+     *     as literal-backslash + newline), and
      *   - at the very end of the value, where it escapes the closing quote
      *     and swallows the rest of the line ("Too many tokens").
      *
@@ -635,7 +664,7 @@ class SerializerContext {
      */
     private escapeString(s: string): string {
         return s
-            .replace(/\\+(?=["n])/g, '')
+            .replace(/\\+(?=n)/g, '')
             .replace(/\\+$/, '')
             .replace(/"/g, '\\"')
             .replace(/\r\n|\r|\n/g, '\\n')

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -114,9 +114,16 @@ class SerializerContext {
         el: { tags: string[]; location?: string },
         defaults: string[],
     ): string | undefined {
-        const tags = el.location === 'External' && !el.tags.includes('External')
-            ? [...el.tags, 'External']
-            : el.tags
+        let tags = el.tags
+        if (el.location === 'External' && !tags.includes('External')) {
+            tags = [...tags, 'External']
+        } else if (el.location === 'Internal' && tags.includes('External')) {
+            // Contradictory combination (explicit Internal + an External user
+            // tag, only reachable via legacy files): emitting the tag would
+            // flip the element to External on the next parse. The explicit
+            // field wins; the tag is dropped.
+            tags = tags.filter(t => t !== 'External')
+        }
         return this.getExtraTags(tags, defaults)
     }
 
@@ -125,14 +132,18 @@ class SerializerContext {
      * Structurizr keywords (the real parser rejects them inside an element
      * block), so they travel inside the `properties` block — `owner` under the
      * bare `owner` key, `status` under `c4hero.status`; the parser hoists both
-     * back to their fields. Derived keys are emitted first and win over a
-     * colliding user property, so serialize → parse → serialize is
-     * byte-identical.
+     * back to their fields. Derived keys are emitted first and deliberately
+     * win over a colliding user property (the collision is only reachable by
+     * hand-writing a reserved key next to the legacy bare keyword), so
+     * serialize → parse → serialize is byte-identical.
      */
     private elementProperties(
         el: { owner?: string; status?: string; properties: Record<string, string> },
     ): Record<string, string> {
-        const props: Record<string, string> = {}
+        // Null prototype: with a plain literal, `key in props` would also
+        // match inherited keys (`constructor`, `toString`, ...) and silently
+        // drop a user property with that name.
+        const props: Record<string, string> = Object.create(null)
         if (el.owner) props.owner = el.owner
         if (el.status) props['c4hero.status'] = el.status
         for (const [key, val] of Object.entries(el.properties)) {
@@ -149,7 +160,7 @@ class SerializerContext {
      * derived-wins rules as elementProperties().
      */
     private relationshipProperties(rel: Relationship): Record<string, string> {
-        const props: Record<string, string> = {}
+        const props: Record<string, string> = Object.create(null)
         if (rel.lineStyle) props['c4hero.lineStyle'] = rel.lineStyle
         if (rel.interactionStyle) props['c4hero.interactionStyle'] = rel.interactionStyle
         for (const [key, val] of Object.entries(rel.properties)) {
@@ -661,6 +672,7 @@ class SerializerContext {
      *     and swallows the rest of the line ("Too many tokens").
      *
      * Those backslashes are dropped. Everything else round-trips exactly.
+     * The drop is silent for now; surfacing a save-time warning is TEA-169.
      */
     private escapeString(s: string): string {
         return s
@@ -682,8 +694,9 @@ class SerializerContext {
 
     /**
      * Structurizr splits a tag string on commas, so a tag containing a comma
-     * would silently become two tags. Drop commas rather than corrupt the set.
-     * Values still go through escapeString like every other quoted string.
+     * would silently become two tags. Drop commas rather than corrupt the set
+     * (warning the user about the rename is TEA-169). Values still go through
+     * escapeString like every other quoted string.
      */
     private getExtraTags(tags: string[], defaults: string[]): string | undefined {
         const extra = tags

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -117,11 +117,11 @@ class SerializerContext {
         let tags = el.tags
         if (el.location === 'External' && !tags.includes('External')) {
             tags = [...tags, 'External']
-        } else if (el.location === 'Internal' && tags.includes('External')) {
-            // Contradictory combination (explicit Internal + an External user
-            // tag, only reachable via legacy files): emitting the tag would
-            // flip the element to External on the next parse. The explicit
-            // field wins; the tag is dropped.
+        } else if (el.location !== undefined && el.location !== 'External' && tags.includes('External')) {
+            // Contradictory combination (an explicit non-External location —
+            // Internal or Unspecified — plus an External user tag): emitting
+            // the tag would flip the element to External on the next parse.
+            // The explicit field wins; the tag is dropped.
             tags = tags.filter(t => t !== 'External')
         }
         return this.getExtraTags(tags, defaults)
@@ -140,16 +140,10 @@ class SerializerContext {
     private elementProperties(
         el: { owner?: string; status?: string; properties: Record<string, string> },
     ): Record<string, string> {
-        // Null prototype: with a plain literal, `key in props` would also
-        // match inherited keys (`constructor`, `toString`, ...) and silently
-        // drop a user property with that name.
-        const props: Record<string, string> = Object.create(null)
-        if (el.owner) props.owner = el.owner
-        if (el.status) props['c4hero.status'] = el.status
-        for (const [key, val] of Object.entries(el.properties)) {
-            if (!(key in props)) props[key] = val
-        }
-        return props
+        return this.mergeDerivedProperties(
+            [['owner', el.owner], ['c4hero.status', el.status]],
+            el.properties,
+        )
     }
 
     /**
@@ -160,10 +154,27 @@ class SerializerContext {
      * derived-wins rules as elementProperties().
      */
     private relationshipProperties(rel: Relationship): Record<string, string> {
+        return this.mergeDerivedProperties(
+            [['c4hero.lineStyle', rel.lineStyle], ['c4hero.interactionStyle', rel.interactionStyle]],
+            rel.properties,
+        )
+    }
+
+    /**
+     * Merge derived (field-encoded) keys ahead of user properties. Null
+     * prototype so `key in props` cannot match inherited names like
+     * `constructor`; a derived key deliberately wins over a colliding user
+     * property so serialize → parse → serialize stays byte-identical.
+     */
+    private mergeDerivedProperties(
+        derived: ReadonlyArray<readonly [string, string | undefined]>,
+        user: Record<string, string>,
+    ): Record<string, string> {
         const props: Record<string, string> = Object.create(null)
-        if (rel.lineStyle) props['c4hero.lineStyle'] = rel.lineStyle
-        if (rel.interactionStyle) props['c4hero.interactionStyle'] = rel.interactionStyle
-        for (const [key, val] of Object.entries(rel.properties)) {
+        for (const [key, val] of derived) {
+            if (val) props[key] = val
+        }
+        for (const [key, val] of Object.entries(user)) {
             if (!(key in props)) props[key] = val
         }
         return props
@@ -589,23 +600,37 @@ class SerializerContext {
 
     // ─── Styles ─────────────────────────────────────────────────────
 
+    /**
+     * Styles whose tag survives sanitization. A selector that sanitizes to
+     * nothing (e.g. a tag of only commas) would emit `element "" {`, which
+     * the real parser rejects ("A tag must be specified") — skip it instead.
+     */
+    private emittableStyles(config: ViewConfiguration): { elements: ElementStyle[]; relationships: RelationshipStyle[] } {
+        return {
+            elements: config.styles.elements.filter(s => this.sanitizeTag(s.tag).length > 0),
+            relationships: config.styles.relationships.filter(s => this.sanitizeTag(s.tag).length > 0),
+        }
+    }
+
     private hasStyles(config: ViewConfiguration): boolean {
-        return config.styles.elements.length > 0 || config.styles.relationships.length > 0
+        const { elements, relationships } = this.emittableStyles(config)
+        return elements.length > 0 || relationships.length > 0
     }
 
     private serializeStyles(config: ViewConfiguration): void {
+        const { elements, relationships } = this.emittableStyles(config)
         this.emit('styles {')
         this.depth++
 
         let needsBlank = false
 
-        for (const style of config.styles.elements) {
+        for (const style of elements) {
             if (needsBlank) this.emitBlank()
             this.serializeElementStyle(style)
             needsBlank = true
         }
 
-        for (const style of config.styles.relationships) {
+        for (const style of relationships) {
             if (needsBlank) this.emitBlank()
             this.serializeRelationshipStyle(style)
             needsBlank = true
@@ -616,7 +641,7 @@ class SerializerContext {
     }
 
     private serializeElementStyle(style: ElementStyle): void {
-        this.emit(`element "${this.escapeStyleTag(style.tag)}" {`)
+        this.emit(`element "${this.sanitizeTag(style.tag)}" {`)
         this.depth++
 
         if (style.background !== undefined) this.emit(`background ${style.background}`)
@@ -634,7 +659,7 @@ class SerializerContext {
     }
 
     private serializeRelationshipStyle(style: RelationshipStyle): void {
-        this.emit(`relationship "${this.escapeStyleTag(style.tag)}" {`)
+        this.emit(`relationship "${this.sanitizeTag(style.tag)}" {`)
         this.depth++
 
         if (style.color !== undefined) this.emit(`color ${style.color}`)
@@ -683,25 +708,21 @@ class SerializerContext {
     }
 
     /**
-     * A style's tag selector must match the tag the element actually carries,
-     * so it goes through the same comma-stripping as getExtraTags — otherwise
-     * a style keyed on "has,comma" would silently detach from the element's
-     * renamed "hascomma" tag.
-     */
-    private escapeStyleTag(tag: string): string {
-        return this.escapeString(tag.replace(/,/g, ''))
-    }
-
-    /**
      * Structurizr splits a tag string on commas, so a tag containing a comma
      * would silently become two tags. Drop commas rather than corrupt the set
      * (warning the user about the rename is TEA-169). Values still go through
-     * escapeString like every other quoted string.
+     * escapeString like every other quoted string. Element tags and style tag
+     * selectors both use this, so a style keyed on "has,comma" stays attached
+     * to the element's renamed "hascomma" tag.
      */
+    private sanitizeTag(tag: string): string {
+        return this.escapeString(tag.replace(/,/g, ''))
+    }
+
     private getExtraTags(tags: string[], defaults: string[]): string | undefined {
         const extra = tags
             .filter(t => !defaults.includes(t))
-            .map(t => this.escapeString(t.replace(/,/g, '')))
+            .map(t => this.sanitizeTag(t))
             .filter(t => t.length > 0)
         if (extra.length === 0) return undefined
         return extra.join(',')

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -13,9 +13,36 @@ import type {
     ElementStyle,
     RelationshipStyle,
     ViewConfiguration,
+    Group,
+    ModelElement,
 } from '@/types/model'
 
 const INDENT = '    ' // 4 spaces
+const GROUP_SEPARATOR = '/'
+
+interface ScopedGroup<T extends ModelElement> {
+    group: Group
+    globalMemberIds: Set<string>
+    memberIds: Set<string>
+    members: T[]
+    children: ScopedGroup<T>[]
+    order: number
+}
+
+interface GroupScope<T extends ModelElement> {
+    ungrouped: T[]
+    roots: ScopedGroup<T>[]
+    nested: boolean
+}
+
+/** Raised when c4hero's richer boundary model cannot be represented by
+ * Structurizr's single hierarchical group path per element. */
+export class GroupSerializationError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'GroupSerializationError'
+    }
+}
 
 // ─── Public API ─────────────────────────────────────────────────────
 
@@ -37,10 +64,202 @@ class SerializerContext {
 
     // Track all element IDs for relationship serialization
     private allElementIds = new Set<string>()
+    private topLevelGroups: GroupScope<Person | SoftwareSystem>
+    private containerGroups = new Map<string, GroupScope<Container>>()
+    private componentGroups = new Map<string, GroupScope<Component>>()
+    private hasNestedGroups = false
 
     constructor(workspace: Workspace) {
         this.workspace = workspace
         this.buildIdMaps()
+        this.topLevelGroups = this.buildGroupScope(
+            [...workspace.model.people, ...workspace.model.softwareSystems],
+            true,
+        )
+        this.hasNestedGroups ||= this.topLevelGroups.nested
+        for (const sys of workspace.model.softwareSystems) {
+            const containers = this.buildGroupScope(sys.containers)
+            this.containerGroups.set(sys.id, containers)
+            this.hasNestedGroups ||= containers.nested
+            for (const container of sys.containers) {
+                const components = this.buildGroupScope(container.components)
+                this.componentGroups.set(container.id, components)
+                this.hasNestedGroups ||= components.nested
+            }
+        }
+        if (this.hasNestedGroups) {
+            const badName = workspace.model.groups.find(group => group.name.includes(GROUP_SEPARATOR))
+            if (badName) {
+                throw new GroupSerializationError(
+                    `Cannot export nested group "${badName.name}": group names may not contain `
+                    + `the configured separator "${GROUP_SEPARATOR}". Rename the group first.`,
+                )
+            }
+        }
+    }
+
+    /**
+     * Project flat c4hero group membership into the one group path Structurizr
+     * permits at a single abstraction scope. Disjoint sets are siblings and a
+     * proper subset is a nested group. Explicit parentId retains nesting when
+     * parent and child aggregate to equal sets; unrelated crossing or equal
+     * sets would require two paths, so fail instead of silently degrading the
+     * exported model.
+     */
+    private buildGroupScope<T extends ModelElement>(
+        elements: T[],
+        includeGloballyEmpty = false,
+    ): GroupScope<T> {
+        const elementIds = new Set(elements.map(element => element.id))
+        const groups: ScopedGroup<T>[] = this.workspace.model.groups
+            .map((group, order) => ({
+                group,
+                globalMemberIds: new Set(group.elementIds),
+                memberIds: new Set(group.elementIds.filter(id => elementIds.has(id))),
+                members: [],
+                children: [],
+                order,
+            }))
+            .filter(scoped => scoped.memberIds.size > 0 || (includeGloballyEmpty && scoped.group.elementIds.length === 0))
+
+        const allGroupsById = new Map(this.workspace.model.groups.map(group => [group.id, group]))
+        const scopedById = new Map(groups.map(group => [group.group.id, group]))
+        for (const scoped of groups) {
+            const seen = new Set([scoped.group.id])
+            let parentId = scoped.group.parentId
+            while (parentId) {
+                if (seen.has(parentId)) {
+                    throw new GroupSerializationError(
+                        `Cannot export group "${scoped.group.name}": its parent hierarchy contains a cycle.`,
+                    )
+                }
+                seen.add(parentId)
+                const parent = allGroupsById.get(parentId)
+                if (!parent) {
+                    throw new GroupSerializationError(
+                        `Cannot export group "${scoped.group.name}": parent group ${parentId} does not exist.`,
+                    )
+                }
+                parentId = parent.parentId
+            }
+        }
+        const isExplicitDescendant = (child: Group, ancestor: Group): boolean => {
+            const seen = new Set<string>()
+            let parentId = child.parentId
+            while (parentId) {
+                if (parentId === ancestor.id) return true
+                if (seen.has(parentId)) {
+                    throw new GroupSerializationError(
+                        `Cannot export group "${child.name}": its parent hierarchy contains a cycle.`,
+                    )
+                }
+                seen.add(parentId)
+                const parent = allGroupsById.get(parentId)
+                if (!parent) {
+                    throw new GroupSerializationError(
+                        `Cannot export group "${child.name}": parent group ${parentId} does not exist.`,
+                    )
+                }
+                parentId = parent.parentId
+            }
+            return false
+        }
+
+        for (const child of groups) {
+            if (!child.group.parentId) continue
+            const explicitParent = allGroupsById.get(child.group.parentId)
+            if (!explicitParent) {
+                throw new GroupSerializationError(
+                    `Cannot export group "${child.group.name}": parent group ${child.group.parentId} does not exist.`,
+                )
+            }
+            const parentIds = new Set(explicitParent.elementIds)
+            if (![...child.globalMemberIds].every(id => parentIds.has(id))) {
+                throw new GroupSerializationError(
+                    `Cannot export nested group "${child.group.name}": its parent "${explicitParent.name}" `
+                    + 'does not contain all of its members.',
+                )
+            }
+        }
+
+        for (let i = 0; i < groups.length; i++) {
+            for (let j = i + 1; j < groups.length; j++) {
+                const a = groups[i]
+                const b = groups[j]
+                const intersection = [...a.memberIds].filter(id => b.memberIds.has(id))
+                if (intersection.length === 0) continue
+
+                if (isExplicitDescendant(a.group, b.group) || isExplicitDescendant(b.group, a.group)) continue
+
+                const aInsideB = a.globalMemberIds.size < b.globalMemberIds.size
+                    && [...a.globalMemberIds].every(id => b.globalMemberIds.has(id))
+                const bInsideA = b.globalMemberIds.size < a.globalMemberIds.size
+                    && [...b.globalMemberIds].every(id => a.globalMemberIds.has(id))
+                if (aInsideB || bInsideA) continue
+
+                const names = intersection.map(id => this.elementName(id)).join(', ')
+                throw new GroupSerializationError(
+                    `Cannot export groups "${a.group.name}" and "${b.group.name}": `
+                    + `${names} ${intersection.length === 1 ? 'belongs' : 'belong'} to both groups, `
+                    + 'but neither group is nested inside the other. Make the groups disjoint or one a strict subset of the other.',
+                )
+            }
+        }
+
+        const parent = new Map<ScopedGroup<T>, ScopedGroup<T>>()
+        for (const child of groups) {
+            if (child.group.parentId) {
+                const explicitParent = scopedById.get(child.group.parentId)
+                if (explicitParent) {
+                    parent.set(child, explicitParent)
+                    continue
+                }
+            }
+            const candidates = groups
+                .filter(candidate => candidate !== child
+                    && child.globalMemberIds.size < candidate.globalMemberIds.size
+                    && [...child.globalMemberIds].every(id => candidate.globalMemberIds.has(id)))
+                .sort((a, b) => a.globalMemberIds.size - b.globalMemberIds.size || a.order - b.order)
+            if (candidates[0]) parent.set(child, candidates[0])
+        }
+
+        for (const group of groups) {
+            const p = parent.get(group)
+            if (p) p.children.push(group)
+        }
+        for (const group of groups) group.children.sort((a, b) => a.order - b.order)
+
+        for (const element of elements) {
+            const memberships = groups
+                .filter(group => group.memberIds.has(element.id))
+                .sort((a, b) => {
+                    if (isExplicitDescendant(a.group, b.group)) return -1
+                    if (isExplicitDescendant(b.group, a.group)) return 1
+                    return a.globalMemberIds.size - b.globalMemberIds.size || a.order - b.order
+                })
+            if (memberships[0]) memberships[0].members.push(element)
+        }
+
+        const ungrouped = elements.filter(element => !groups.some(group => group.memberIds.has(element.id)))
+        const roots = groups.filter(group => !parent.has(group)).sort((a, b) => a.order - b.order)
+        const nested = parent.size > 0
+
+        return { ungrouped, roots, nested }
+    }
+
+    private elementName(id: string): string {
+        for (const person of this.workspace.model.people) {
+            if (person.id === id) return `"${person.name}"`
+        }
+        for (const sys of this.workspace.model.softwareSystems) {
+            if (sys.id === id) return `"${sys.name}"`
+            for (const container of sys.containers) {
+                if (container.id === id) return `"${container.name}"`
+                const component = container.components.find(item => item.id === id)
+                if (component) return `"${component.name}"`
+            }
+        }
+        return `element ${id}`
     }
 
     private buildIdMaps(): void {
@@ -250,34 +469,12 @@ class SerializerContext {
 
         const model = this.workspace.model
 
-        // People
-        for (const person of model.people) {
-            this.serializePerson(person)
-        }
-
-        if (model.people.length > 0 && model.softwareSystems.length > 0) {
+        if (this.hasNestedGroups) {
+            this.serializeProperties({ 'structurizr.groupSeparator': GROUP_SEPARATOR })
             this.emitBlank()
         }
 
-        // Software Systems
-        for (let i = 0; i < model.softwareSystems.length; i++) {
-            if (i > 0) this.emitBlank()
-            this.serializeSoftwareSystem(model.softwareSystems[i])
-        }
-
-        // Groups
-        if (model.groups.length > 0) {
-            this.emitBlank()
-            for (const group of model.groups) {
-                this.emit(`group "${this.escapeString(group.name)}" {`)
-                this.depth++
-                for (const elementId of group.elementIds) {
-                    this.emit(this.idToVar.get(elementId) ?? elementId)
-                }
-                this.depth--
-                this.emit('}')
-            }
-        }
+        this.serializeGroupScope(this.topLevelGroups, element => this.serializeModelElement(element))
 
         // Relationships
         if (model.relationships.length > 0) {
@@ -289,6 +486,49 @@ class SerializerContext {
 
         this.depth--
         this.emit('}')
+    }
+
+    private serializeGroupScope<T extends ModelElement>(
+        scope: GroupScope<T>,
+        serializeElement: (element: T) => void,
+    ): void {
+        let emitted = false
+        for (const group of scope.roots) {
+            if (emitted) this.emitBlank()
+            this.serializeGroup(group, serializeElement)
+            emitted = true
+        }
+        if (emitted && scope.ungrouped.length > 0) this.emitBlank()
+        for (const element of scope.ungrouped) {
+            serializeElement(element)
+            emitted = true
+        }
+    }
+
+    private serializeGroup<T extends ModelElement>(
+        scoped: ScopedGroup<T>,
+        serializeElement: (element: T) => void,
+    ): void {
+        this.emit(`group "${this.escapeString(scoped.group.name)}" {`)
+        this.depth++
+        let emitted = false
+        for (const child of scoped.children) {
+            if (emitted) this.emitBlank()
+            this.serializeGroup(child, serializeElement)
+            emitted = true
+        }
+        if (emitted && scoped.members.length > 0) this.emitBlank()
+        for (const element of scoped.members) {
+            serializeElement(element)
+            emitted = true
+        }
+        this.depth--
+        this.emit('}')
+    }
+
+    private serializeModelElement(element: Person | SoftwareSystem): void {
+        if (element.type === 'person') this.serializePerson(element)
+        else this.serializeSoftwareSystem(element)
     }
 
     private serializePerson(person: Person): void {
@@ -344,10 +584,8 @@ class SerializerContext {
             if (sys.url) this.emit(`url "${this.escapeString(sys.url)}"`)
             if (hasProperties) this.serializeProperties(props)
 
-            for (let i = 0; i < sys.containers.length; i++) {
-                if (i > 0) this.emitBlank()
-                this.serializeContainer(sys.containers[i])
-            }
+            const scope = this.containerGroups.get(sys.id)
+            if (scope) this.serializeGroupScope(scope, container => this.serializeContainer(container))
 
             this.depth--
             this.emit('}')
@@ -382,9 +620,8 @@ class SerializerContext {
 
             if (container.url) this.emit(`url "${this.escapeString(container.url)}"`)
             if (hasProperties) this.serializeProperties(props)
-            for (const comp of container.components) {
-                this.serializeComponent(comp)
-            }
+            const scope = this.componentGroups.get(container.id)
+            if (scope) this.serializeGroupScope(scope, comp => this.serializeComponent(comp))
 
             this.depth--
             this.emit('}')

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -605,7 +605,7 @@ class SerializerContext {
     }
 
     private serializeElementStyle(style: ElementStyle): void {
-        this.emit(`element "${this.escapeString(style.tag)}" {`)
+        this.emit(`element "${this.escapeStyleTag(style.tag)}" {`)
         this.depth++
 
         if (style.background !== undefined) this.emit(`background ${style.background}`)
@@ -623,7 +623,7 @@ class SerializerContext {
     }
 
     private serializeRelationshipStyle(style: RelationshipStyle): void {
-        this.emit(`relationship "${this.escapeString(style.tag)}" {`)
+        this.emit(`relationship "${this.escapeStyleTag(style.tag)}" {`)
         this.depth++
 
         if (style.color !== undefined) this.emit(`color ${style.color}`)
@@ -668,6 +668,16 @@ class SerializerContext {
             .replace(/\\+$/, '')
             .replace(/"/g, '\\"')
             .replace(/\r\n|\r|\n/g, '\\n')
+    }
+
+    /**
+     * A style's tag selector must match the tag the element actually carries,
+     * so it goes through the same comma-stripping as getExtraTags — otherwise
+     * a style keyed on "has,comma" would silently detach from the element's
+     * renamed "hascomma" tag.
+     */
+    private escapeStyleTag(tag: string): string {
+        return this.escapeString(tag.replace(/,/g, ''))
     }
 
     /**

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -161,18 +161,26 @@ class SerializerContext {
     }
 
     /**
-     * Merge derived (field-encoded) keys ahead of user properties. Null
-     * prototype so `key in props` cannot match inherited names like
-     * `constructor`; a derived key deliberately wins over a colliding user
-     * property so serialize → parse → serialize stays byte-identical.
+     * Merge derived (field-encoded) keys ahead of user properties. A reserved
+     * key always occupies its leading slot — filled from the field when set
+     * (deliberately winning over a colliding user property), else from a user
+     * property with that key. The fixed position matters: parsing hoists a
+     * valid reserved-key property onto its field and forgets where it sat in
+     * the block, so only a position-independent emission order keeps
+     * serialize → parse → serialize byte-identical. Null prototype so
+     * `key in props` cannot match inherited names like `constructor`.
      */
     private mergeDerivedProperties(
         derived: ReadonlyArray<readonly [string, string | undefined]>,
         user: Record<string, string>,
     ): Record<string, string> {
         const props: Record<string, string> = Object.create(null)
-        for (const [key, val] of derived) {
-            if (val) props[key] = val
+        for (const [key, fieldVal] of derived) {
+            if (fieldVal) {
+                props[key] = fieldVal
+            } else if (Object.prototype.hasOwnProperty.call(user, key)) {
+                props[key] = user[key]
+            }
         }
         for (const [key, val] of Object.entries(user)) {
             if (!(key in props)) props[key] = val
@@ -498,10 +506,11 @@ class SerializerContext {
             needsBlank = true
         }
 
-        // Styles
-        if (this.hasStyles(views.configuration)) {
+        // Styles — sanitize and filter once; emission reuses the result.
+        const styles = this.emittableStyles(views.configuration)
+        if (styles.elements.length > 0 || styles.relationships.length > 0) {
             if (needsBlank) this.emitBlank()
-            this.serializeStyles(views.configuration)
+            this.serializeStyles(styles)
             needsBlank = true
         }
 
@@ -601,38 +610,40 @@ class SerializerContext {
     // ─── Styles ─────────────────────────────────────────────────────
 
     /**
-     * Styles whose tag survives sanitization. A selector that sanitizes to
+     * Styles whose tag survives sanitization, paired with the sanitized
+     * selector so it is computed exactly once. A selector that sanitizes to
      * nothing (e.g. a tag of only commas) would emit `element "" {`, which
      * the real parser rejects ("A tag must be specified") — skip it instead.
      */
-    private emittableStyles(config: ViewConfiguration): { elements: ElementStyle[]; relationships: RelationshipStyle[] } {
+    private emittableStyles(config: ViewConfiguration): {
+        elements: Array<{ style: ElementStyle; tag: string }>
+        relationships: Array<{ style: RelationshipStyle; tag: string }>
+    } {
+        const sanitize = <T extends { tag: string }>(styles: T[]) =>
+            styles
+                .map(style => ({ style, tag: this.sanitizeTag(style.tag) }))
+                .filter(s => s.tag.length > 0)
         return {
-            elements: config.styles.elements.filter(s => this.sanitizeTag(s.tag).length > 0),
-            relationships: config.styles.relationships.filter(s => this.sanitizeTag(s.tag).length > 0),
+            elements: sanitize(config.styles.elements),
+            relationships: sanitize(config.styles.relationships),
         }
     }
 
-    private hasStyles(config: ViewConfiguration): boolean {
-        const { elements, relationships } = this.emittableStyles(config)
-        return elements.length > 0 || relationships.length > 0
-    }
-
-    private serializeStyles(config: ViewConfiguration): void {
-        const { elements, relationships } = this.emittableStyles(config)
+    private serializeStyles(styles: ReturnType<SerializerContext['emittableStyles']>): void {
         this.emit('styles {')
         this.depth++
 
         let needsBlank = false
 
-        for (const style of elements) {
+        for (const { style, tag } of styles.elements) {
             if (needsBlank) this.emitBlank()
-            this.serializeElementStyle(style)
+            this.serializeElementStyle(style, tag)
             needsBlank = true
         }
 
-        for (const style of relationships) {
+        for (const { style, tag } of styles.relationships) {
             if (needsBlank) this.emitBlank()
-            this.serializeRelationshipStyle(style)
+            this.serializeRelationshipStyle(style, tag)
             needsBlank = true
         }
 
@@ -640,8 +651,8 @@ class SerializerContext {
         this.emit('}')
     }
 
-    private serializeElementStyle(style: ElementStyle): void {
-        this.emit(`element "${this.sanitizeTag(style.tag)}" {`)
+    private serializeElementStyle(style: ElementStyle, tag: string): void {
+        this.emit(`element "${tag}" {`)
         this.depth++
 
         if (style.background !== undefined) this.emit(`background ${style.background}`)
@@ -658,8 +669,8 @@ class SerializerContext {
         this.emit('}')
     }
 
-    private serializeRelationshipStyle(style: RelationshipStyle): void {
-        this.emit(`relationship "${this.sanitizeTag(style.tag)}" {`)
+    private serializeRelationshipStyle(style: RelationshipStyle, tag: string): void {
+        this.emit(`relationship "${tag}" {`)
         this.depth++
 
         if (style.color !== undefined) this.emit(`color ${style.color}`)

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -103,6 +103,33 @@ class SerializerContext {
         }
     }
 
+    /**
+     * Tags to emit for an element that has a `location`.
+     *
+     * Structurizr removed the `location` keyword; externality is now carried
+     * by the `External` tag. c4hero keeps the field (it drives the UI and the
+     * model), and the parser maps the tag back on import.
+     */
+    private locationAwareTags(
+        el: { tags: string[]; location?: string },
+        defaults: string[],
+    ): string | undefined {
+        const tags = el.location === 'External' && !el.tags.includes('External')
+            ? [...el.tags, 'External']
+            : el.tags
+        return this.getExtraTags(tags, defaults)
+    }
+
+    /**
+     * Properties to emit. `owner` is not a Structurizr keyword, so it travels
+     * inside the `properties` block; the parser hoists it back to the field.
+     */
+    private ownerAwareProperties(
+        el: { owner?: string; properties: Record<string, string> },
+    ): Record<string, string> {
+        return el.owner ? { ...el.properties, owner: el.owner } : el.properties
+    }
+
     /** Emit a `properties { }` block for any user-defined key/value pairs. */
     private serializeProperties(props: Record<string, string>): void {
         const entries = Object.entries(props)
@@ -208,10 +235,10 @@ class SerializerContext {
 
     private serializePerson(person: Person): void {
         const varName = this.idToVar.get(person.id)
-        const extraTags = this.getExtraTags(person.tags, ['Element', 'Person'])
-        const isExternal = person.location === 'External'
-        const hasProperties = Object.keys(person.properties).length > 0
-        const hasBlock = isExternal || !!person.url || !!person.status || !!person.owner || hasProperties
+        const extraTags = this.locationAwareTags(person, ['Element', 'Person'])
+        const props = this.ownerAwareProperties(person)
+        const hasProperties = Object.keys(props).length > 0
+        const hasBlock = !!person.url || !!person.status || hasProperties
 
         const parts: string[] = []
         parts.push('person')
@@ -228,9 +255,7 @@ class SerializerContext {
             this.depth++
             if (person.url) this.emit(`url "${this.escapeString(person.url)}"`)
             if (person.status) this.emit(`status ${person.status}`)
-            if (person.owner) this.emit(`owner "${this.escapeString(person.owner)}"`)
-            if (isExternal) this.emit('location External')
-            if (hasProperties) this.serializeProperties(person.properties)
+            if (hasProperties) this.serializeProperties(props)
             this.depth--
             this.emit('}')
         } else {
@@ -240,10 +265,10 @@ class SerializerContext {
 
     private serializeSoftwareSystem(sys: SoftwareSystem): void {
         const varName = this.idToVar.get(sys.id)
-        const extraTags = this.getExtraTags(sys.tags, ['Element', 'Software System'])
-        const isExternal = sys.location === 'External'
-        const hasProperties = Object.keys(sys.properties).length > 0
-        const hasBody = sys.containers.length > 0 || isExternal || !!sys.url || !!sys.status || !!sys.owner || hasProperties
+        const extraTags = this.locationAwareTags(sys, ['Element', 'Software System'])
+        const props = this.ownerAwareProperties(sys)
+        const hasProperties = Object.keys(props).length > 0
+        const hasBody = sys.containers.length > 0 || !!sys.url || !!sys.status || hasProperties
 
         const parts: string[] = []
         parts.push('softwareSystem')
@@ -261,9 +286,7 @@ class SerializerContext {
 
             if (sys.url) this.emit(`url "${this.escapeString(sys.url)}"`)
             if (sys.status) this.emit(`status ${sys.status}`)
-            if (sys.owner) this.emit(`owner "${this.escapeString(sys.owner)}"`)
-            if (isExternal) this.emit('location External')
-            if (hasProperties) this.serializeProperties(sys.properties)
+            if (hasProperties) this.serializeProperties(props)
 
             for (let i = 0; i < sys.containers.length; i++) {
                 if (i > 0) this.emitBlank()
@@ -280,8 +303,9 @@ class SerializerContext {
     private serializeContainer(container: Container): void {
         const varName = this.idToVar.get(container.id)
         const extraTags = this.getExtraTags(container.tags, ['Element', 'Container'])
-        const hasProperties = Object.keys(container.properties).length > 0
-        const hasBody = container.components.length > 0 || !!container.url || !!container.status || !!container.owner || hasProperties
+        const props = this.ownerAwareProperties(container)
+        const hasProperties = Object.keys(props).length > 0
+        const hasBody = container.components.length > 0 || !!container.url || !!container.status || hasProperties
 
         const parts: string[] = []
         parts.push('container')
@@ -302,8 +326,7 @@ class SerializerContext {
 
             if (container.url) this.emit(`url "${this.escapeString(container.url)}"`)
             if (container.status) this.emit(`status ${container.status}`)
-            if (container.owner) this.emit(`owner "${this.escapeString(container.owner)}"`)
-            if (hasProperties) this.serializeProperties(container.properties)
+            if (hasProperties) this.serializeProperties(props)
             for (const comp of container.components) {
                 this.serializeComponent(comp)
             }
@@ -318,8 +341,9 @@ class SerializerContext {
     private serializeComponent(comp: Component): void {
         const varName = this.idToVar.get(comp.id)
         const extraTags = this.getExtraTags(comp.tags, ['Element', 'Component'])
-        const hasProperties = Object.keys(comp.properties).length > 0
-        const hasBlock = !!comp.url || !!comp.status || !!comp.owner || hasProperties
+        const props = this.ownerAwareProperties(comp)
+        const hasProperties = Object.keys(props).length > 0
+        const hasBlock = !!comp.url || !!comp.status || hasProperties
 
         const parts: string[] = []
         parts.push('component')
@@ -339,8 +363,7 @@ class SerializerContext {
             this.depth++
             if (comp.url) this.emit(`url "${this.escapeString(comp.url)}"`)
             if (comp.status) this.emit(`status ${comp.status}`)
-            if (comp.owner) this.emit(`owner "${this.escapeString(comp.owner)}"`)
-            if (hasProperties) this.serializeProperties(comp.properties)
+            if (hasProperties) this.serializeProperties(props)
             this.depth--
             this.emit('}')
         } else {
@@ -513,7 +536,9 @@ class SerializerContext {
         const parts: string[] = ['autoLayout']
 
         if (layout.direction !== 'TB' || layout.rankSeparation !== undefined || layout.nodeSeparation !== undefined) {
-            parts.push(layout.direction)
+            // Structurizr accepts only lowercase rank directions (tb|bt|lr|rl)
+            // and rejects the uppercase form c4hero stores internally.
+            parts.push(layout.direction.toLowerCase())
         }
 
         if (layout.rankSeparation !== undefined) {
@@ -589,16 +614,43 @@ class SerializerContext {
 
     // ─── Helpers ────────────────────────────────────────────────────
 
+    /**
+     * Encode a value as the body of a Structurizr double-quoted string.
+     *
+     * Structurizr's tokenizer (verified against structurizr-java 5.0.2)
+     * recognises exactly two escapes inside a quoted string: `\"` and `\n`.
+     * Every other backslash is kept verbatim — `\\` is NOT collapsed to a
+     * single backslash the way JSON does it. Emitting JSON-style escapes
+     * therefore corrupts the value rather than protecting it.
+     *
+     * Because there is no way to escape a backslash, a backslash is
+     * unrepresentable in the two positions where it would be read as the
+     * start of an escape:
+     *
+     *   - immediately before a `"` or an `n`, and
+     *   - at the very end of the value, where it escapes the closing quote
+     *     and swallows the rest of the line ("Too many tokens").
+     *
+     * Those backslashes are dropped. Everything else round-trips exactly.
+     */
     private escapeString(s: string): string {
         return s
-            .replace(/\\/g, '\\\\')
+            .replace(/\\+(?=["n])/g, '')
+            .replace(/\\+$/, '')
             .replace(/"/g, '\\"')
-            .replace(/\n/g, '\\n')
-            .replace(/\t/g, '\\t')
+            .replace(/\r\n|\r|\n/g, '\\n')
     }
 
+    /**
+     * Structurizr splits a tag string on commas, so a tag containing a comma
+     * would silently become two tags. Drop commas rather than corrupt the set.
+     * Values still go through escapeString like every other quoted string.
+     */
     private getExtraTags(tags: string[], defaults: string[]): string | undefined {
-        const extra = tags.filter(t => !defaults.includes(t))
+        const extra = tags
+            .filter(t => !defaults.includes(t))
+            .map(t => this.escapeString(t.replace(/,/g, '')))
+            .filter(t => t.length > 0)
         if (extra.length === 0) return undefined
         return extra.join(',')
     }

--- a/src/lib/dsl/status-owner-roundtrip.test.ts
+++ b/src/lib/dsl/status-owner-roundtrip.test.ts
@@ -395,6 +395,25 @@ describe('reserved property key collisions', () => {
     expect(serializeDSL(parsed)).toBe(dsl1)
   })
 
+  it('round-trips byte-identical when a hoistable user property is not first in its block', () => {
+    // The reserved key claims its leading slot even when supplied as a user
+    // property: parsing hoists it onto the field and forgets its position,
+    // so a positional emission would reorder the block on the second save.
+    const dsl1 = serializeDSL(sysWs({ properties: { z: '2', owner: 'UserValue' } }))
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.softwareSystems[0].owner).toBe('UserValue')
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('round-trips byte-identical when a hoistable relationship property is not first', () => {
+    const dsl1 = serializeDSL(relWs({ properties: { other: 'x', 'c4hero.lineStyle': 'Curved' } }))
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.relationships[0].lineStyle).toBe('Curved')
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
   it('legacy bare status keyword wins over the property form when both appear', () => {
     const dsl = `
 workspace {

--- a/src/lib/dsl/status-owner-roundtrip.test.ts
+++ b/src/lib/dsl/status-owner-roundtrip.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { parseDSL, serializeDSL } from '@/lib/dsl'
-import type { Workspace, Person, SoftwareSystem, Container, Component } from '@/types/model'
+import type { Workspace, Person, SoftwareSystem, Container, Component, Relationship } from '@/types/model'
 
 // ─── Parsing ──────────────────────────────────────────────────────────────────
 
@@ -111,11 +111,13 @@ describe('status serialization', () => {
     }
   }
 
-  it('emits status keyword without quotes', () => {
+  it('emits status as a c4hero.status property, not a bare status keyword', () => {
+    // Real Structurizr rejects a bare `status` keyword inside an element
+    // block, so it travels as a "c4hero.status" property instead.
     const dsl = serializeDSL(makeWs({ status: 'Live' }))
-    expect(dsl).toContain('status Live')
-    // Must be a block form (has braces)
-    expect(dsl).toContain('{')
+    expect(dsl).not.toMatch(/^\s*status\s/m)
+    expect(dsl).toContain('properties {')
+    expect(dsl).toContain('"c4hero.status" "Live"')
   })
 
   it('does not emit status when undefined', () => {
@@ -294,5 +296,141 @@ describe('owner roundtrip', () => {
     const app = parsed.model.softwareSystems[0]
     expect(app.status).toBe('Live')
     expect(app.owner).toBe('Backend Team')
+  })
+})
+
+// ─── Reserved property key collisions ─────────────────────────────────────────
+
+describe('reserved property key collisions', () => {
+  function sysWs(sys: Partial<SoftwareSystem>): Workspace {
+    return {
+      name: 'Test',
+      model: {
+        people: [],
+        softwareSystems: [{ id: 'sys', type: 'softwareSystem', name: 'App', tags: ['Element', 'Software System'], properties: {}, containers: [], ...sys }],
+        relationships: [],
+        groups: [],
+      },
+      views: { systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [], configuration: { styles: { elements: [], relationships: [] } } },
+    }
+  }
+
+  function relWs(rel: Partial<Relationship>): Workspace {
+    return {
+      name: 'Test',
+      model: {
+        people: [{ id: 'alice', type: 'person', name: 'Alice', tags: ['Element', 'Person'], properties: {} }],
+        softwareSystems: [{ id: 'sys', type: 'softwareSystem', name: 'App', tags: ['Element', 'Software System'], properties: {}, containers: [] }],
+        relationships: [{ id: 'rel-1', sourceId: 'alice', destinationId: 'sys', description: 'Uses', tags: ['Relationship'], properties: {}, ...rel }],
+        groups: [],
+      },
+      views: { systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [], configuration: { styles: { elements: [], relationships: [] } } },
+    }
+  }
+
+  it('idempotence: a user property `owner` with no owner field round-trips byte-identical', () => {
+    const dsl1 = serializeDSL(sysWs({ properties: { owner: 'UserValue', z: '2' } }))
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('idempotence: a user property `c4hero.status` with no status field round-trips byte-identical', () => {
+    // 'UserValue' is not a valid status enum member, so the parser must leave
+    // it as a plain property rather than hoist (and then drop) it.
+    const dsl1 = serializeDSL(sysWs({ properties: { 'c4hero.status': 'UserValue' } }))
+    expect(dsl1).toContain('"c4hero.status" "UserValue"')
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.softwareSystems[0].status).toBeUndefined()
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('derived owner field wins over a colliding user property, byte-identically', () => {
+    const dsl1 = serializeDSL(sysWs({ owner: 'RealOwner', properties: { owner: 'UserProp', z: '2' } }))
+    expect(dsl1).toContain('"owner" "RealOwner"')
+    expect(dsl1).not.toContain('UserProp')
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.softwareSystems[0].owner).toBe('RealOwner')
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('derived status field wins over a colliding user property, byte-identically', () => {
+    const dsl1 = serializeDSL(sysWs({ status: 'Live', properties: { 'c4hero.status': 'UserValue' } }))
+    expect(dsl1).toContain('"c4hero.status" "Live"')
+    expect(dsl1).not.toContain('UserValue')
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.softwareSystems[0].status).toBe('Live')
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('idempotence: a user property `c4hero.lineStyle` with no lineStyle field round-trips byte-identical', () => {
+    const dsl1 = serializeDSL(relWs({ properties: { 'c4hero.lineStyle': 'UserValue' } }))
+    expect(dsl1).toContain('"c4hero.lineStyle" "UserValue"')
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.relationships[0].lineStyle).toBeUndefined()
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('derived lineStyle field wins over a colliding user property, byte-identically', () => {
+    const dsl1 = serializeDSL(relWs({ lineStyle: 'Orthogonal', properties: { 'c4hero.lineStyle': 'UserValue' } }))
+    expect(dsl1).toContain('"c4hero.lineStyle" "Orthogonal"')
+    expect(dsl1).not.toContain('UserValue')
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.relationships[0].lineStyle).toBe('Orthogonal')
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('derived interactionStyle field wins over a colliding user property, byte-identically', () => {
+    const dsl1 = serializeDSL(relWs({ interactionStyle: 'Synchronous', properties: { 'c4hero.interactionStyle': 'UserValue' } }))
+    expect(dsl1).toContain('"c4hero.interactionStyle" "Synchronous"')
+    expect(dsl1).not.toContain('UserValue')
+    const { workspace: parsed, errors } = parseDSL(dsl1)
+    expect(errors).toHaveLength(0)
+    expect(parsed.model.relationships[0].interactionStyle).toBe('Synchronous')
+    expect(serializeDSL(parsed)).toBe(dsl1)
+  })
+
+  it('legacy bare status keyword wins over the property form when both appear', () => {
+    const dsl = `
+workspace {
+  model {
+    sys = softwareSystem "App" {
+      status Planned
+      properties {
+        "c4hero.status" "Live"
+      }
+    }
+  }
+  views {}
+}
+`
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+    expect(workspace.model.softwareSystems[0].status).toBe('Planned')
+  })
+
+  it('hoists a valid c4hero.status property onto the status field', () => {
+    const dsl = `
+workspace {
+  model {
+    sys = softwareSystem "App" {
+      properties {
+        "c4hero.status" "Deprecated"
+      }
+    }
+  }
+  views {}
+}
+`
+    const { workspace, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+    const app = workspace.model.softwareSystems[0]
+    expect(app.status).toBe('Deprecated')
+    expect(app.properties['c4hero.status']).toBeUndefined()
   })
 })

--- a/src/lib/dsl/status-owner-roundtrip.test.ts
+++ b/src/lib/dsl/status-owner-roundtrip.test.ts
@@ -138,9 +138,14 @@ describe('owner serialization', () => {
     }
   }
 
-  it('emits owner as quoted string', () => {
+  // `owner` is not a Structurizr keyword — a bare `owner "..."` line is a
+  // parse error there. It travels as a property instead, and the parser
+  // hoists it back onto the field.
+  it('emits owner inside a properties block, not as a bare keyword', () => {
     const dsl = serializeDSL(makeWs({ owner: 'Platform Team' }))
-    expect(dsl).toContain('owner "Platform Team"')
+    expect(dsl).toContain('properties {')
+    expect(dsl).toContain('"owner" "Platform Team"')
+    expect(dsl).not.toMatch(/^\s*owner "/m)
   })
 
   it('does not emit owner when undefined', () => {

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -7,11 +7,15 @@
 // nothing about agreeing with anyone else.
 //
 // These tests use the Structurizr CLI as an independent oracle. They skip
-// when it is not installed so local `npm test` stays fast; CI installs it and
-// sets STRUCTURIZR_CLI, so the gate is enforced there.
+// when it is not installed so local `npm test` stays fast; CI installs it
+// into .structurizr-cli/ (the default path below) and sets
+// STRUCTURIZR_CONFORMANCE=1, so a missing CLI fails there instead of
+// skipping. Set STRUCTURIZR_CLI to point at an install elsewhere. Use the
+// same pinned version as ci.yml — the encoding rules were verified against
+// this release, so "latest" can drift from the oracle CI enforces:
 //
 //   curl -sSL -o cli.zip \
-//     https://github.com/structurizr/cli/releases/latest/download/structurizr-cli.zip
+//     https://github.com/structurizr/cli/releases/download/v2025.11.09/structurizr-cli.zip
 //   unzip cli.zip -d .structurizr-cli && chmod +x .structurizr-cli/structurizr.sh
 //
 // Note that validation alone is NOT sufficient. `container "X:\\"` passes

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -197,19 +197,10 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
 
     it('the IcePanel landscape model re-serializes to DSL Structurizr accepts', () => {
         const ws = icePanelWorkspace()
-        // Two exclusions, both tracked elsewhere and neither a string/keyword
-        // problem:
-        //
-        //  - groups serialize as a trailing block of bare identifier
-        //    references, which Structurizr rejects outright (TEA-164).
-        //  - the source file's own systemContext/container view keys contain
+        // The source file's own systemContext/container view keys contain
         //    spaces ("Label 602"), which Structurizr rejects at line 814 of
         //    the fixture itself — before c4hero touches it. Reproducing an
         //    invalid key faithfully is not this ticket's bug.
-        //
-        // What remains is the 1060-line real-world model, which is what the
-        // escaping/location/owner fixes here are responsible for.
-        ws.model.groups = []
         ws.views.systemLandscapeViews = []
         ws.views.systemContextViews = []
         ws.views.containerViews = []
@@ -225,11 +216,33 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
         expect(validate(source)).toContain('View keys can only contain')
     })
 
-    // Locks in the known-broken group emission so it cannot regress further,
-    // and trips the moment TEA-164 fixes it — at which point fold the groups
-    // back into the test above and delete this one.
-    it.fails('TEA-164: groups still emit bare refs that Structurizr rejects', () => {
-        expect(validate(serializeDSL(icePanelWorkspace()))).toBeNull()
+    it('nested model, container and component groups serialize to DSL Structurizr accepts', () => {
+        const { workspace, errors } = parseDSL(`
+workspace "Grouped" {
+  model {
+    properties {
+      "structurizr.groupSeparator" "/"
+    }
+    group "Zone" {
+      group "Team" {
+        sys = softwareSystem "System" {
+          group "Applications" {
+            web = container "Web" {
+              group "Layers" {
+                ui = component "UI"
+                api = component "API"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  views {}
+}
+`)
+        expect(errors).toEqual([])
+        expect(validate(serializeDSL(workspace))).toBeNull()
     })
 
     // Validation is not enough: "X:\\" validates fine and stores a corrupted

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -1,0 +1,233 @@
+// Conformance tests against the REAL Structurizr parser.
+//
+// Every other test in this directory checks c4hero against itself:
+// `parse(serialize(x)) === x`. That invariant held perfectly while the
+// serializer emitted DSL that Structurizr rejected or silently misread
+// (GH #109) — a parser and serializer that agree with each other prove
+// nothing about agreeing with anyone else.
+//
+// These tests use the Structurizr CLI as an independent oracle. They skip
+// when it is not installed so local `npm test` stays fast; CI installs it and
+// sets STRUCTURIZR_CLI, so the gate is enforced there.
+//
+//   curl -sSL -o cli.zip \
+//     https://github.com/structurizr/cli/releases/latest/download/structurizr-cli.zip
+//   unzip cli.zip -d .structurizr-cli && chmod +x .structurizr-cli/structurizr.sh
+//
+// Note that validation alone is NOT sufficient. `container "X:\\"` passes
+// validation and stores `X:\" ` — a corrupted value, no error. Anything
+// asserting round-trip safety has to compare the value the real parser
+// actually stored, which is why exportModel() exists below.
+
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { serializeDSL, parseDSL } from '@/lib/dsl'
+import { createBigBankSample } from '@/lib/templates/bigBank'
+import { createMicroservicesTemplate } from '@/lib/templates/microservices'
+import { createMonolithTemplate } from '@/lib/templates/monolith'
+import { createEventDrivenTemplate } from '@/lib/templates/eventDriven'
+import type { Workspace } from '@/types/model'
+
+const CLI = process.env.STRUCTURIZR_CLI ?? join(process.cwd(), '.structurizr-cli', 'structurizr.sh')
+const CLI_AVAILABLE = existsSync(CLI)
+
+function withTempDsl<T>(dsl: string, fn: (dir: string, file: string) => T): T {
+    const dir = mkdtempSync(join(tmpdir(), 'c4hero-conformance-'))
+    try {
+        const file = join(dir, 'workspace.dsl')
+        writeFileSync(file, dsl, 'utf8')
+        return fn(dir, file)
+    } finally {
+        rmSync(dir, { recursive: true, force: true })
+    }
+}
+
+/** Run the real parser over `dsl`. Returns its complaint, or null if accepted. */
+function validate(dsl: string): string | null {
+    return withTempDsl(dsl, (_dir, file) => {
+        try {
+            execFileSync(CLI, ['validate', '-w', file], { encoding: 'utf8', stdio: 'pipe' })
+            return null
+        } catch (err) {
+            const e = err as { stdout?: string; stderr?: string; message: string }
+            return (e.stdout ?? '') + (e.stderr ?? '') || e.message
+        }
+    })
+}
+
+/** Parse with the real parser and return the model it actually built. */
+function exportModel(dsl: string): Record<string, never> | Record<string, unknown> {
+    return withTempDsl(dsl, (dir, file) => {
+        const out = join(dir, 'out')
+        execFileSync(CLI, ['export', '-w', file, '-f', 'json', '-o', out], { stdio: 'pipe' })
+        const json = readdirSync(out).find(f => f.endsWith('.json'))
+        if (!json) throw new Error('Structurizr CLI produced no JSON export')
+        return JSON.parse(readFileSync(join(out, json), 'utf8'))
+    })
+}
+
+/** Names of every container the real parser found, in declaration order. */
+function containerNames(model: Record<string, unknown>): string[] {
+    const m = model.model as { softwareSystems?: { containers?: { name: string }[] }[] } | undefined
+    return (m?.softwareSystems ?? []).flatMap(s => (s.containers ?? []).map(c => c.name))
+}
+
+function systemNamed(model: Record<string, unknown>, name: string) {
+    const m = model.model as { softwareSystems?: { name: string; tags?: string; properties?: Record<string, string> }[] } | undefined
+    return (m?.softwareSystems ?? []).find(s => s.name === name)
+}
+
+/** A workspace whose strings exercise everything Structurizr's tokenizer treats specially. */
+function hostileWorkspace(): Workspace {
+    return {
+        name: 'Hostile',
+        description: '',
+        model: {
+            people: [],
+            softwareSystems: [
+                {
+                    id: 'sys', type: 'softwareSystem', name: 'Example System',
+                    tags: ['Element', 'Software System', 'has,comma', 'has"quote'],
+                    properties: {}, owner: 'Platform Team', location: 'External',
+                    containers: [
+                        // The exact values from GH #109.
+                        {
+                            id: 'folder', type: 'container', name: 'Shared Folder X:\\',
+                            description: "HOST-01 'U:\\'", technology: 'File System',
+                            tags: ['Element', 'Container'], properties: {}, components: [],
+                        },
+                        {
+                            id: 'quoted', type: 'container', name: 'Say "hi"',
+                            description: 'ends with backslash \\', technology: 'C:\\Program Files',
+                            tags: ['Element', 'Container'], properties: {}, components: [],
+                        },
+                        {
+                            id: 'newline', type: 'container', name: 'two\nlines',
+                            description: 'tab\there', technology: 'literal \\n not newline',
+                            tags: ['Element', 'Container'], properties: {}, components: [],
+                        },
+                    ],
+                },
+            ],
+            relationships: [],
+            groups: [],
+        },
+        views: {
+            systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [],
+            configuration: { styles: { elements: [], relationships: [] } },
+        },
+    }
+}
+
+describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
+    const templates: [string, () => Workspace][] = [
+        ['bigBank', createBigBankSample],
+        ['microservices', createMicroservicesTemplate],
+        ['monolith', createMonolithTemplate],
+        ['eventDriven', createEventDrivenTemplate],
+    ]
+
+    it.each(templates)('%s template serializes to DSL Structurizr accepts', (_name, make) => {
+        expect(validate(serializeDSL(make()))).toBeNull()
+    })
+
+    it('hostile strings serialize to DSL Structurizr accepts', () => {
+        expect(validate(serializeDSL(hostileWorkspace()))).toBeNull()
+    })
+
+    function icePanelWorkspace(): Workspace {
+        const source = readFileSync(join(process.cwd(), 'src/lib/dsl/__fixtures__/hierarchical-landscape.dsl'), 'utf8')
+        const { workspace, errors } = parseDSL(source)
+        expect(errors).toEqual([])
+        return workspace
+    }
+
+    it('the IcePanel landscape model re-serializes to DSL Structurizr accepts', () => {
+        const ws = icePanelWorkspace()
+        // Two exclusions, both tracked elsewhere and neither a string/keyword
+        // problem:
+        //
+        //  - groups serialize as a trailing block of bare identifier
+        //    references, which Structurizr rejects outright (TEA-164).
+        //  - the source file's own systemContext/container view keys contain
+        //    spaces ("Label 602"), which Structurizr rejects at line 814 of
+        //    the fixture itself — before c4hero touches it. Reproducing an
+        //    invalid key faithfully is not this ticket's bug.
+        //
+        // What remains is the 1060-line real-world model, which is what the
+        // escaping/location/owner fixes here are responsible for.
+        ws.model.groups = []
+        ws.views.systemLandscapeViews = []
+        ws.views.systemContextViews = []
+        ws.views.containerViews = []
+        ws.views.componentViews = []
+        expect(validate(serializeDSL(ws))).toBeNull()
+    })
+
+    it('does not make the IcePanel fixture any less valid than it already was', () => {
+        // The source is non-conformant on its own (invalid view keys). The
+        // property that matters is that a c4hero round-trip does not introduce
+        // a *new* class of error — it should still fail on the same thing.
+        const source = readFileSync(join(process.cwd(), 'src/lib/dsl/__fixtures__/hierarchical-landscape.dsl'), 'utf8')
+        expect(validate(source)).toContain('View keys can only contain')
+    })
+
+    // Locks in the known-broken group emission so it cannot regress further,
+    // and trips the moment TEA-164 fixes it — at which point fold the groups
+    // back into the test above and delete this one.
+    it.fails('TEA-164: groups still emit bare refs that Structurizr rejects', () => {
+        expect(validate(serializeDSL(icePanelWorkspace()))).toBeNull()
+    })
+
+    // Validation is not enough: "X:\\" validates fine and stores a corrupted
+    // value. These assert what the real parser actually built.
+    describe('value fidelity', () => {
+        it('preserves hostile container strings exactly, modulo unrepresentable backslashes', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            expect(containerNames(model)).toEqual([
+                // Trailing backslash is unrepresentable in Structurizr DSL and is dropped.
+                'Shared Folder X:',
+                'Say "hi"',
+                'two\nlines',
+            ])
+        })
+
+        it('keeps an interior backslash single, not doubled', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const m = model.model as { softwareSystems: { containers: { name: string; technology?: string }[] }[] }
+            const quoted = m.softwareSystems[0].containers.find(c => c.name === 'Say "hi"')
+            expect(quoted?.technology).toBe('C:\\Program Files')
+        })
+
+        it('carries externality as the External tag', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            expect(systemNamed(model, 'Example System')?.tags).toContain('External')
+        })
+
+        it('carries owner as a property the real parser can read', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            expect(systemNamed(model, 'Example System')?.properties?.owner).toBe('Platform Team')
+        })
+
+        it('does not split a tag containing a comma into two tags', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const tags = (systemNamed(model, 'Example System')?.tags ?? '').split(',')
+            expect(tags).not.toContain('has')
+            expect(tags).not.toContain('comma')
+        })
+    })
+})
+
+// A suite that silently skips is indistinguishable from a suite that passes —
+// which is the same false-confidence failure this whole file exists to prevent.
+// The CI job sets STRUCTURIZR_CONFORMANCE=1, so a broken CLI download turns
+// into a red build instead of a green skip.
+describe('Structurizr conformance harness', () => {
+    it('has the CLI installed when conformance is required', () => {
+        if (process.env.STRUCTURIZR_CONFORMANCE !== '1') return
+        expect(CLI_AVAILABLE, `Structurizr CLI not found at ${CLI}`).toBe(true)
+    })
+})

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -231,8 +231,14 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
     // Validation is not enough: "X:\\" validates fine and stores a corrupted
     // value. These assert what the real parser actually built.
     describe('value fidelity', () => {
+        // Every test reads the same export; one CLI (JVM) run instead of ten.
+        let memo: Record<string, unknown> | undefined
+        function hostileModel(): Record<string, unknown> {
+            memo ??= exportModel(serializeDSL(hostileWorkspace()))
+            return memo
+        }
         it('preserves hostile container strings exactly, modulo unrepresentable backslashes', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             expect(containerNames(model)).toEqual([
                 // Trailing backslash is unrepresentable in Structurizr DSL and is dropped.
                 'Shared Folder X:',
@@ -244,14 +250,14 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
         })
 
         it('keeps an interior backslash single, not doubled', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             const m = model.model as { softwareSystems: { containers: { name: string; technology?: string }[] }[] }
             const quoted = m.softwareSystems[0].containers.find(c => c.name === 'Say "hi"')
             expect(quoted?.technology).toBe('C:\\Program Files')
         })
 
         it('stores backslash-before-quote byte-exactly', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             const m = model.model as { softwareSystems: { containers: { name: string; technology?: string }[] }[] }
             const bsq = m.softwareSystems[0].containers.find(c => c.name === 'see "manual\\"')
             expect(bsq).toBeDefined()
@@ -259,29 +265,29 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
         })
 
         it('carries externality as the External tag', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             expect(systemNamed(model, 'Example System')?.tags).toContain('External')
         })
 
         it('carries owner as a property the real parser can read', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             expect(systemNamed(model, 'Example System')?.properties?.owner).toBe('Platform Team')
         })
 
         it('does not split a tag containing a comma into two tags', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             const tags = (systemNamed(model, 'Example System')?.tags ?? '').split(',')
             expect(tags).not.toContain('has')
             expect(tags).not.toContain('comma')
         })
 
         it('carries element status as a property the real parser can read', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             expect(systemNamed(model, 'Example System')?.properties?.['c4hero.status']).toBe('Live')
         })
 
         it('preserves relationship description, technology and url exactly', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             const [rel] = allRelationships(model)
             expect(rel).toBeDefined()
             expect(rel.description).toBe('Reads the "daily"\nreport')
@@ -290,7 +296,7 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
         })
 
         it('carries lineStyle and interactionStyle as properties, next to user properties', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             const [rel] = allRelationships(model)
             expect(rel?.properties?.['c4hero.lineStyle']).toBe('Orthogonal')
             expect(rel?.properties?.['c4hero.interactionStyle']).toBe('Asynchronous')
@@ -298,7 +304,7 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
         })
 
         it('does not split a relationship tag containing a comma into two tags', () => {
-            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const model = hostileModel()
             const tags = (allRelationships(model)[0]?.tags ?? '').split(',')
             expect(tags).not.toContain('nightly')
             expect(tags).not.toContain('batch')

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -80,18 +80,44 @@ function systemNamed(model: Record<string, unknown>, name: string) {
     return (m?.softwareSystems ?? []).find(s => s.name === name)
 }
 
+interface ExportedRelationship {
+    description?: string
+    technology?: string
+    url?: string
+    tags?: string
+    properties?: Record<string, string>
+}
+
+/** Every relationship the real parser stored (it hangs them off the source element). */
+function allRelationships(model: Record<string, unknown>): ExportedRelationship[] {
+    const m = model.model as {
+        people?: { relationships?: ExportedRelationship[] }[]
+        softwareSystems?: { relationships?: ExportedRelationship[] }[]
+    } | undefined
+    return [
+        ...(m?.people ?? []).flatMap(p => p.relationships ?? []),
+        ...(m?.softwareSystems ?? []).flatMap(s => s.relationships ?? []),
+    ]
+}
+
 /** A workspace whose strings exercise everything Structurizr's tokenizer treats specially. */
 function hostileWorkspace(): Workspace {
     return {
         name: 'Hostile',
         description: '',
         model: {
-            people: [],
+            people: [
+                {
+                    id: 'user', type: 'person', name: 'Ops User',
+                    tags: ['Element', 'Person'], properties: {},
+                },
+            ],
             softwareSystems: [
                 {
                     id: 'sys', type: 'softwareSystem', name: 'Example System',
                     tags: ['Element', 'Software System', 'has,comma', 'has"quote'],
                     properties: {}, owner: 'Platform Team', location: 'External',
+                    status: 'Live',
                     containers: [
                         // The exact values from GH #109.
                         {
@@ -109,10 +135,30 @@ function hostileWorkspace(): Workspace {
                             description: 'tab\there', technology: 'literal \\n not newline',
                             tags: ['Element', 'Container'], properties: {}, components: [],
                         },
+                        // Backslash immediately before a quote — representable
+                        // (emitted as `\\"`, decoded as literal-\ + quote).
+                        {
+                            id: 'bsq', type: 'container', name: 'see "manual\\"',
+                            description: 'backslash before quote', technology: 'a\\"b',
+                            tags: ['Element', 'Container'], properties: {}, components: [],
+                        },
                     ],
                 },
             ],
-            relationships: [],
+            relationships: [
+                // Exercises every relationship field the serializer must encode:
+                // description/technology (with hostile strings), the
+                // property-encoded lineStyle/interactionStyle, url, a tag with
+                // a comma, and a user property.
+                {
+                    id: 'rel1', sourceId: 'user', destinationId: 'sys',
+                    description: 'Reads the "daily"\nreport', technology: 'SMB 3.0',
+                    tags: ['Relationship', 'nightly,batch'],
+                    properties: { 'sync.source': 'ldap' },
+                    interactionStyle: 'Asynchronous', lineStyle: 'Orthogonal',
+                    url: 'https://example.com/share',
+                },
+            ],
             groups: [],
         },
         views: {
@@ -192,6 +238,8 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
                 'Shared Folder X:',
                 'Say "hi"',
                 'two\nlines',
+                // Backslash-before-quote IS representable and survives byte-exact.
+                'see "manual\\"',
             ])
         })
 
@@ -200,6 +248,14 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
             const m = model.model as { softwareSystems: { containers: { name: string; technology?: string }[] }[] }
             const quoted = m.softwareSystems[0].containers.find(c => c.name === 'Say "hi"')
             expect(quoted?.technology).toBe('C:\\Program Files')
+        })
+
+        it('stores backslash-before-quote byte-exactly', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const m = model.model as { softwareSystems: { containers: { name: string; technology?: string }[] }[] }
+            const bsq = m.softwareSystems[0].containers.find(c => c.name === 'see "manual\\"')
+            expect(bsq).toBeDefined()
+            expect(bsq?.technology).toBe('a\\"b')
         })
 
         it('carries externality as the External tag', () => {
@@ -217,6 +273,36 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
             const tags = (systemNamed(model, 'Example System')?.tags ?? '').split(',')
             expect(tags).not.toContain('has')
             expect(tags).not.toContain('comma')
+        })
+
+        it('carries element status as a property the real parser can read', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            expect(systemNamed(model, 'Example System')?.properties?.['c4hero.status']).toBe('Live')
+        })
+
+        it('preserves relationship description, technology and url exactly', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const [rel] = allRelationships(model)
+            expect(rel).toBeDefined()
+            expect(rel.description).toBe('Reads the "daily"\nreport')
+            expect(rel.technology).toBe('SMB 3.0')
+            expect(rel.url).toBe('https://example.com/share')
+        })
+
+        it('carries lineStyle and interactionStyle as properties, next to user properties', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const [rel] = allRelationships(model)
+            expect(rel?.properties?.['c4hero.lineStyle']).toBe('Orthogonal')
+            expect(rel?.properties?.['c4hero.interactionStyle']).toBe('Asynchronous')
+            expect(rel?.properties?.['sync.source']).toBe('ldap')
+        })
+
+        it('does not split a relationship tag containing a comma into two tags', () => {
+            const model = exportModel(serializeDSL(hostileWorkspace()))
+            const tags = (allRelationships(model)[0]?.tags ?? '').split(',')
+            expect(tags).not.toContain('nightly')
+            expect(tags).not.toContain('batch')
+            expect(tags).toContain('nightlybatch')
         })
     })
 })

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -166,6 +166,15 @@ workspace {
     const sys = workspace.model.softwareSystems[0]
     expect(sys.location).toBe('Internal')
     expect(sys.tags).toContain('External')
+
+    // On save the field wins again: the tag is dropped rather than emitted,
+    // because an emitted External tag would flip the element to External on
+    // the next parse.
+    const dsl = serializeDSL(workspace)
+    expect(dsl).not.toContain('External')
+    const reparsed = parseDSL(dsl)
+    expect(reparsed.errors).toEqual([])
+    expect(reparsed.workspace.model.softwareSystems[0].location).not.toBe('External')
   })
 
   it('leaves an empty owner property as a property, so it survives round-trip', () => {
@@ -205,6 +214,18 @@ workspace {
     const sys = parsed.workspace.model.softwareSystems[0]
     expect(sys.location).toBe('External')
     expect(sys.tags).not.toContain('External')
+  })
+
+  it('keeps a user property named after an Object.prototype member', () => {
+    // The derived-vs-user merge must not treat inherited keys (constructor,
+    // toString, ...) as collisions.
+    const dsl = serializeDSL(wsWith({ properties: { constructor: 'x', toString: 'y' } }))
+    expect(dsl).toContain('"constructor" "x"')
+    expect(dsl).toContain('"toString" "y"')
+
+    const parsed = parseDSL(dsl)
+    expect(parsed.errors).toEqual([])
+    expect(serializeDSL(parsed.workspace)).toBe(dsl)
   })
 
   it('emits status via properties and hoists it back on parse', () => {

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -6,10 +6,13 @@
 // points at the exact rule that broke.
 //
 // The rules (verified against structurizr-java 5.0.2):
-//   \" and \n are the only escapes; every other backslash is literal.
-//   A backslash before " or n, or at end of value, is unrepresentable.
+//   \" and \n are the only escapes; every other backslash is literal, and a
+//   missed escape consumes only the backslash (so `a\\"b` decodes to `a\"b`).
+//   A backslash before n, or at end of value, is unrepresentable; a backslash
+//   before a quote is representable (the quote's own escape covers it).
 //   Tags are comma-separated, so a comma inside a tag would split it.
-//   `location` and `owner` are not keywords.
+//   `location`, `owner`, `status`, `lineStyle` and `interactionStyle` are not
+//   keywords.
 
 import { describe, it, expect } from 'vitest'
 import { serializeDSL, parseDSL } from '@/lib/dsl'
@@ -63,12 +66,21 @@ describe('string encoding', () => {
     expect(dsl).not.toContain('X:\\"')
   })
 
-  it('drops a backslash that would start an escape sequence', () => {
-    const dsl = serializeDSL(wsWith({ containers: [container('a\\nb', { technology: 'x\\"y' })] }))
-    // Neither may survive as a backslash — Structurizr would read \n as a
-    // newline and \" as a quote, corrupting the value either way.
+  it('drops a backslash that would read as a newline escape', () => {
+    // `a\nb` emitted verbatim would decode as a real newline, corrupting the
+    // value — and there is no way to escape the backslash itself.
+    const dsl = serializeDSL(wsWith({ containers: [container('a\\nb')] }))
     expect(dsl).toContain('"anb"')
-    expect(dsl).toContain('"x\\"y"')
+  })
+
+  it('emits backslash-before-quote losslessly and restores it on parse', () => {
+    // Raw `x\"y` emits as `x\\"y`: the tokenizer reads the first backslash as
+    // a literal miss (consuming one char) and the second as the quote escape.
+    const dsl = serializeDSL(wsWith({ containers: [container('x\\"y')] }))
+    expect(dsl).toContain('"x\\\\"y"')
+    const parsed = parseDSL(dsl)
+    expect(parsed.errors).toEqual([])
+    expect(parsed.workspace.model.softwareSystems[0].containers[0].name).toBe('x\\"y')
   })
 
   it('encodes a real newline as \\n', () => {
@@ -136,6 +148,33 @@ describe('location and owner are not Structurizr keywords', () => {
     expect(sys.tags).not.toContain('External')
   })
 
+  it('emits status via properties and hoists it back on parse', () => {
+    const dsl = serializeDSL(wsWith({ status: 'Live' }))
+    expect(dsl).not.toMatch(/^\s*status\s/m)
+    expect(dsl).toContain('"c4hero.status" "Live"')
+
+    const parsed = parseDSL(dsl)
+    expect(parsed.errors).toEqual([])
+    const sys = parsed.workspace.model.softwareSystems[0]
+    expect(sys.status).toBe('Live')
+    expect(sys.properties['c4hero.status']).toBeUndefined()
+  })
+
+  it('still accepts the legacy bare status keyword on import', () => {
+    const { workspace, errors } = parseDSL(`
+workspace {
+  model {
+    s = softwareSystem "S" {
+      status Planned
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+    expect(workspace.model.softwareSystems[0].status).toBe('Planned')
+  })
+
   it('still accepts the legacy bare owner keyword on import', () => {
     const { workspace, errors } = parseDSL(`
 workspace {
@@ -149,6 +188,66 @@ workspace {
 `)
     expect(errors).toEqual([])
     expect(workspace.model.softwareSystems[0].owner).toBe('Legacy Team')
+  })
+})
+
+describe('lineStyle and interactionStyle are not Structurizr relationship keywords', () => {
+  function relWs(): Workspace {
+    const ws = wsWith({})
+    ws.model.people.push({ id: 'u', type: 'person', name: 'U', tags: ['Element', 'Person'], properties: {} })
+    ws.model.relationships.push({
+      id: 'rel-1', sourceId: 'u', destinationId: 'sys',
+      description: 'Uses', technology: 'REST',
+      tags: ['Relationship', 'nightly,batch'],
+      properties: { 'sync.source': 'ldap' },
+      interactionStyle: 'Asynchronous', lineStyle: 'Orthogonal',
+    })
+    return ws
+  }
+
+  it('emits both via properties, never as bare keywords', () => {
+    const dsl = serializeDSL(relWs())
+    expect(dsl).not.toMatch(/^\s*lineStyle\s/m)
+    expect(dsl).not.toMatch(/^\s*interactionStyle\s/m)
+    expect(dsl).toContain('"c4hero.lineStyle" "Orthogonal"')
+    expect(dsl).toContain('"c4hero.interactionStyle" "Asynchronous"')
+    // User properties still travel alongside the derived ones.
+    expect(dsl).toContain('"sync.source" "ldap"')
+  })
+
+  it('hoists both back onto the fields on parse, leaving user properties alone', () => {
+    const parsed = parseDSL(serializeDSL(relWs()))
+    expect(parsed.errors).toEqual([])
+    const rel = parsed.workspace.model.relationships[0]
+    expect(rel.description).toBe('Uses')
+    expect(rel.technology).toBe('REST')
+    expect(rel.lineStyle).toBe('Orthogonal')
+    expect(rel.interactionStyle).toBe('Asynchronous')
+    expect(rel.properties).toEqual({ 'sync.source': 'ldap' })
+  })
+
+  it('still accepts the legacy bare keywords on import, and they win over the property form', () => {
+    const { workspace, errors } = parseDSL(`
+workspace {
+  model {
+    u = person "U"
+    s = softwareSystem "S"
+    u -> s "Uses" {
+      lineStyle Curved
+      interactionStyle Synchronous
+      properties {
+        "c4hero.lineStyle" "Orthogonal"
+        "c4hero.interactionStyle" "Asynchronous"
+      }
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+    const rel = workspace.model.relationships[0]
+    expect(rel.lineStyle).toBe('Curved')
+    expect(rel.interactionStyle).toBe('Synchronous')
   })
 })
 

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -1,0 +1,178 @@
+// The Structurizr encoding contract, asserted without needing the CLI.
+//
+// structurizr-conformance.test.ts proves these rules against the real parser
+// but skips when the CLI is absent. These tests pin the same contract in plain
+// unit form so it is still covered on a bare checkout, and so a regression
+// points at the exact rule that broke.
+//
+// The rules (verified against structurizr-java 5.0.2):
+//   \" and \n are the only escapes; every other backslash is literal.
+//   A backslash before " or n, or at end of value, is unrepresentable.
+//   Tags are comma-separated, so a comma inside a tag would split it.
+//   `location` and `owner` are not keywords.
+
+import { describe, it, expect } from 'vitest'
+import { serializeDSL, parseDSL } from '@/lib/dsl'
+import type { Workspace, SoftwareSystem, Container } from '@/types/model'
+
+function wsWith(sys: Partial<SoftwareSystem> & { containers?: Container[] }): Workspace {
+  return {
+    name: 'Test',
+    description: '',
+    model: {
+      people: [],
+      softwareSystems: [{
+        id: 'sys', type: 'softwareSystem', name: 'Sys',
+        tags: ['Element', 'Software System'], properties: {}, containers: [],
+        ...sys,
+      } as SoftwareSystem],
+      relationships: [],
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+function container(name: string, extra: Partial<Container> = {}): Container {
+  return {
+    id: 'c1', type: 'container', name,
+    tags: ['Element', 'Container'], properties: {}, components: [],
+    ...extra,
+  } as Container
+}
+
+describe('string encoding', () => {
+  it('emits an interior backslash verbatim', () => {
+    expect(serializeDSL(wsWith({ containers: [container('C:\\Program Files')] })))
+      .toContain('"C:\\Program Files"')
+  })
+
+  it('escapes a double quote as \\"', () => {
+    expect(serializeDSL(wsWith({ containers: [container('Say "hi"')] })))
+      .toContain('"Say \\"hi\\""')
+  })
+
+  it('drops a trailing backslash, which would escape the closing quote', () => {
+    // GH #109: `container "Shared Folder X:\\"` swallowed the closing quote
+    // and produced "Too many tokens".
+    const dsl = serializeDSL(wsWith({ containers: [container('Shared Folder X:\\')] }))
+    expect(dsl).toContain('"Shared Folder X:"')
+    expect(dsl).not.toContain('X:\\"')
+  })
+
+  it('drops a backslash that would start an escape sequence', () => {
+    const dsl = serializeDSL(wsWith({ containers: [container('a\\nb', { technology: 'x\\"y' })] }))
+    // Neither may survive as a backslash — Structurizr would read \n as a
+    // newline and \" as a quote, corrupting the value either way.
+    expect(dsl).toContain('"anb"')
+    expect(dsl).toContain('"x\\"y"')
+  })
+
+  it('encodes a real newline as \\n', () => {
+    expect(serializeDSL(wsWith({ containers: [container('two\nlines')] })))
+      .toContain('"two\\nlines"')
+  })
+
+  it('leaves a real tab alone, since \\t is not an escape', () => {
+    const dsl = serializeDSL(wsWith({ containers: [container('a\tb')] }))
+    expect(dsl).toContain('"a\tb"')
+    expect(dsl).not.toContain('a\\tb')
+  })
+
+  it('round-trips the GH #109 values through parse', () => {
+    const ws = wsWith({ containers: [container('Shared Folder X:', { description: "HOST-01 'U:\\'", technology: 'File System' })] })
+    const parsed = parseDSL(serializeDSL(ws))
+    expect(parsed.errors).toEqual([])
+    const c = parsed.workspace.model.softwareSystems[0].containers[0]
+    expect(c.name).toBe('Shared Folder X:')
+    expect(c.description).toBe("HOST-01 'U:\\'")
+    expect(c.technology).toBe('File System')
+  })
+})
+
+describe('tags', () => {
+  it('strips a comma so one tag cannot become two', () => {
+    const dsl = serializeDSL(wsWith({ tags: ['Element', 'Software System', 'has,comma'] }))
+    expect(dsl).toContain('"hascomma"')
+  })
+
+  it('escapes a quote inside a tag instead of emitting it bare', () => {
+    const dsl = serializeDSL(wsWith({ tags: ['Element', 'Software System', 'has"quote'] }))
+    expect(dsl).toContain('has\\"quote')
+  })
+
+  it('still joins multiple tags with a comma', () => {
+    const dsl = serializeDSL(wsWith({ tags: ['Element', 'Software System', 'A', 'B'] }))
+    expect(dsl).toContain('"A,B"')
+  })
+})
+
+describe('location and owner are not Structurizr keywords', () => {
+  it('emits owner via properties and hoists it back on parse', () => {
+    const dsl = serializeDSL(wsWith({ owner: 'Platform Team' }))
+    expect(dsl).not.toMatch(/^\s*owner "/m)
+    expect(dsl).toContain('"owner" "Platform Team"')
+
+    const parsed = parseDSL(dsl)
+    expect(parsed.errors).toEqual([])
+    const sys = parsed.workspace.model.softwareSystems[0]
+    expect(sys.owner).toBe('Platform Team')
+    // ...and does not linger as a stray property, so the round-trip is exact.
+    expect(sys.properties.owner).toBeUndefined()
+  })
+
+  it('emits externality as the External tag and maps it back on parse', () => {
+    const dsl = serializeDSL(wsWith({ location: 'External' }))
+    expect(dsl).not.toContain('location External')
+    expect(dsl).toContain('"External"')
+
+    const parsed = parseDSL(dsl)
+    expect(parsed.errors).toEqual([])
+    const sys = parsed.workspace.model.softwareSystems[0]
+    expect(sys.location).toBe('External')
+    expect(sys.tags).not.toContain('External')
+  })
+
+  it('still accepts the legacy bare owner keyword on import', () => {
+    const { workspace, errors } = parseDSL(`
+workspace {
+  model {
+    s = softwareSystem "S" {
+      owner "Legacy Team"
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+    expect(workspace.model.softwareSystems[0].owner).toBe('Legacy Team')
+  })
+})
+
+describe('autoLayout', () => {
+  it('emits a lowercase rank direction', () => {
+    const ws = wsWith({})
+    ws.views.systemLandscapeViews.push({
+      key: 'k', type: 'systemLandscape', elements: [], relationships: [],
+      autoLayout: { direction: 'LR' },
+    })
+    const dsl = serializeDSL(ws)
+    // Structurizr rejects `autoLayout LR` — valid directions are tb|bt|lr|rl.
+    expect(dsl).toContain('autoLayout lr')
+    expect(dsl).not.toContain('autoLayout LR')
+  })
+
+  it('round-trips the direction back to the internal uppercase form', () => {
+    const ws = wsWith({})
+    ws.views.systemLandscapeViews.push({
+      key: 'k', type: 'systemLandscape', elements: [], relationships: [],
+      autoLayout: { direction: 'RL' },
+    })
+    const parsed = parseDSL(serializeDSL(ws))
+    expect(parsed.errors).toEqual([])
+    expect(parsed.workspace.views.systemLandscapeViews[0].autoLayout?.direction).toBe('RL')
+  })
+})

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -121,6 +121,17 @@ describe('tags', () => {
     expect(dsl).toContain('"A,B"')
   })
 
+  it('skips a style whose tag sanitizes to nothing instead of emitting element ""', () => {
+    // `element "" {` is rejected outright by the real parser ("A tag must
+    // be specified"), so a selector that sanitizes to empty must not emit.
+    const ws = wsWith({})
+    ws.views.configuration.styles.elements.push({ tag: ',', background: '#999999' })
+    const dsl = serializeDSL(ws)
+    expect(dsl).not.toContain('element ""')
+    // It was the only style, so the styles block disappears entirely.
+    expect(dsl).not.toContain('styles {')
+  })
+
   it('strips the comma from a style tag selector so it still matches the renamed tag', () => {
     // Element tags have commas stripped, so a style keyed on the same tag
     // must be renamed identically or it silently detaches.
@@ -204,6 +215,17 @@ workspace {
     expect(serializeDSL(reparsed.workspace)).toBe(dsl1)
   })
 
+  it('an explicit Unspecified location also wins over an External tag on save', () => {
+    // Same contradiction rule as Internal: any explicit non-External
+    // location beats a stray External tag, so a save/reload cycle cannot
+    // silently flip the element to External.
+    const dsl = serializeDSL(wsWith({ location: 'Unspecified', tags: ['Element', 'Software System', 'External'] }))
+    expect(dsl).not.toContain('External')
+    const parsed = parseDSL(dsl)
+    expect(parsed.errors).toEqual([])
+    expect(parsed.workspace.model.softwareSystems[0].location).not.toBe('External')
+  })
+
   it('emits externality as the External tag and maps it back on parse', () => {
     const dsl = serializeDSL(wsWith({ location: 'External' }))
     expect(dsl).not.toContain('location External')
@@ -214,6 +236,31 @@ workspace {
     const sys = parsed.workspace.model.softwareSystems[0]
     expect(sys.location).toBe('External')
     expect(sys.tags).not.toContain('External')
+  })
+
+  it('stores a "__proto__" property as data on parse instead of setting the prototype', () => {
+    const source = `
+workspace {
+  model {
+    s = softwareSystem "S" {
+      properties {
+        "__proto__" "x"
+      }
+    }
+  }
+  views {}
+}
+`
+    const { workspace, errors } = parseDSL(source)
+    expect(errors).toEqual([])
+    const sys = workspace.model.softwareSystems[0]
+    expect(Object.getPrototypeOf(sys.properties)).toBe(Object.prototype)
+    expect(Object.entries(sys.properties)).toContainEqual(['__proto__', 'x'])
+
+    const dsl1 = serializeDSL(workspace)
+    expect(dsl1).toContain('"__proto__" "x"')
+    const reparsed = parseDSL(dsl1)
+    expect(serializeDSL(reparsed.workspace)).toBe(dsl1)
   })
 
   it('keeps a user property named after an Object.prototype member', () => {

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -120,6 +120,19 @@ describe('tags', () => {
     const dsl = serializeDSL(wsWith({ tags: ['Element', 'Software System', 'A', 'B'] }))
     expect(dsl).toContain('"A,B"')
   })
+
+  it('strips the comma from a style tag selector so it still matches the renamed tag', () => {
+    // Element tags have commas stripped, so a style keyed on the same tag
+    // must be renamed identically or it silently detaches.
+    const ws = wsWith({ tags: ['Element', 'Software System', 'has,comma'] })
+    ws.views.configuration.styles.elements.push({ tag: 'has,comma', background: '#999999' })
+    ws.views.configuration.styles.relationships.push({ tag: 'slow,path', color: '#ff0000' })
+    const dsl = serializeDSL(ws)
+    expect(dsl).toContain('element "hascomma"')
+    expect(dsl).toContain('relationship "slowpath"')
+    expect(dsl).not.toContain('"has,comma"')
+    expect(dsl).not.toContain('"slow,path"')
+  })
 })
 
 describe('location and owner are not Structurizr keywords', () => {
@@ -134,6 +147,52 @@ describe('location and owner are not Structurizr keywords', () => {
     expect(sys.owner).toBe('Platform Team')
     // ...and does not linger as a stray property, so the round-trip is exact.
     expect(sys.properties.owner).toBeUndefined()
+  })
+
+  it('an explicit legacy location Internal wins over an External tag on import', () => {
+    // A contradictory legacy file: the bare keyword is the more explicit
+    // signal, so it wins and the tag stays put as an opaque user tag.
+    const { workspace, errors } = parseDSL(`
+workspace {
+  model {
+    s = softwareSystem "S" "" "External" {
+      location Internal
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+    const sys = workspace.model.softwareSystems[0]
+    expect(sys.location).toBe('Internal')
+    expect(sys.tags).toContain('External')
+  })
+
+  it('leaves an empty owner property as a property, so it survives round-trip', () => {
+    // The serializer only re-emits a truthy owner field; hoisting "" would
+    // drop the property on the next save.
+    const source = `
+workspace {
+  model {
+    s = softwareSystem "S" {
+      properties {
+        "owner" ""
+      }
+    }
+  }
+  views {}
+}
+`
+    const { workspace, errors } = parseDSL(source)
+    expect(errors).toEqual([])
+    const sys = workspace.model.softwareSystems[0]
+    expect(sys.owner).toBeUndefined()
+    expect(sys.properties.owner).toBe('')
+
+    const dsl1 = serializeDSL(workspace)
+    expect(dsl1).toContain('"owner" ""')
+    const reparsed = parseDSL(dsl1)
+    expect(serializeDSL(reparsed.workspace)).toBe(dsl1)
   })
 
   it('emits externality as the External tag and maps it back on parse', () => {

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -215,6 +215,32 @@ workspace {
     expect(serializeDSL(reparsed.workspace)).toBe(dsl1)
   })
 
+  it('keeps an unhoistable c4hero.location value as a plain property', () => {
+    // Only External/Internal hoist onto the field; anything else must stay a
+    // property so no value is silently lost.
+    const { workspace, errors } = parseDSL(`
+workspace {
+  model {
+    s = softwareSystem "S" {
+      properties {
+        "c4hero.location" "Unspecified"
+      }
+    }
+  }
+  views {}
+}
+`)
+    expect(errors).toEqual([])
+    const sys = workspace.model.softwareSystems[0]
+    expect(sys.location).toBeUndefined()
+    expect(sys.properties['c4hero.location']).toBe('Unspecified')
+
+    const dsl1 = serializeDSL(workspace)
+    expect(dsl1).toContain('"c4hero.location" "Unspecified"')
+    const reparsed = parseDSL(dsl1)
+    expect(serializeDSL(reparsed.workspace)).toBe(dsl1)
+  })
+
   it('an explicit Unspecified location also wins over an External tag on save', () => {
     // Same contradiction rule as Internal: any explicit non-External
     // location beats a stray External tag, so a save/reload cycle cannot

--- a/src/lib/dsl/url-tags-roundtrip.test.ts
+++ b/src/lib/dsl/url-tags-roundtrip.test.ts
@@ -187,7 +187,7 @@ describe('element custom tag roundtrip', () => {
       model: {
         people: [],
         softwareSystems: [
-          { id: 'sys', type: 'softwareSystem', name: 'Payments', tags: ['Element', 'Software System', 'External'], properties: {}, containers: [] },
+          { id: 'sys', type: 'softwareSystem', name: 'Payments', tags: ['Element', 'Software System', 'Critical'], properties: {}, containers: [] },
         ],
         relationships: [],
         groups: [],
@@ -203,7 +203,10 @@ describe('element custom tag roundtrip', () => {
     const { workspace, errors } = parseDSL(serializeDSL(ws))
     expect(errors).toEqual([])
     const sys = workspace.model.softwareSystems.find(s => s.name === 'Payments')
-    expect(sys?.tags).toContain('External')
+    // A genuinely opaque tag stays a tag. `External` is deliberately not used
+    // here — it is Structurizr's externality marker and maps to `location`,
+    // which location-roundtrip.test.ts covers.
+    expect(sys?.tags).toContain('Critical')
     expect(sys?.tags).toContain('Software System')
   })
 

--- a/src/lib/dsl/url-tags-roundtrip.test.ts
+++ b/src/lib/dsl/url-tags-roundtrip.test.ts
@@ -103,7 +103,8 @@ describe('relationship tag roundtrip', () => {
     const ws = makeWs()
     const dsl = serializeDSL(ws)
     // rel-2 has tag 'Secondary' and interactionStyle Asynchronous → block form
-    expect(dsl).toContain('interactionStyle Asynchronous')
+    // (interactionStyle travels as a property; Structurizr rejects the bare keyword)
+    expect(dsl).toContain('"c4hero.interactionStyle" "Asynchronous"')
     expect(dsl).toContain('tags "Secondary"')
     const { workspace, errors } = parseDSL(dsl)
     expect(errors).toEqual([])

--- a/src/store/slices/group-slice.ts
+++ b/src/store/slices/group-slice.ts
@@ -35,8 +35,14 @@ export const createGroupSlice: StateCreator<
 
   deleteGroup: (id) => set((s) => {
     if (!s.workspace) return
-    if (!s.workspace.model.groups.some(g => g.id === id)) return
+    const deleted = s.workspace.model.groups.find(g => g.id === id)
+    if (!deleted) return
     pushUndoSnapshot(s)
+    for (const group of s.workspace.model.groups) {
+      if (group.parentId !== id) continue
+      if (deleted.parentId) group.parentId = deleted.parentId
+      else delete group.parentId
+    }
     s.workspace.model.groups = s.workspace.model.groups.filter(g => g.id !== id)
     if (s.selectedGroupId === id) s.selectedGroupId = null
   }),

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -66,6 +66,21 @@ describe('Group store actions', () => {
     expect(ws.model.groups).toHaveLength(0)
   })
 
+  it('deleteGroup reparents explicit child groups', () => {
+    const ws = useWorkspaceStore.getState().workspace!
+    ws.model.groups = [
+      { id: 'outer', name: 'Outer', elementIds: ['alice', 'api'] },
+      { id: 'middle', name: 'Middle', elementIds: ['alice'], parentId: 'outer' },
+      { id: 'inner', name: 'Inner', elementIds: ['alice'], parentId: 'middle' },
+    ]
+
+    useWorkspaceStore.getState().deleteGroup('middle')
+    expect(useWorkspaceStore.getState().workspace!.model.groups.find(g => g.id === 'inner')?.parentId).toBe('outer')
+
+    useWorkspaceStore.getState().deleteGroup('outer')
+    expect(useWorkspaceStore.getState().workspace!.model.groups.find(g => g.id === 'inner')?.parentId).toBeUndefined()
+  })
+
   it('deleteGroup clears selectedGroupId if it was the deleted group', () => {
     useWorkspaceStore.getState().addGroup('Team', ['alice'])
     const id = useWorkspaceStore.getState().workspace!.model.groups[0].id

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -58,6 +58,10 @@ export interface Group {
   id: string
   name: string
   elementIds: string[]
+  /** Explicit hierarchy retained from nested Structurizr group blocks.
+   *  Older c4hero workspaces omit this; strict subset membership still lets
+   *  the serializer infer their hierarchy. */
+  parentId?: string
 }
 
 export type ModelElement = Person | SoftwareSystem | Container | Component

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -6,6 +6,19 @@ export type LayoutDirection = 'TB' | 'BT' | 'LR' | 'RL'
 export type ElementStatus = 'Live' | 'Planned' | 'Deprecated' | 'Removed'
 export type LineStyle = 'Curved' | 'Straight' | 'Orthogonal'
 
+// Runtime guards for the unions above. The DSL parser validates untrusted
+// input against these in two places each (legacy bare keyword + property
+// hoist), so they live next to the type to keep the lists from diverging.
+export function isElementStatus(v: string): v is ElementStatus {
+  return v === 'Live' || v === 'Planned' || v === 'Deprecated' || v === 'Removed'
+}
+export function isInteractionStyle(v: string): v is InteractionStyle {
+  return v === 'Synchronous' || v === 'Asynchronous'
+}
+export function isLineStyle(v: string): v is LineStyle {
+  return v === 'Curved' || v === 'Straight' || v === 'Orthogonal'
+}
+
 // ─── Elements ────────────────────────────────────────────────────────
 
 export interface BaseElement {


### PR DESCRIPTION
Fixes all four issues in [#109](https://github.com/c4hero/c4hero/issues/109) (TEA-163, TEA-164).

## Root cause

c4hero's parser and serializer agreed with **each other** but not with Structurizr. Every round-trip test passed while the emitted DSL was rejected or silently misread everywhere else.

I verified the real contract against `structurizr-java 5.0.2` instead of inferring it — and it differs from what the ticket assumed. Structurizr's tokenizer *does* support `\"` and `\n`. What it does **not** do is collapse `\\`:

```
emitted   container "X:\\"
stored    X:\"            <- and the parse ran on into the next token
```

That case **passes validation** while storing a corrupted value. Worth dwelling on: a conformance gate that only checked exit status would not have caught the original bug.

## Verified tokenizer contract

| DSL literal | Value Structurizr stores |
| --- | --- |
| `"C:\Users\me"` | `C:\Users\me` — backslash literal |
| `"Say \"hi\""` | `Say "hi"` — `\"` is a real escape |
| `"line1\nline2"` | `line1`⏎`line2` — `\n` is a real escape |
| `"a\tb"` | `a\tb` — `\t` is **not** an escape |
| `"X:\\"` | `X:\"` — `\\` **not** collapsed |
| `"a\\"b"` | `a\"b` — a missed escape consumes **one** char, so the second `\` starts the `\"` escape |
| `"X:\"` | `X:"` — trailing `\` eats the closing quote |

## Changes

- **`escapeString`** — escape only `"` and newline; emit other backslashes verbatim. A backslash before a quote is representable (raw `a\"b` emits as `a\\"b` and round-trips byte-exact — see the table row above; an earlier revision of this PR dropped it unnecessarily). Drop only the backslashes that genuinely cannot be represented: before an `n` (any run length decodes into a newline escape) and at end of value (escapes the closing quote → "Too many tokens").
- **`lexer`** — decode only `\"` and `\n`, and consume just **one** char on a missed escape, mirroring the real tokenizer exactly (the old two-char consume disagreed with Structurizr on backslash-heavy values like `a\\"b`). The old divergence is what made the corruption invisible locally.
- **tags** — routed through `escapeString`, commas stripped (Structurizr's tag separator).
- **`location`** — emit the `External` tag; Structurizr removed the keyword. The model field stays because the canvas renders from it (`canvasBuilders.ts:69`, `SystemNode`/`PersonNode`), and the parser maps the tag back.
- **`owner`** — never a Structurizr keyword; travels inside `properties`, hoisted back to the field on parse.
- **`status` / `lineStyle` / `interactionStyle`** — same class as `owner` (see finding 3 below); travel as `c4hero.status` / `c4hero.lineStyle` / `c4hero.interactionStyle` properties. The parser hoists valid enum members back onto the fields and leaves anything else as a plain property; derived keys win over a colliding user property, so serialize → parse → serialize stays byte-identical.
- **`autoLayout`** — emit lowercase rank directions.
- **groups** — emit element declarations inside valid group scopes at the model/container/component level; infer subset nesting, retain explicit equal-set nesting, emit `structurizr.groupSeparator`, and block irreducible overlaps with an actionable save/export error.

Legacy bare `location`, `owner`, `status`, `lineStyle` and `interactionStyle` keywords still parse on import, and win over the property form when both appear.

## Three findings beyond the ticket

All the same class (emitting DSL the real parser rejects). The first and third are fixed here; the second is scoped out.

1. **`autoLayout LR` is invalid.** Structurizr accepts only `tb|bt|lr|rl`. Every view with a non-default direction was emitting invalid DSL. Fixed here.
2. **View keys may only contain `a-zA-Z0-9_-`.** The IcePanel fixture uses `"Label 602"`. This is **not** our bug — the source file fails validation at its own line 814 before c4hero touches it. But c4hero can also *generate* such keys from user input, so it needs its own decision (reject at input vs sanitise at export). Filed separately; not fixed here.
3. **Bare `status`, `lineStyle` and `interactionStyle` are also invalid.** Rejected outright by the real parser ("Unexpected tokens (expected: ... description, tags, url, properties, perspectives ...)"), same as `location`/`owner` — but the gate stayed green because nothing in its corpus used these fields. Found by comparing against the competing agent PR #119; fixed here (routed through `properties`, see above), and the hostile fixture now exercises every one of these fields so the gap can't reopen.

## The gate

`dsl-conformance` runs the real CLI (pinned to `2025.11.09`) over the four templates, a hostile-strings fixture built from #109's exact values, the grouped IcePanel landscape, and nested model/container/component groups.

- Asserts **value fidelity**, not just exit status — see the `"X:\\"` case above.
- The hostile fixture now also covers an element `status`, a relationship carrying description/technology/`interactionStyle`/`lineStyle`/url/a comma-bearing tag/a user property, and a backslash-before-quote value — each pinned to the exact value the real parser stores.
- **Fails rather than skips** when `STRUCTURIZR_CONFORMANCE=1`, so a broken download can't become a green skip. A silently-skipping suite is the same false confidence this PR exists to remove.
- Skips locally when the CLI is absent, so `npm test` stays fast. `npm run test:conformance` to run it.


## Relationship to PR #119

#119 attacked the same ticket independently and found the three genuine defects above that this branch's first revision missed (bare `status`/`lineStyle`/`interactionStyle`, lossless `\\"` emission, consume-one lexer semantics). Those are ported here. Its lossy newline/tab→space flattening and its lexer's refusal to decode `\n` were deliberately **not** adopted — both diverge from the measured behaviour of the real CLI, which this branch's `\n`-escape + literal-tab policy matches losslessly.

## Deferred

Pre-fix c4hero files containing old-style `\\` / `\t` escapes now read back with doubled backslashes / a literal `\t` (silent value drift on import of old saves). #119's document-level legacy-marker heuristic is a defensible fix but deserves its own review — filed as TEA-167 rather than grown into this PR.

## Test plan

- [x] `npm run check` — 1861 passed, exit 0
- [x] `STRUCTURIZR_CONFORMANCE=1 npm run test:conformance` with the real CLI — 19 passed
- [x] Pre-existing tests asserting the old contract (bare keyword emissions, dropped `\"` backslash, two-char lexer consume) were updated, each with a comment on why

Closes TEA-163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTwQGLTnFVd2aW7QYcaZ57
