### PR TITLE
test(e2e): wait for the canvas to settle before clicking a relationship

### DIFF
--- a/e2e/fixtures/workspace.ts
+++ b/e2e/fixtures/workspace.ts
@@ -413,6 +413,70 @@ export class WorkspaceHelper {
     await this.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
   }
 
+  // loadSample() resolves once .react-flow is visible, but React Flow is still
+  // running its fitView animation at that point. Any screen coordinate read before
+  // it settles refers to a viewport that has already moved on.
+  async waitForCanvasSettled() {
+    await this.page.waitForFunction(
+      () => {
+        const viewport = document.querySelector('.react-flow__viewport') as HTMLElement | null
+        if (!viewport) return false
+        const state = window as unknown as { __c4Viewport?: { transform: string; stable: number } }
+        const transform = viewport.style.transform
+        const seen = state.__c4Viewport
+        if (!seen || seen.transform !== transform) {
+          state.__c4Viewport = { transform, stable: 1 }
+          return false
+        }
+        seen.stable += 1
+        return seen.stable >= 3
+      },
+      null,
+      { polling: 100, timeout: 10_000 },
+    )
+  }
+
+  // Selecting an edge by clicking a bounding-box centre does not work: an edge
+  // label sits at the path midpoint and covers it, and parts of the path run
+  // underneath the nodes it connects. Both depend on layout geometry, which varies
+  // with viewport and font metrics, so any fixed point is a coin flip across
+  // environments. Probe along the path instead and click the first point that
+  // actually hit-tests to this edge.
+  async clickRelationship(index = 0) {
+    const path = this.page.locator('.react-flow__edge-interaction').nth(index)
+    await expect(path).toBeAttached()
+    await this.waitForCanvasSettled()
+
+    const found = await path.evaluate((el) => {
+      const p = el as SVGPathElement
+      const m = p.getScreenCTM()
+      if (!m) return { point: null, probes: ['path is not rendered'] }
+      const total = p.getTotalLength()
+      const probes: string[] = []
+      // Midpoint outwards: the middle of an edge is the part least likely to be
+      // occluded by the nodes at either end.
+      for (const f of [0.5, 0.4, 0.6, 0.3, 0.7, 0.25, 0.75, 0.2, 0.8]) {
+        const at = p.getPointAtLength(total * f)
+        const x = at.x * m.a + at.y * m.c + m.e
+        const y = at.x * m.b + at.y * m.d + m.f
+        const hit = document.elementFromPoint(x, y)
+        if (hit === p) return { point: { x, y }, probes }
+        probes.push(`${f}: ${hit ? `${hit.tagName}.${hit.getAttribute('class') ?? ''}` : 'null'}`)
+      }
+      return { point: null, probes }
+    })
+
+    if (!found.point) {
+      throw new Error(
+        `No point on edge ${index} hit-tests to the edge itself. Probed:\n  ${found.probes.join('\n  ')}`,
+      )
+    }
+
+    await this.page.mouse.click(found.point.x, found.point.y)
+    // Fail here rather than at a downstream assertion if the click did not select.
+    await expect(this.page.locator('.react-flow__edge.selected')).toHaveCount(1)
+  }
+
   async getElementByName(name: string) {
     const ws = await this.getWorkspace()
     if (!ws) return undefined

--- a/e2e/panels/right-panel.spec.ts
+++ b/e2e/panels/right-panel.spec.ts
@@ -51,7 +51,7 @@ test.describe('Right Panel', () => {
 
   test('relationship controls stay neutral by default and can be reset to defaults', async ({ workspace }) => {
     await workspace.loadSample()
-    await workspace.page.locator('[aria-label^="Edge from "]').first().click({ force: true })
+    await workspace.clickRelationship()
 
     const defaultInteraction = workspace.page.getByRole('button', { name: 'Interaction style: Default' })
     const asyncInteraction = workspace.page.getByRole('button', { name: 'Interaction style: Asynchronous' })


### PR DESCRIPTION
Fixes the flaky `e2e/panels/right-panel.spec.ts:52` failure that turned `main` red after the round-2 dependency bumps (#130) and passed on re-run.

## Root cause: a race with fitView, not the click target

My first theory was the click target. It was wrong, and the trace from the failing CI run settles it.

`loadSample()` resolves as soon as `.react-flow` is visible, but React Flow is still running its `fitView` animation at that moment. Reproduced locally under 20x CPU throttling:

```
right after loadSample():   translate(0px, 0px) scale(1)
400ms later:                translate(174.079px, 91.775px) scale(0.564752)
```

So the viewport is unfitted when `loadSample()` returns, then moves. Any screen coordinate computed in that window points at a viewport that has already moved on. The CI trace shows the click landing at `x=915` where the settled layout puts that edge near `x=384`, and the screencast frames show the whole diagram re-fitting between the click and the assertion.

This is why it is environment-sensitive: local machines finish the animation before the click, CI (slower, `workers: 1`) does not. It also explains why only this test trips — Playwright's actionability checks include a bounding-box stability wait, so ordinary locator clicks are protected. A hand-computed `page.mouse.click()` is not.

The `@dagrejs/dagre` 3.0.0 → 3.1.0 bump changed layout geometry enough to shift which side of the race we landed on; it didn't create the bug.

## Fix

`waitForCanvasSettled()` waits for the React Flow viewport transform to hold steady across three polls. `clickRelationship()` calls it before resolving any coordinate.

`clickRelationship()` also probes along the path instead of using a fixed point. That part of the original theory did hold up: measuring all nine edges in the sample workspace, `elementFromPoint` at the interaction path's bbox centre returns an edge **label** every time, never the stroke — so a centre click only ever selected the edge by way of the label.

```
Edge from customer to internetBanking      SPAN.text-[11px]   onStroke: false
Edge from internetBanking to mainframe     SPAN.text-[11px]   onStroke: false
... 9/9 onStroke: false
```

It ends by asserting an edge became selected, so a future failure points at the click rather than at a downstream assertion.

## Verification

- Throttled reproduction confirms the viewport moves after `loadSample()` and is stable after `waitForCanvasSettled()`
- Full Playwright suite with `--workers=1`, matching CI: 158 passed, 1 skipped
- `npm run check` — lint, typecheck, 1861 unit tests, build

## Deliberately out of scope

`selectNewestRelationship()` and the gauntlet specs compute coordinates the same way and are exposed to the same race; they can now call `waitForCanvasSettled()`. Putting the wait inside `loadSample()` would fix the class outright — happy to do that instead if you'd prefer, but it touches every test's timing so I kept this scoped to the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019i8EMfKVRjmbuRU55kohqU