### PR TITLE
fix(canvas): spread edges across seven connection points per side (TEA-162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Crowded nodes no longer stack their connections.** Each side of a node now
+  offers seven connection points instead of three, so a system with several
+  integrations fans them out along its edge rather than routing the fourth
+  relationship onto the same pixels as the first. Diagrams with one, two or
+  three connections on a side are unchanged. Reported in
+  [#108](https://github.com/c4hero/c4hero/issues/108).
 - Corrected the documented AI feature set. The 0.3.0 notes and the README both
   described a **From your code** repo scan that proposes elements from a local
   repository. That feature was never shipped — no implementation exists — so the

--- a/e2e/canvas/connections.spec.ts
+++ b/e2e/canvas/connections.spec.ts
@@ -227,6 +227,36 @@ test.describe('Node Connections', () => {
     expect(await workspace.getEdgeCount()).toBe(2)
   })
 
+  test('a connection point grows under the cursor without sliding off the border', async ({ workspace }) => {
+    await workspace.loadSample()
+
+    const node = workspace.page.locator('.react-flow__node').first()
+    const nodeId = await node.getAttribute('data-id')
+    await node.locator('.c4-node').hover()
+
+    for (const side of ['right', 'bottom']) {
+      const dot = workspace.page.locator(`[data-nodeid="${nodeId}"][data-handleid="${side}-b-source"]`).first()
+      const before = await dot.boundingBox()
+      await dot.hover({ force: true })
+      await workspace.page.waitForTimeout(300)
+      const after = await dot.boundingBox()
+      if (!before || !after) throw new Error(`No bounding box for the ${side} handle`)
+
+      // It should get bigger...
+      expect(after.width).toBeGreaterThan(before.width)
+      // ...around the same point. React Flow centres handles on the border with
+      // a percentage translate; a hover transform overrides that and the dot
+      // jumps out from under the cursor.
+      const centre = (box: { x: number; y: number; width: number; height: number }) =>
+        ({ x: box.x + box.width / 2, y: box.y + box.height / 2 })
+      expect(Math.abs(centre(after).x - centre(before).x)).toBeLessThan(0.5)
+      expect(Math.abs(centre(after).y - centre(before).y)).toBeLessThan(0.5)
+
+      await workspace.page.mouse.move(5, 5)
+      await node.locator('.c4-node').hover()
+    }
+  })
+
   // ─── Handle slot distribution ─────────────────────────────────────────────
 
   test('six relationships into one system land on six separate connection points', async ({ workspace }) => {

--- a/e2e/canvas/connections.spec.ts
+++ b/e2e/canvas/connections.spec.ts
@@ -229,6 +229,57 @@ test.describe('Node Connections', () => {
 
   // ─── Handle slot distribution ─────────────────────────────────────────────
 
+  test('six relationships into one system land on six separate connection points', async ({ workspace }) => {
+    // GH #108: past the third edge, connections used to stack back onto the
+    // points already taken and the lines crossed each other.
+    const callers = ['one', 'two', 'three', 'four', 'five', 'six']
+    await workspace.parseAndLoad(`workspace "Six Integrations" {
+  model {
+    hub = softwareSystem "Hub"
+${callers.map((id) => `    ${id} = softwareSystem "System ${id}"`).join('\n')}
+
+${callers.map((id) => `    ${id} -> hub "Integrates with"`).join('\n')}
+  }
+  views {
+    systemLandscape landscape "Landscape" {
+      include *
+      autolayout lr
+    }
+  }
+}`)
+
+    await expect(workspace.page.locator('.react-flow__edge')).toHaveCount(6)
+
+    // Stack the callers in a column directly to the left of the hub, close
+    // enough that every relationship enters the hub's left side — the shape a
+    // context view takes when one system has a lot of integrations.
+    await workspace.page.evaluate((ids) => {
+      const store = (window as Record<string, unknown>).__testStore as () => {
+        updateNodePositions: (updates: Array<{ id: string; x: number; y: number }>) => void
+      }
+      store().updateNodePositions([
+        { id: 'hub', x: 900, y: 500 },
+        ...ids.map((id, i) => ({ id, x: 0, y: 380 + i * 60 })),
+      ])
+    }, callers)
+    await workspace.page.waitForTimeout(300)
+
+    // Every edge ends at its own point on the hub — the last coordinate pair in
+    // the path data is where the arrow touches the node.
+    const endpoints = await workspace.page.$$eval('.react-flow__edge path[marker-end]', (paths) =>
+      paths.map((path) => {
+        const numbers = (path.getAttribute('d') ?? '').match(/-?\d+(\.\d+)?/g) ?? []
+        return numbers.slice(-2).map((n) => Math.round(Number(n))).join(',')
+      }),
+    )
+    expect(endpoints).toHaveLength(6)
+    expect(new Set(endpoints).size).toBe(6)
+
+    // ...and the hub reveals a connection point for each of them.
+    const occupied = workspace.page.locator('[data-nodeid="hub"].c4-handle-extra:not(.c4-handle-hidden-extra)')
+    await expect(occupied).toHaveCount(6)
+  })
+
   test('two connections on same side of a node use different handle slots', async ({ workspace }) => {
     await workspace.loadBlank()
 

--- a/src/components/canvas/canvasBuilders.test.ts
+++ b/src/components/canvas/canvasBuilders.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { buildNodes } from './canvasBuilders'
+import type { Node } from '@xyflow/react'
+import { buildEdges, buildNodes } from './canvasBuilders'
+import { handleSide, handleSlot } from './handleSlots'
 import type { HighlightFilters } from '@/lib/highlight'
 import { THEMES } from '@/lib/themes'
 import type { ElementStyle, Workspace } from '@/types/model'
@@ -92,5 +94,93 @@ describe('buildNodes theme styles', () => {
     const style = renderedStyle([vipStyle], THEMES.structurizr, ['Element', 'Person', 'VIP'])
     expect(style.background).toBe('#441155')
     expect(style.stroke).toBe('#dd77ff')
+  })
+})
+
+/** Hub system with `callerCount` systems wired into it from the left, so every
+ *  one of those relationships lands on the hub's left side. */
+function hubWorkspace(callerCount: number): Workspace {
+  const callers = Array.from({ length: callerCount }, (_, i) => `caller${i}`)
+  return {
+    name: 'Hub test',
+    model: {
+      people: [],
+      softwareSystems: [
+        { id: 'hub', type: 'softwareSystem', name: 'Hub', tags: ['Element', 'Software System'], properties: {}, containers: [] },
+        ...callers.map((id) => ({
+          id, type: 'softwareSystem' as const, name: id, tags: ['Element', 'Software System'], properties: {}, containers: [],
+        })),
+      ],
+      relationships: callers.map((id) => ({
+        id: `rel-${id}`, sourceId: id, destinationId: 'hub', tags: ['Relationship'], properties: {},
+      })),
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [
+        {
+          type: 'systemLandscape',
+          key: 'landscape',
+          elements: [{ id: 'hub' }, ...callers.map((id) => ({ id }))],
+          relationships: callers.map((id) => ({ id: `rel-${id}` })),
+        },
+      ],
+      systemContextViews: [],
+      containerViews: [],
+      componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+/** Callers stacked in a column to the left of the hub. */
+function hubNodes(callerCount: number): Node[] {
+  return [
+    { id: 'hub', type: 'softwareSystem', position: { x: 1200, y: 600 }, data: {} },
+    ...Array.from({ length: callerCount }, (_, i) => ({
+      id: `caller${i}`,
+      type: 'softwareSystem',
+      position: { x: 0, y: i * 200 },
+      data: {},
+    })),
+  ]
+}
+
+function hubEdges(callerCount: number) {
+  const ws = hubWorkspace(callerCount)
+  return buildEdges(ws, ws.views.systemLandscapeViews[0], hubNodes(callerCount), NO_FILTERS)
+}
+
+describe('buildEdges handle routing', () => {
+  it('gives six relationships entering one side six distinct handles', () => {
+    // GH #108: past three, edges used to stack back onto the same pixels.
+    const edges = hubEdges(6)
+    expect(edges).toHaveLength(6)
+
+    const targets = edges.map((e) => e.targetHandle)
+    expect(new Set(targets).size).toBe(6)
+    for (const handle of targets) {
+      expect(handleSide(handle!)).toBe('left')
+    }
+  })
+
+  it('still routes a lone relationship through the centre slot', () => {
+    const [edge] = hubEdges(1)
+    expect(edge.sourceHandle).toBe('right-b-source')
+    expect(edge.targetHandle).toBe('left-b-target')
+  })
+
+  it('routes two and three relationships through the slots they always used', () => {
+    expect(hubEdges(2).map((e) => e.targetHandle)).toEqual(['left-a-target', 'left-c-target'])
+    expect(hubEdges(3).map((e) => e.targetHandle)).toEqual(['left-a-target', 'left-b-target', 'left-c-target'])
+  })
+
+  it('only ever names handles the renderer knows how to draw', () => {
+    for (const edge of hubEdges(7)) {
+      for (const handle of [edge.sourceHandle, edge.targetHandle]) {
+        expect(handleSide(handle!)).not.toBeNull()
+        expect(handleSlot(handle!)).not.toBeNull()
+      }
+    }
   })
 })

--- a/src/components/canvas/canvasBuilders.ts
+++ b/src/components/canvas/canvasBuilders.ts
@@ -7,6 +7,7 @@ import {
   groupSpansBoundaryClusters,
   type LayoutBoundaryCluster,
 } from '@/lib/canvasLayout'
+import { CENTER_SLOT, handleId, pickSlots, type Side } from './handleSlots'
 import type { ModelElement, ElementStyle, RelationshipStyle, View, Workspace } from '@/types/model'
 
 /** Build a tag → style index from the styles array (O(S) once, then O(1) lookups) */
@@ -73,8 +74,16 @@ function getChildCount(element: ModelElement): number | undefined {
   return undefined
 }
 
+function centerPair(sourceSide: Side, targetSide: Side) {
+  return {
+    sourceHandle: handleId(sourceSide, CENTER_SLOT, 'source'),
+    targetHandle: handleId(targetSide, CENTER_SLOT, 'target'),
+  }
+}
+
 /** Pick the best source/target handle sides based on relative node positions.
- *  Uses center slot (b) by default. Handle ID format: {side}-{slot}-{type} */
+ *  Uses the center slot; buildEdges spreads them apart afterwards when several
+ *  edges share a side. Handle ID format: {side}-{slot}-{type} */
 function computeHandlePair(
   srcPos: { x: number; y: number },
   dstPos: { x: number; y: number },
@@ -82,20 +91,11 @@ function computeHandlePair(
   const dx = dstPos.x - srcPos.x
   const dy = dstPos.y - srcPos.y
 
-  // Use the dominant axis to pick sides, default to center slot (b)
+  // Use the dominant axis to pick sides
   if (Math.abs(dx) > Math.abs(dy)) {
-    if (dx > 0) {
-      return { sourceHandle: 'right-b-source', targetHandle: 'left-b-target' }
-    } else {
-      return { sourceHandle: 'left-b-source', targetHandle: 'right-b-target' }
-    }
-  } else {
-    if (dy > 0) {
-      return { sourceHandle: 'bottom-b-source', targetHandle: 'top-b-target' }
-    } else {
-      return { sourceHandle: 'top-b-source', targetHandle: 'bottom-b-target' }
-    }
+    return dx > 0 ? centerPair('right', 'left') : centerPair('left', 'right')
   }
+  return dy > 0 ? centerPair('bottom', 'top') : centerPair('top', 'bottom')
 }
 
 /** Pre-compute the set of element IDs that can be drilled into (have a child view).
@@ -480,28 +480,6 @@ export function buildBoundaryNodes(
   return boundaries
 }
 
-/** Distribute multiple edges on the same side across 3 slots (a–c) */
-const SLOTS = ['a', 'b', 'c'] as const
-
-/**
- * Pick N slots from the 3 available, centered on b.
- * N=1→[b], N=2→[a,c], N=3→[a,b,c],
- * N>3→cycle through all 3.
- */
-function pickSlots(n: number): string[] {
-  if (n <= 0) return []
-  const all = SLOTS as unknown as string[]
-  if (n >= all.length) {
-    // More edges than slots: assign all slots then cycle
-    return Array.from({ length: n }, (_, i) => all[i % all.length])
-  }
-  const spread: Record<number, string[]> = {
-    1: ['b'],
-    2: ['a', 'c'],
-  }
-  return spread[n] ?? all
-}
-
 /** Build edges using final node positions for optimal handle routing. */
 export function buildEdges(
   workspace: Workspace,
@@ -540,7 +518,7 @@ export function buildEdges(
     const dstPos = posMap.get(rel.destinationId)
     const handles = srcPos && dstPos
       ? computeHandlePair(srcPos, dstPos)
-      : { sourceHandle: 'bottom-b-source', targetHandle: 'top-b-target' }
+      : centerPair('bottom', 'top')
 
     // Extract side name (e.g. "right" from "right-b-source")
     const sourceSide = handles.sourceHandle.split('-')[0]
@@ -597,8 +575,8 @@ export function buildEdges(
   const edges: Edge[] = []
   for (let i = 0; i < edgeInfos.length; i++) {
     const e = edgeInfos[i]
-    const srcSlot = sourceSlots.get(i) ?? 'b'
-    const tgtSlot = targetSlots.get(i) ?? 'b'
+    const srcSlot = sourceSlots.get(i) ?? CENTER_SLOT
+    const tgtSlot = targetSlots.get(i) ?? CENTER_SLOT
 
     const techHighlighted = techActive && isHighlightedRel(e.rel, filters)
     const endpointsHighlighted = highlightedNodeIds.has(e.sourceId) && highlightedNodeIds.has(e.targetId)
@@ -613,8 +591,8 @@ export function buildEdges(
       id: e.rel.id,
       source: e.sourceId,
       target: e.targetId,
-      sourceHandle: `${e.sourceSide}-${srcSlot}-source`,
-      targetHandle: `${e.targetSide}-${tgtSlot}-target`,
+      sourceHandle: handleId(e.sourceSide, srcSlot, 'source'),
+      targetHandle: handleId(e.targetSide, tgtSlot, 'target'),
       type: 'relationship',
       data: { relationship: e.rel, relationshipStyle: e.relStyle, highlighted },
       className,

--- a/src/components/canvas/handleSlots.test.ts
+++ b/src/components/canvas/handleSlots.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { CENTER_SLOT, SLOTS, handleSide, handleSlot, handleId, pickSlots, slotOffset } from './handleSlots'
+
+const percent = (slot: string) => Number.parseFloat(slotOffset(slot))
+
+describe('slot offsets', () => {
+  it('spreads seven slots evenly across the side', () => {
+    expect(SLOTS.map(slotOffset)).toEqual([
+      '12.5%', '25%', '37.5%', '50%', '62.5%', '75%', '87.5%',
+    ])
+  })
+
+  it('keeps a/b/c at the offsets they have always had', () => {
+    // Diagrams built before the pool grew must not move a single pixel.
+    expect(slotOffset('a')).toBe('25%')
+    expect(slotOffset('b')).toBe('50%')
+    expect(slotOffset('c')).toBe('75%')
+    expect(CENTER_SLOT).toBe('b')
+  })
+
+  it('falls back to centre for a slot it does not know', () => {
+    expect(slotOffset('nonsense')).toBe('50%')
+  })
+})
+
+describe('pickSlots', () => {
+  it('returns nothing for a side with no edges', () => {
+    expect(pickSlots(0)).toEqual([])
+    expect(pickSlots(-1)).toEqual([])
+  })
+
+  it('routes one, two and three edges exactly where it used to', () => {
+    expect(pickSlots(1)).toEqual(['b'])
+    expect(pickSlots(2)).toEqual(['a', 'c'])
+    expect(pickSlots(3)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('gives four to seven edges a distinct slot each', () => {
+    for (let n = 4; n <= SLOTS.length; n++) {
+      const slots = pickSlots(n)
+      expect(slots).toHaveLength(n)
+      expect(new Set(slots).size).toBe(n)
+    }
+  })
+
+  it('spreads six edges over six separate points instead of stacking three pairs', () => {
+    // The GH #108 case: six integrations entering one side of a system.
+    const slots = pickSlots(6)
+    expect(slots).toEqual(['x1', 'a', 'x3', 'x5', 'c', 'x7'])
+    expect(new Set(slots.map(percent)).size).toBe(6)
+  })
+
+  it('keeps every spread ordered and symmetric about the centre', () => {
+    for (let n = 1; n <= SLOTS.length; n++) {
+      const offsets = pickSlots(n).map(percent)
+      const ascending = [...offsets].sort((a, b) => a - b)
+      expect(offsets).toEqual(ascending)
+      // Mirroring the spread about 50% reproduces it.
+      expect(offsets.map((offset) => 100 - offset).reverse()).toEqual(offsets)
+    }
+  })
+
+  it('cycles the pool past seven edges rather than dropping any', () => {
+    const slots = pickSlots(9)
+    expect(slots).toHaveLength(9)
+    expect(slots.slice(0, 7)).toEqual([...SLOTS])
+    expect(slots.slice(7)).toEqual(['x1', 'a'])
+  })
+})
+
+describe('handle ids', () => {
+  it('round-trips side and slot', () => {
+    for (const slot of SLOTS) {
+      const id = handleId('right', slot, 'source')
+      expect(handleSide(id)).toBe('right')
+      expect(handleSlot(id)).toBe(slot)
+    }
+  })
+
+  it('rejects ids that are not ours', () => {
+    expect(handleSide('diagonal-a-source')).toBeNull()
+    expect(handleSlot('top-zzz-source')).toBeNull()
+  })
+})

--- a/src/components/canvas/handleSlots.ts
+++ b/src/components/canvas/handleSlots.ts
@@ -1,0 +1,94 @@
+/**
+ * Connection-point slots — the single source of truth for where edges may
+ * attach along a node side.
+ *
+ * Handle id format: `{side}-{slot}-{type}`, e.g. `right-b-source`.
+ *
+ * Both the renderer (`nodes/NodeHandles.tsx`) and the router
+ * (`canvasBuilders.ts` → `buildEdges`) import from here, so the names and the
+ * offsets can't drift apart.
+ *
+ * The pool holds seven slots, evenly spaced at `(i + 1) / 8` of the side:
+ *
+ *     x1     a    x3     b    x5     c    x7
+ *    12.5   25   37.5   50   62.5   75   87.5
+ *           ^^         ^^         ^^
+ *      the original three slots, unmoved
+ *
+ * Slots 2, 4 and 6 keep their historical `a`/`b`/`c` names at exactly their
+ * historical offsets, so diagrams built before the pool grew render pixel for
+ * pixel as they did. The `xN` names spell out the numerator over 8. Seven is
+ * odd on purpose: a lone edge still leaves dead centre.
+ */
+
+export const SIDES = ['top', 'bottom', 'left', 'right'] as const
+export type Side = (typeof SIDES)[number]
+
+export const SLOTS = ['x1', 'a', 'x3', 'b', 'x5', 'c', 'x7'] as const
+export type Slot = (typeof SLOTS)[number]
+
+/** The centre slot — where a single edge attaches, and the only slot every
+ *  node offers unconditionally. */
+export const CENTER_SLOT: Slot = 'b'
+
+export function isSide(value: string): value is Side {
+  return (SIDES as readonly string[]).includes(value)
+}
+
+/** CSS offset along the side for a slot, as a percentage string. */
+export function slotOffset(slot: string): string {
+  const index = (SLOTS as readonly string[]).indexOf(slot)
+  if (index < 0) return '50%'
+  // Trim the float: 25 stays "25%", 12.5 stays "12.5%".
+  return `${+(((index + 1) / (SLOTS.length + 1)) * 100).toFixed(4)}%`
+}
+
+/**
+ * Which slots to use for `n` edges sharing one side, as indexes into `SLOTS`.
+ *
+ * Every spread is symmetric about the centre and as evenly spaced as the pool
+ * allows. The first three are pinned to the pre-existing 25/50/75 layout — the
+ * overwhelmingly common case, and changing it would reflow every simple
+ * diagram for no benefit.
+ */
+const SPREAD_BY_COUNT: Record<number, readonly number[]> = {
+  1: [3],                 //             b
+  2: [1, 5],              //          a     c
+  3: [1, 3, 5],           //          a  b  c
+  4: [0, 2, 4, 6],        //       x1  x3  x5  x7
+  5: [0, 2, 3, 4, 6],     //       x1  x3 b x5  x7
+  6: [0, 1, 2, 4, 5, 6],  //       x1 a x3  x5 c x7
+  7: [0, 1, 2, 3, 4, 5, 6],
+}
+
+/**
+ * Pick `n` slots for `n` edges landing on the same node side.
+ *
+ * Callers pass edges already sorted by the position of the node at the far end,
+ * so assigning slots in order fans the edges out without crossing them.
+ *
+ * Past a full pool the slots cycle and edges do double up — seven simultaneous
+ * connections on one side of one node is already well past what stays readable.
+ */
+export function pickSlots(n: number): Slot[] {
+  if (n <= 0) return []
+  const spread = SPREAD_BY_COUNT[n]
+  if (spread) return spread.map((index) => SLOTS[index])
+  return Array.from({ length: n }, (_, i) => SLOTS[i % SLOTS.length])
+}
+
+export function handleId(side: string, slot: string, type: 'source' | 'target'): string {
+  return `${side}-${slot}-${type}`
+}
+
+/** Side a handle id belongs to, or null if it isn't one of ours. */
+export function handleSide(handleId: string): Side | null {
+  const side = handleId.split('-')[0]
+  return isSide(side) ? side : null
+}
+
+/** Slot a handle id names, or null if it isn't one of ours. */
+export function handleSlot(handleId: string): Slot | null {
+  const slot = handleId.split('-')[1]
+  return (SLOTS as readonly string[]).includes(slot) ? (slot as Slot) : null
+}

--- a/src/components/canvas/nodes/NodeHandles.test.tsx
+++ b/src/components/canvas/nodes/NodeHandles.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { ReactFlow, type Edge, type Node } from '@xyflow/react'
 import NodeHandles from './NodeHandles'
+import { SIDES, SLOTS, handleId, pickSlots, slotOffset } from '../handleSlots'
 
 // ─── jsdom stubs required by React Flow (official testing recipe) ─────
 class ResizeObserverStub {
@@ -70,17 +71,35 @@ function handle(container: HTMLElement, nodeId: string, handleId: string): HTMLE
 }
 
 describe('NodeHandles', () => {
-  it('renders 12 source and 12 target handles per node (4 sides x 3 slots)', () => {
+  it('renders 28 source and 28 target handles per node (4 sides x 7 slots)', () => {
     const { container } = renderFlow()
     const n1Handles = container.querySelectorAll('[data-nodeid="n1"].c4-handle')
-    expect(n1Handles.length).toBe(24)
+    expect(n1Handles.length).toBe(56)
     const sources = container.querySelectorAll('[data-nodeid="n1"].source.c4-handle')
     const targets = container.querySelectorAll('[data-nodeid="n1"].target.c4-handle')
-    expect(sources.length).toBe(12)
-    expect(targets.length).toBe(12)
+    expect(sources.length).toBe(28)
+    expect(targets.length).toBe(28)
   })
 
-  it('positions slots at 25%/50%/75% along the correct axis', () => {
+  it('renders a handle for every slot the router can route to, at the shared offset', () => {
+    // Guards the one hazard of splitting slot names across two modules: a slot
+    // the router hands out that the renderer never draws.
+    const { container } = renderFlow()
+    const routable = new Set(pickSlots(SLOTS.length))
+    expect(routable).toEqual(new Set(SLOTS))
+
+    for (const side of SIDES) {
+      const alongTop = side === 'left' || side === 'right'
+      for (const slot of routable) {
+        for (const type of ['source', 'target'] as const) {
+          const el = handle(container, 'n1', handleId(side, slot, type))
+          expect(alongTop ? el.style.top : el.style.left).toBe(slotOffset(slot))
+        }
+      }
+    }
+  })
+
+  it('positions the original slots at 25%/50%/75% along the correct axis', () => {
     const { container } = renderFlow()
     // top/bottom sides offset via `left`
     expect(handle(container, 'n1', 'top-a-source').style.left).toBe('25%')
@@ -89,9 +108,12 @@ describe('NodeHandles', () => {
     // left/right sides offset via `top`
     expect(handle(container, 'n1', 'left-a-source').style.top).toBe('25%')
     expect(handle(container, 'n1', 'right-c-target').style.top).toBe('75%')
+    // the slots added either side of them
+    expect(handle(container, 'n1', 'top-x1-source').style.left).toBe('12.5%')
+    expect(handle(container, 'n1', 'left-x7-target').style.top).toBe('87.5%')
   })
 
-  it('hides side (a/c) handles and shows center (b) handles when no edges connect', () => {
+  it('hides non-centre handles and shows centre handles when no edges connect', () => {
     const { container } = renderFlow()
     // Center source handle: visible, never hidden
     const centerSource = handle(container, 'n1', 'top-b-source')
@@ -109,33 +131,57 @@ describe('NodeHandles', () => {
     expect(sideTarget.className).toContain('c4-handle-hidden-extra')
   })
 
-  it('reveals extra handles on sides occupied by a source connection', () => {
+  it('reveals exactly the slots an edge lands on, both ends', () => {
     const { container } = renderFlow([
-      { id: 'e1', source: 'n1', target: 'n2', sourceHandle: 'right-a-source', targetHandle: 'left-b-target' },
+      { id: 'e1', source: 'n1', target: 'n2', sourceHandle: 'right-x1-source', targetHandle: 'left-c-target' },
     ])
-    // n1 right side occupied via sourceHandle
-    const occupiedSource = handle(container, 'n1', 'right-c-source')
+    // n1's right side: the occupied slot shows as a source dot and a drop zone
+    const occupiedSource = handle(container, 'n1', 'right-x1-source')
     expect(occupiedSource.className).toContain('c4-handle-extra')
     expect(occupiedSource.className).not.toContain('c4-handle-hidden-extra')
-    const occupiedTarget = handle(container, 'n1', 'right-a-target')
-    expect(occupiedTarget.className).not.toContain('c4-handle-hidden-extra')
-    // n1 top side remains unoccupied
-    expect(handle(container, 'n1', 'top-a-source').className).toContain('c4-handle-hidden-extra')
-    // n2 left side occupied via targetHandle
-    const n2Left = handle(container, 'n2', 'left-a-source')
-    expect(n2Left.className).toContain('c4-handle-extra')
+    expect(handle(container, 'n1', 'right-x1-target').className).not.toContain('c4-handle-hidden-extra')
+    // ...while the untouched slots on that same side stay hidden
+    expect(handle(container, 'n1', 'right-a-source').className).toContain('c4-handle-hidden-extra')
+    // n1 top side is untouched entirely
+    expect(handle(container, 'n1', 'top-x1-source').className).toContain('c4-handle-hidden-extra')
+    // n2's left side is occupied via targetHandle
+    expect(handle(container, 'n2', 'left-c-source').className).toContain('c4-handle-extra')
+    expect(handle(container, 'n2', 'left-x1-source').className).toContain('c4-handle-hidden-extra')
     // n2 right side unoccupied
-    expect(handle(container, 'n2', 'right-a-source').className).toContain('c4-handle-hidden-extra')
+    expect(handle(container, 'n2', 'right-c-source').className).toContain('c4-handle-hidden-extra')
   })
 
-  it('ignores edges without handle ids and handle ids with unknown sides', () => {
+  it('shows six separate points when six edges share a side', () => {
+    // The GH #108 case — previously slots 4-6 stacked back onto 1-3.
+    const slots = pickSlots(6)
+    const { container } = renderFlow(
+      slots.map((slot, i) => ({
+        id: `e${i}`,
+        source: 'n1',
+        target: 'n2',
+        sourceHandle: handleId('right', slot, 'source'),
+        targetHandle: 'left-b-target',
+      })),
+    )
+
+    const offsets = slots.map((slot) => handle(container, 'n1', handleId('right', slot, 'source')).style.top)
+    expect(new Set(offsets).size).toBe(6)
+    for (const slot of slots) {
+      expect(handle(container, 'n1', handleId('right', slot, 'source')).className)
+        .not.toContain('c4-handle-hidden-extra')
+    }
+  })
+
+  it('ignores edges without handle ids and handle ids with unknown sides or slots', () => {
     const { container } = renderFlow([
       // no handles at all — occupies nothing
       { id: 'e1', source: 'n1', target: 'n2' },
       // unknown side prefixes — filtered by the SIDES guard
       { id: 'e2', source: 'n1', target: 'n2', sourceHandle: 'diagonal-a-source', targetHandle: 'weird-b-target' },
+      // known side, slot that isn't in the pool
+      { id: 'e3', source: 'n1', target: 'n2', sourceHandle: 'top-zzz-source', targetHandle: 'bottom-zzz-target' },
     ])
-    for (const side of ['top', 'bottom', 'left', 'right']) {
+    for (const side of SIDES) {
       expect(handle(container, 'n1', `${side}-a-source`).className).toContain('c4-handle-hidden-extra')
       expect(handle(container, 'n2', `${side}-a-source`).className).toContain('c4-handle-hidden-extra')
     }

--- a/src/components/canvas/nodes/NodeHandles.tsx
+++ b/src/components/canvas/nodes/NodeHandles.tsx
@@ -1,21 +1,27 @@
 import { Handle, Position, useNodeId, useStore } from '@xyflow/react'
 import { useMemo } from 'react'
+import {
+  CENTER_SLOT,
+  SIDES,
+  SLOTS,
+  handleId as makeHandleId,
+  handleSide,
+  handleSlot,
+  slotOffset,
+  type Side,
+} from '../handleSlots'
 
 /**
  * Handle naming convention:
  *   {side}-{slot}-{type}
  *   side: top | bottom | left | right
- *   slot: a (25%) | b (50%, center) | c (75%)
+ *   slot: one of the seven positions in `handleSlots.SLOTS`
  *   type: source | target
  *
- * Center handles (b) always show on node hover.
- * Side handles (a, c) show when that side already has a connection.
+ * The centre slot always shows on node hover. The other six stay hidden until
+ * an edge actually lands on them, so a node with two connections shows two
+ * extra points rather than a picket fence of six.
  */
-
-const SIDES = ['top', 'bottom', 'left', 'right'] as const
-const SLOTS = ['a', 'b', 'c'] as const
-
-type Side = (typeof SIDES)[number]
 
 const POSITION_MAP: Record<Side, Position> = {
   top: Position.Top,
@@ -24,15 +30,8 @@ const POSITION_MAP: Record<Side, Position> = {
   right: Position.Right,
 }
 
-/** Percentage offset from the side start for each slot */
-const SLOT_OFFSET: Record<string, string> = {
-  a: '25%',
-  b: '50%',
-  c: '75%',
-}
-
 function getHandleStyle(side: Side, slot: string): React.CSSProperties {
-  const offset = SLOT_OFFSET[slot]
+  const offset = slotOffset(slot)
   if (side === 'top' || side === 'bottom') {
     return { left: offset }
   }
@@ -56,44 +55,52 @@ export default function NodeHandles() {
       prev.every((e, i) => e.id === next[i].id && e.sourceHandle === next[i].sourceHandle && e.targetHandle === next[i].targetHandle),
   )
 
-  // Determine which sides have existing connections
-  const occupiedSides = useMemo(() => {
-    const sides = new Set<Side>()
-    if (!nodeId) return sides
-    for (const edge of connectedEdges) {
-      if (edge.source === nodeId && edge.sourceHandle) {
-        const side = edge.sourceHandle.split('-')[0] as Side
-        if (SIDES.includes(side)) sides.add(side)
-      }
-      if (edge.target === nodeId && edge.targetHandle) {
-        const side = edge.targetHandle.split('-')[0] as Side
-        if (SIDES.includes(side)) sides.add(side)
-      }
+  // Slots this node's own edges land on, keyed by side. A slot counts as
+  // occupied whichever end of the edge it is — the source dot and the target
+  // drop zone at a given point reveal together.
+  const occupiedSlots = useMemo(() => {
+    const occupied = new Map<Side, Set<string>>()
+    if (!nodeId) return occupied
+
+    const occupy = (handleId: string) => {
+      const side = handleSide(handleId)
+      const slot = handleSlot(handleId)
+      if (!side || !slot) return
+      const slots = occupied.get(side) ?? new Set<string>()
+      slots.add(slot)
+      occupied.set(side, slots)
     }
-    return sides
+
+    for (const edge of connectedEdges) {
+      if (edge.source === nodeId && edge.sourceHandle) occupy(edge.sourceHandle)
+      if (edge.target === nodeId && edge.targetHandle) occupy(edge.targetHandle)
+    }
+    return occupied
   }, [nodeId, connectedEdges])
 
   return (
     <>
       {SIDES.map((side) => {
         const pos = POSITION_MAP[side]
-        const sideOccupied = occupiedSides.has(side)
+        const sideSlots = occupiedSlots.get(side)
 
         return SLOTS.map((slot) => {
-          const isCenter = slot === 'b'
-          const sourceId = `${side}-${slot}-source`
-          const targetId = `${side}-${slot}-target`
+          const isCenter = slot === CENTER_SLOT
+          const shown = isCenter || sideSlots?.has(slot) === true
+          const sourceId = makeHandleId(side, slot, 'source')
+          const targetId = makeHandleId(side, slot, 'target')
 
-          // Center handles always visible on hover; side handles only if occupied
+          // Centre handles always visible on hover; the rest only once an edge
+          // uses them.
           const sourceClass = isCenter
             ? 'c4-handle c4-handle-visible !border-0'
-            : sideOccupied
+            : shown
             ? 'c4-handle c4-handle-visible c4-handle-extra !border-0'
             : 'c4-handle c4-handle-visible c4-handle-hidden-extra !border-0'
 
           const targetClass = isCenter
             ? 'c4-handle c4-handle-target !border-0'
-            : sideOccupied
+            : shown
             ? 'c4-handle c4-handle-target !border-0'
             : 'c4-handle c4-handle-target c4-handle-hidden-extra !border-0'
 

--- a/src/index.css
+++ b/src/index.css
@@ -2200,15 +2200,10 @@ body {
   border-bottom-color: var(--node-glow, var(--canvas-selection, var(--color-accent))) !important;
 }
 
-/* Extra handles (slot a, c) on occupied sides show on hover */
+/* Extra handles on occupied slots show on hover */
 .c4-handle-extra {
   width: 6px;
   height: 6px;
-}
-
-/* Extra handles on unoccupied sides stay hidden even on hover */
-.c4-node:hover .c4-handle-hidden-extra {
-  opacity: 0 !important;
 }
 
 .c4-handle-visible:hover {
@@ -2225,11 +2220,17 @@ body {
   pointer-events: none !important;
 }
 
-/* Hidden extra targets stay hidden */
-.c4-handle-target.c4-handle-hidden-extra {
+/* Unused slots collapse to nothing: invisible but still-clickable handles would
+   line the node border with dead zones that start a connection instead of
+   dragging the node — and there are six of them per side now. */
+.c4-handle-hidden-extra {
   width: 0 !important;
   height: 0 !important;
   pointer-events: none !important;
+}
+
+.c4-node:hover .c4-handle-hidden-extra {
+  opacity: 0 !important;
 }
 
 /* When React Flow v12 is in connecting mode, valid target handles get class .connectionindicator.

--- a/src/index.css
+++ b/src/index.css
@@ -2182,7 +2182,7 @@ body {
   background: var(--color-border);
   border-radius: 50%;
   opacity: 0;
-  transition: opacity 150ms ease, background 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+  transition: opacity 150ms ease, background 150ms ease, width 150ms ease, height 150ms ease, box-shadow 150ms ease;
 }
 
 /* Center handles (slot b) show on node hover */
@@ -2206,10 +2206,21 @@ body {
   height: 6px;
 }
 
+/* Grow the box rather than scaling it. React Flow centres each handle on the
+   border with a percentage translate, which re-derives itself from the new
+   size — a transform would either replace that translate or scale about the
+   pre-translate origin, and either way the dot slides out from under the
+   cursor as it grows. */
 .c4-handle-visible:hover {
-  transform: scale(1.5);
+  width: 12px;
+  height: 12px;
   background: var(--canvas-selection, var(--color-accent-hover)) !important;
   box-shadow: 0 0 10px color-mix(in srgb, var(--canvas-selection, var(--color-accent-hover)) 60%, transparent) !important;
+}
+
+.c4-handle-extra:hover {
+  width: 9px;
+  height: 9px;
 }
 
 .c4-handle-target {


### PR DESCRIPTION
Fixes the root cause of #108.

## The problem

Each node side offered three attachment points, and `pickSlots` cycled once it ran out — the fourth relationship on a side landed on exactly the same pixels as the first. A context view of a system with six integrations drew them as three overlapping pairs, which is what the reporter saw as auto-layout "simply crossing lines".

## The change

The pool is now seven points per side, at 12.5 / 25 / 37.5 / 50 / 62.5 / 75 / 87.5%.

Slots 2, 4 and 6 keep the `a` / `b` / `c` names at their original 25/50/75 offsets, so one, two and three connections on a side render exactly where they always did — no reflow on existing diagrams.

Measured on a six-into-one landscape with the callers pinned to one side:

| | endpoints on the hub | handles per node |
|---|---|---|
| before | 3 distinct (6 edges) | 24 |
| after | 6 distinct (6 edges) | 56 |

Two smaller things came with it:

- Slot names and offsets now live in `src/components/canvas/handleSlots.ts`, imported by both the handle renderer and the edge router, instead of two arrays that had to be kept in sync by hand.
- Unused slots collapse to zero size. They were invisible but still clickable, and lining each border with six dead zones that start a connection instead of dragging the node would have been a regression.

Handle visibility also got tighter: a non-centre point now reveals itself when an edge actually lands on it, rather than every extra point on the side appearing as soon as the side had any connection.

## Second commit: hovering a connection point moved it

Reported while reviewing the above. Hovering a handle applied `transform: scale(1.5)`, which replaced the percentage translate React Flow uses to centre each handle on the node border — so the dot jumped half its own width diagonally as it grew, sliding out from under the cursor.

```
right handle centre, on hover:
  before   drift 5.6px diagonal   transform: matrix(1.5,0,0,1.5,0,0)   <- translate gone
  after    drift 0px              transform: matrix(1,0,0,1,6,-6)      <- translate intact, re-derived
```

The fix grows the box (8px to 12px, and 6px to 9px for the smaller dots) rather than transforming it. React Flow's translate is a percentage, so it recomputes from the new size and the centre holds still. The individual `scale` property — which composes with `transform` instead of replacing it — only gets drift down to 2px, because it scales about the pre-translate origin.

Pre-existing, but far easier to hit now that a node shows a point at every slot an edge lands on.

## Verification

- `npm run check` — lint, typecheck, 1878 unit tests, build.
- New unit coverage: `handleSlots.test.ts` (offsets, spreads, symmetry, backward compatibility), `NodeHandles.test.tsx` (renderer draws every slot the router can hand out, at the shared offset), `canvasBuilders.test.ts` (six relationships into one side get six distinct handles).
- New e2e, both confirmed to fail without their fix:
  - six-integration case asserts six distinct edge endpoints — fails on `main` with `Expected: 6, Received: 3`
  - hovered handle grows while its centre stays put — fails with `Expected: < 0.5, Received: 2.26`

Does not address the other half of #108 (a way to lock nodes against auto-layout) — that is TEA-161 and ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rj74LjHbHsRewHJMa5gEdg