### PR TITLE
feat(dsl): parse + serialize dynamic and deployment views, oracle-verified (TEA-81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter: stacked PRs target another PR's branch as their
+  # base, and a filter of [main] left their required checks "Expected -
+  # Waiting" forever (the workflow never triggered).
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dynamic and deployment views now round-trip through the DSL.** Workspaces
+  using `dynamic` views (ordered interaction steps, including response
+  messages and repeated steps) and `deployment` views (`deploymentEnvironment`,
+  nested `deploymentNode`s, `containerInstance` / `softwareSystemInstance`,
+  `infrastructureNode`) parse and re-serialize losslessly, verified against the
+  real Structurizr parser in CI. Canvas rendering for both view types is in
+  progress; until it lands these views are preserved, not yet drawn.
+
 ### Fixed
 
 - **Crowded nodes no longer stack their connections.** Each side of a node now

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -162,6 +162,8 @@ const VIEW_TYPE_LABELS: Record<View['type'], string> = {
   systemContext: 'System Context',
   container: 'Container',
   component: 'Component',
+  dynamic: 'Dynamic',
+  deployment: 'Deployment',
 }
 
 /** Short human label for a view, e.g. "Container view "Containers"". */

--- a/src/lib/ai/operations.ts
+++ b/src/lib/ai/operations.ts
@@ -349,6 +349,8 @@ const VIEW_KIND_LABEL: Record<ViewType, string> = {
   systemContext: 'a system context',
   container: 'a container',
   component: 'a component',
+  dynamic: 'a dynamic',
+  deployment: 'a deployment',
 }
 
 /** Human-readable, one-line-per-op preview, resolving existing ids to names. */

--- a/src/lib/ai/testFixture.ts
+++ b/src/lib/ai/testFixture.ts
@@ -29,12 +29,15 @@ export function makeWorkspace(): Workspace {
         { id: 'r2', sourceId: 'web', destinationId: 'db', tags: [], properties: {} }, // no description
       ],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: [],
       systemContextViews: [],
       containerViews: [],
       componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: { styles: { elements: [], relationships: [] } },
     },
   }

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -1,0 +1,89 @@
+// Deployment-model helpers shared by the DSL layer and (later) the canvas.
+//
+// Deployment elements (nodes, infrastructure nodes, instances) live in a tree
+// under Model.deploymentEnvironments, separate from the C4 element tree.
+
+import type {
+    Model,
+    DeploymentEnvironment,
+    DeploymentNode,
+    Relationship,
+} from '@/types/model'
+
+/** Depth-first walk over an environment's deployment node tree. */
+export function walkDeploymentNodes(env: DeploymentEnvironment, visit: (node: DeploymentNode) => void): void {
+    const stack = [...env.deploymentNodes]
+    while (stack.length > 0) {
+        const node = stack.pop()!
+        visit(node)
+        stack.push(...node.children)
+    }
+}
+
+/** Instance-to-instance relationships implied by the model, derived on demand.
+ *
+ *  Mirrors Structurizr's implied instance relationships: if container A ->
+ *  container B exists and both have instances in `environmentName`, each
+ *  instance pair gets a derived relationship carrying the original's
+ *  description/technology/style.
+ *
+ *  These are intentionally NOT materialized into `model.relationships`:
+ *  they are a projection of the container/system relationship, so storing
+ *  them would let users edit or delete copies that parse re-derives on the
+ *  next load (silently reverting the edit), and it forces every serializer
+ *  and view-population path to know which relationships are "real". The
+ *  canvas asks for them when rendering a deployment view instead.
+ *
+ *  Ids embed the source relationship id plus both instance ids, so two model
+ *  relationships between the same element pair derive distinct ids.
+ *
+ *  Instance pairs connected by an explicit model relationship (Structurizr
+ *  allows `liveWeb -> liveDb` between instances) are skipped — the explicit
+ *  relationship overrides the derived one. */
+export function deriveInstanceRelationships(model: Model, environmentName?: string): Relationship[] {
+    const derived: Relationship[] = []
+    const explicitPairs = new Set(model.relationships.map(r => `${r.sourceId}→${r.destinationId}`))
+
+    for (const env of model.deploymentEnvironments ?? []) {
+        if (environmentName !== undefined && env.name !== environmentName) continue
+
+        // Map: model element id -> instance ids within this environment
+        const instancesByElement = new Map<string, string[]>()
+        walkDeploymentNodes(env, node => {
+            for (const inst of node.containerInstances) {
+                const list = instancesByElement.get(inst.containerId) ?? []
+                list.push(inst.id)
+                instancesByElement.set(inst.containerId, list)
+            }
+            for (const inst of node.softwareSystemInstances) {
+                const list = instancesByElement.get(inst.softwareSystemId) ?? []
+                list.push(inst.id)
+                instancesByElement.set(inst.softwareSystemId, list)
+            }
+        })
+        if (instancesByElement.size === 0) continue
+
+        for (const rel of model.relationships) {
+            const sourceInstances = instancesByElement.get(rel.sourceId)
+            const destInstances = instancesByElement.get(rel.destinationId)
+            if (!sourceInstances || !destInstances) continue
+            for (const src of sourceInstances) {
+                for (const dst of destInstances) {
+                    if (explicitPairs.has(`${src}→${dst}`)) continue
+                    derived.push({
+                        id: `rel-implied-${rel.id}-${src}-${dst}`,
+                        sourceId: src,
+                        destinationId: dst,
+                        description: rel.description,
+                        technology: rel.technology,
+                        interactionStyle: rel.interactionStyle,
+                        lineStyle: rel.lineStyle,
+                        tags: [...rel.tags],
+                        properties: {},
+                    })
+                }
+            }
+        }
+    }
+    return derived
+}

--- a/src/lib/dsl/auto-views.ts
+++ b/src/lib/dsl/auto-views.ts
@@ -15,7 +15,9 @@ export function generateDefaultViews(ws: Workspace): void {
         ws.views.systemLandscapeViews.length > 0 ||
         ws.views.systemContextViews.length > 0 ||
         ws.views.containerViews.length > 0 ||
-        ws.views.componentViews.length > 0
+        ws.views.componentViews.length > 0 ||
+        (ws.views.dynamicViews?.length ?? 0) > 0 ||
+        (ws.views.deploymentViews?.length ?? 0) > 0
     if (hasViews) return
 
     const allElements = collectAllElementsById(ws)

--- a/src/lib/dsl/deployment-roundtrip.test.ts
+++ b/src/lib/dsl/deployment-roundtrip.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest'
+import { parseDSL, serializeDSL } from './index'
+import type { DeploymentNode, Workspace } from '@/types/model'
+
+// Structurizr-authored deployment DSL, adapted from the official Big Bank plc
+// example — nested deployment nodes, container instances, an infrastructure
+// node, instance counts, and both scoped and unscoped deployment views.
+const STRUCTURIZR_DSL = `
+workspace "Big Bank plc" {
+    model {
+        internetBankingSystem = softwareSystem "Internet Banking System" {
+            webApplication = container "Web Application" "Delivers SPA" "Java and Spring MVC"
+            database = container "Database" "Stores data" "Oracle" "Database"
+            webApplication -> database "Reads from and writes to" "JDBC"
+        }
+        mainframe = softwareSystem "Mainframe Banking System" "Stores core banking information"
+        webApplication -> mainframe "Uses"
+
+        deploymentEnvironment "Live" {
+            deploymentNode "AWS" "" "Amazon Web Services" {
+                deploymentNode "us-east-1" "" "AWS region" {
+                    lb = infrastructureNode "Load Balancer" "Routes traffic" "Elastic Load Balancer"
+                    deploymentNode "Web Server" "" "Ubuntu" {
+                        instances 4
+                        liveWebApp = containerInstance webApplication
+                    }
+                    deploymentNode "Database Server" "" "Ubuntu" {
+                        liveDatabase = containerInstance database
+                    }
+                }
+            }
+            deploymentNode "Big Bank plc Data Center" {
+                liveMainframe = softwareSystemInstance mainframe
+            }
+            lb -> liveWebApp "Forwards requests to" "HTTPS"
+        }
+    }
+    views {
+        deployment internetBankingSystem "Live" "LiveDeployment" {
+            include *
+            autoLayout lr
+        }
+        deployment * "Live" "AllLiveDeployment" {
+            include *
+        }
+    }
+}
+`
+
+describe('deployment model parsing (Structurizr-authored)', () => {
+  it('parses environments, nested nodes, instances, and infrastructure', () => {
+    const { workspace: ws, errors } = parseDSL(STRUCTURIZR_DSL)
+    expect(errors).toHaveLength(0)
+
+    expect(ws.model.deploymentEnvironments).toHaveLength(1)
+    const env = ws.model.deploymentEnvironments[0]
+    expect(env.name).toBe('Live')
+    expect(env.deploymentNodes).toHaveLength(2)
+
+    const aws = env.deploymentNodes[0]
+    expect(aws.name).toBe('AWS')
+    expect(aws.technology).toBe('Amazon Web Services')
+    expect(aws.tags).toEqual(expect.arrayContaining(['Element', 'Deployment Node']))
+    expect(aws.children).toHaveLength(1)
+
+    const region = aws.children[0]
+    expect(region.name).toBe('us-east-1')
+    expect(region.infrastructureNodes).toHaveLength(1)
+    expect(region.infrastructureNodes[0].name).toBe('Load Balancer')
+    expect(region.infrastructureNodes[0].tags).toEqual(expect.arrayContaining(['Element', 'Infrastructure Node']))
+    expect(region.children).toHaveLength(2)
+
+    const webServer = region.children[0]
+    expect(webServer.name).toBe('Web Server')
+    expect(webServer.instances).toBe('4')
+    expect(webServer.containerInstances).toHaveLength(1)
+
+    // Container instance resolves to the model container's id
+    const webAppId = ws.model.softwareSystems[0].containers[0].id
+    expect(webServer.containerInstances[0].containerId).toBe(webAppId)
+    expect(webServer.containerInstances[0].tags).toContain('Container Instance')
+
+    // Software system instance in the second top-level node
+    const dataCenter = env.deploymentNodes[1]
+    expect(dataCenter.softwareSystemInstances).toHaveLength(1)
+    expect(dataCenter.softwareSystemInstances[0].softwareSystemId).toBe(ws.model.softwareSystems[1].id)
+  })
+
+  it('replicates model relationships between instances (implied) and keeps explicit ones', () => {
+    const { workspace: ws } = parseDSL(STRUCTURIZR_DSL)
+    const env = ws.model.deploymentEnvironments[0]
+    const webInstance = env.deploymentNodes[0].children[0].children[0].containerInstances[0]
+    const dbInstance = env.deploymentNodes[0].children[0].children[1].containerInstances[0]
+    const mainframeInstance = env.deploymentNodes[1].softwareSystemInstances[0]
+
+    // webApplication -> database replicated between their instances
+    const impliedWebDb = ws.model.relationships.find(
+      r => r.implied && r.sourceId === webInstance.id && r.destinationId === dbInstance.id
+    )
+    expect(impliedWebDb).toBeDefined()
+    expect(impliedWebDb!.description).toBe('Reads from and writes to')
+    expect(impliedWebDb!.technology).toBe('JDBC')
+
+    // webApplication -> mainframe replicated container-instance -> system-instance
+    const impliedWebMainframe = ws.model.relationships.find(
+      r => r.implied && r.sourceId === webInstance.id && r.destinationId === mainframeInstance.id
+    )
+    expect(impliedWebMainframe).toBeDefined()
+
+    // The explicit lb -> liveWebApp relationship is a normal (non-implied) relationship
+    const lbId = env.deploymentNodes[0].children[0].infrastructureNodes[0].id
+    const explicit = ws.model.relationships.find(
+      r => r.sourceId === lbId && r.destinationId === webInstance.id
+    )
+    expect(explicit).toBeDefined()
+    expect(explicit!.implied).toBeUndefined()
+  })
+
+  it('expands include * for a scoped deployment view to the relevant subtree', () => {
+    const { workspace: ws } = parseDSL(STRUCTURIZR_DSL)
+    expect(ws.views.deploymentViews).toHaveLength(2)
+
+    const scoped = ws.views.deploymentViews[0]
+    expect(scoped.key).toBe('LiveDeployment')
+    expect(scoped.type).toBe('deployment')
+    expect(scoped.environment).toBe('Live')
+    expect(scoped.softwareSystemId).toBe(ws.model.softwareSystems[0].id)
+    expect(scoped.autoLayout?.direction).toBe('LR')
+
+    const env = ws.model.deploymentEnvironments[0]
+    const ids = new Set(scoped.elements.map(e => e.id))
+    // Scoped to internetBankingSystem: AWS subtree is in (its instances belong
+    // to the system), the mainframe's data-center node is out.
+    expect(ids.has(env.deploymentNodes[0].id)).toBe(true)
+    expect(ids.has(env.deploymentNodes[0].children[0].infrastructureNodes[0].id)).toBe(true)
+    expect(ids.has(env.deploymentNodes[0].children[0].children[0].containerInstances[0].id)).toBe(true)
+    expect(ids.has(env.deploymentNodes[1].id)).toBe(false)
+
+    // View relationships include the implied instance relationship and the explicit lb edge
+    expect(scoped.relationships.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('expands include * for an unscoped deployment view to the whole environment', () => {
+    const { workspace: ws } = parseDSL(STRUCTURIZR_DSL)
+    const all = ws.views.deploymentViews[1]
+    expect(all.softwareSystemId).toBeUndefined()
+
+    const env = ws.model.deploymentEnvironments[0]
+    const ids = new Set(all.elements.map(e => e.id))
+    expect(ids.has(env.deploymentNodes[1].id)).toBe(true)
+    expect(ids.has(env.deploymentNodes[1].softwareSystemInstances[0].id)).toBe(true)
+  })
+
+  it('records an error for a deployment view referencing an unknown environment', () => {
+    const dsl = `workspace {
+      model {
+        a = softwareSystem "A"
+      }
+      views {
+        deployment a "Nonexistent" "bad" {
+          include *
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors.some(e => e.message.includes("unknown environment 'Nonexistent'"))).toBe(true)
+    // View still parses (lenient), just with nothing to show
+    expect(ws.views.deploymentViews).toHaveLength(1)
+    expect(ws.views.deploymentViews[0].elements).toHaveLength(0)
+  })
+})
+
+describe('deployment round-trip (serialize → parse)', () => {
+  function roundtrip(ws: Workspace) {
+    const dsl = serializeDSL(ws)
+    return { dsl, ...parseDSL(dsl) }
+  }
+
+  it('preserves the full deployment structure through serialize → parse', () => {
+    const { workspace: first, errors: parseErrors } = parseDSL(STRUCTURIZR_DSL)
+    expect(parseErrors).toHaveLength(0)
+
+    const { workspace: second, errors, dsl } = roundtrip(first)
+    expect(errors).toHaveLength(0)
+
+    // Same environment/node topology
+    expect(second.model.deploymentEnvironments).toHaveLength(1)
+    const env1 = first.model.deploymentEnvironments[0]
+    const env2 = second.model.deploymentEnvironments[0]
+    expect(env2.name).toBe(env1.name)
+
+    const flatten = (nodes: DeploymentNode[]): string[] =>
+      nodes.flatMap(n => [
+        `node:${n.name}:${n.technology ?? ''}:${n.instances ?? ''}`,
+        ...n.infrastructureNodes.map(i => `infra:${i.name}:${i.technology ?? ''}`),
+        ...n.containerInstances.map(ci => `ci:${ci.containerId}`),
+        ...n.softwareSystemInstances.map(si => `si:${si.softwareSystemId}`),
+        ...flatten(n.children),
+      ])
+    expect(flatten(env2.deploymentNodes)).toEqual(flatten(env1.deploymentNodes))
+
+    // Ids survive because the serializer emits them as identifiers
+    expect(flatten(env2.deploymentNodes).join()).toContain('ci:webApplication')
+
+    // Implied relationships were NOT serialized as model relationships…
+    expect(dsl).not.toContain('rel-implied')
+    const explicitCount = (d: string) => (d.match(/->/g) ?? []).length
+    // …but ARE re-derived on the second parse
+    expect(second.model.relationships.filter(r => r.implied).length).toBe(
+      first.model.relationships.filter(r => r.implied).length
+    )
+    expect(explicitCount(dsl)).toBe(
+      first.model.relationships.filter(r => !r.implied).length
+    )
+  })
+
+  it('preserves deployment views (scope, environment, key) through serialize → parse', () => {
+    const { workspace: first } = parseDSL(STRUCTURIZR_DSL)
+    const { workspace: second, errors } = roundtrip(first)
+    expect(errors).toHaveLength(0)
+
+    expect(second.views.deploymentViews).toHaveLength(2)
+    const scoped = second.views.deploymentViews.find(v => v.key === 'LiveDeployment')!
+    expect(scoped).toBeDefined()
+    expect(scoped.environment).toBe('Live')
+    expect(scoped.softwareSystemId).toBe(second.model.softwareSystems[0].id)
+    expect(scoped.autoLayout?.direction).toBe('LR')
+
+    // Element sets survive (compare cardinality — parse-time expansion
+    // re-derives the same concrete membership from explicit includes)
+    const firstScoped = first.views.deploymentViews.find(v => v.key === 'LiveDeployment')!
+    expect(scoped.elements.length).toBe(firstScoped.elements.length)
+
+    const unscoped = second.views.deploymentViews.find(v => v.key === 'AllLiveDeployment')!
+    expect(unscoped.softwareSystemId).toBeUndefined()
+    expect(unscoped.environment).toBe('Live')
+  })
+
+  it('round-trips instance extra tags, urls, and properties', () => {
+    const dsl = `workspace {
+      model {
+        sys = softwareSystem "Sys" {
+          api = container "API"
+        }
+        deploymentEnvironment "Prod" {
+          k8s = deploymentNode "Kubernetes" "" "EKS" {
+            apiInstance = containerInstance api "critical,monitored" {
+              url "https://runbook.example.com"
+              properties {
+                "region" "us-east-1"
+              }
+            }
+          }
+        }
+      }
+      views {
+        deployment * "Prod" "ProdView" {
+          include *
+        }
+      }
+    }`
+    const { workspace: first, errors: e1 } = parseDSL(dsl)
+    expect(e1).toHaveLength(0)
+
+    const inst1 = first.model.deploymentEnvironments[0].deploymentNodes[0].containerInstances[0]
+    expect(inst1.tags).toEqual(expect.arrayContaining(['Container Instance', 'critical', 'monitored']))
+    expect(inst1.url).toBe('https://runbook.example.com')
+    expect(inst1.properties.region).toBe('us-east-1')
+
+    const { workspace: second, errors: e2 } = parseDSL(serializeDSL(first))
+    expect(e2).toHaveLength(0)
+    const inst2 = second.model.deploymentEnvironments[0].deploymentNodes[0].containerInstances[0]
+    expect(inst2.tags).toEqual(expect.arrayContaining(['Container Instance', 'critical', 'monitored']))
+    expect(inst2.url).toBe('https://runbook.example.com')
+    expect(inst2.properties.region).toBe('us-east-1')
+  })
+})

--- a/src/lib/dsl/deployment-roundtrip.test.ts
+++ b/src/lib/dsl/deployment-roundtrip.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseDSL, serializeDSL } from './index'
+import { deriveInstanceRelationships } from '@/lib/deployment'
 import type { DeploymentNode, Workspace } from '@/types/model'
 
 // Structurizr-authored deployment DSL, adapted from the official Big Bank plc
@@ -86,34 +87,100 @@ describe('deployment model parsing (Structurizr-authored)', () => {
     expect(dataCenter.softwareSystemInstances[0].softwareSystemId).toBe(ws.model.softwareSystems[1].id)
   })
 
-  it('replicates model relationships between instances (implied) and keeps explicit ones', () => {
+  it('derives instance relationships on demand without materializing them in the model', () => {
     const { workspace: ws } = parseDSL(STRUCTURIZR_DSL)
     const env = ws.model.deploymentEnvironments[0]
     const webInstance = env.deploymentNodes[0].children[0].children[0].containerInstances[0]
     const dbInstance = env.deploymentNodes[0].children[0].children[1].containerInstances[0]
     const mainframeInstance = env.deploymentNodes[1].softwareSystemInstances[0]
 
-    // webApplication -> database replicated between their instances
-    const impliedWebDb = ws.model.relationships.find(
-      r => r.implied && r.sourceId === webInstance.id && r.destinationId === dbInstance.id
+    // The model holds only authored relationships — implied instance
+    // relationships are a derived projection, never stored (storing them
+    // would let edits/deletions of the copies silently revert on reload).
+    const instanceIds = new Set([webInstance.id, dbInstance.id, mainframeInstance.id])
+    const materialized = ws.model.relationships.filter(
+      r => instanceIds.has(r.sourceId) && instanceIds.has(r.destinationId),
     )
-    expect(impliedWebDb).toBeDefined()
-    expect(impliedWebDb!.description).toBe('Reads from and writes to')
-    expect(impliedWebDb!.technology).toBe('JDBC')
+    expect(materialized).toHaveLength(0)
+
+    const derived = deriveInstanceRelationships(ws.model, 'Live')
+
+    // webApplication -> database replicated between their instances
+    const webDb = derived.find(
+      r => r.sourceId === webInstance.id && r.destinationId === dbInstance.id,
+    )
+    expect(webDb).toBeDefined()
+    expect(webDb!.description).toBe('Reads from and writes to')
+    expect(webDb!.technology).toBe('JDBC')
 
     // webApplication -> mainframe replicated container-instance -> system-instance
-    const impliedWebMainframe = ws.model.relationships.find(
-      r => r.implied && r.sourceId === webInstance.id && r.destinationId === mainframeInstance.id
-    )
-    expect(impliedWebMainframe).toBeDefined()
+    expect(derived.some(
+      r => r.sourceId === webInstance.id && r.destinationId === mainframeInstance.id,
+    )).toBe(true)
 
-    // The explicit lb -> liveWebApp relationship is a normal (non-implied) relationship
+    // The explicit lb -> liveWebApp relationship stays a normal model relationship
     const lbId = env.deploymentNodes[0].children[0].infrastructureNodes[0].id
-    const explicit = ws.model.relationships.find(
-      r => r.sourceId === lbId && r.destinationId === webInstance.id
-    )
-    expect(explicit).toBeDefined()
-    expect(explicit!.implied).toBeUndefined()
+    expect(ws.model.relationships.some(
+      r => r.sourceId === lbId && r.destinationId === webInstance.id,
+    )).toBe(true)
+  })
+
+  it('consumes the positional instances argument without corrupting the tree', () => {
+    // `deploymentNode <name> [description] [technology] [tags] [instances]` —
+    // left unconsumed, the trailing number ended the node header early, its
+    // children re-parented onto the parent node, and the following sibling
+    // was swallowed by the stray closing brace. All with zero parse errors.
+    const dsl = `workspace {
+      model {
+        sys = softwareSystem "Sys" { web = container "Web" }
+        deploymentEnvironment "Live" {
+          deploymentNode "Region" {
+            deploymentNode "Web Server" "" "Ubuntu" "" 4 {
+              liveWeb = containerInstance web
+            }
+            fw = infrastructureNode "Firewall"
+          }
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+    const region = ws.model.deploymentEnvironments[0].deploymentNodes[0]
+    expect(region.name).toBe('Region')
+    expect(region.children).toHaveLength(1)
+    expect(region.infrastructureNodes).toHaveLength(1)
+    const webServer = region.children[0]
+    expect(webServer.instances).toBe('4')
+    expect(webServer.containerInstances).toHaveLength(1)
+  })
+
+  it('derives distinct ids when two model relationships connect the same element pair', () => {
+    // The old implementation keyed derived relationships by instance pair
+    // alone, so `web -> db "reads"` and `web -> db "writes"` collided on one
+    // id and React Flow dropped an edge.
+    const dsl = `workspace {
+      model {
+        sys = softwareSystem "Sys" {
+          web = container "Web"
+          db = container "DB"
+          web -> db "Reads"
+          web -> db "Writes"
+        }
+        deploymentEnvironment "Live" {
+          deploymentNode "Server" {
+            liveWeb = containerInstance web
+            liveDb = containerInstance db
+          }
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+
+    const derived = deriveInstanceRelationships(ws.model, 'Live')
+    expect(derived).toHaveLength(2)
+    expect(new Set(derived.map(r => r.id)).size).toBe(2)
+    expect(derived.map(r => r.description).sort()).toEqual(['Reads', 'Writes'])
   })
 
   it('expands include * for a scoped deployment view to the relevant subtree', () => {
@@ -136,8 +203,14 @@ describe('deployment model parsing (Structurizr-authored)', () => {
     expect(ids.has(env.deploymentNodes[0].children[0].children[0].containerInstances[0].id)).toBe(true)
     expect(ids.has(env.deploymentNodes[1].id)).toBe(false)
 
-    // View relationships include the implied instance relationship and the explicit lb edge
-    expect(scoped.relationships.length).toBeGreaterThanOrEqual(2)
+    // View relationships hold only authored relationships whose endpoints are
+    // both in the view — here the explicit lb -> liveWebApp edge. Implied
+    // instance edges are derived at render time, not stored on the view.
+    const lbId = env.deploymentNodes[0].children[0].infrastructureNodes[0].id
+    const webInstanceId = env.deploymentNodes[0].children[0].children[0].containerInstances[0].id
+    const relById = new Map(ws.model.relationships.map(r => [r.id, r]))
+    const viewRels = scoped.relationships.map(vr => relById.get(vr.id)!)
+    expect(viewRels.some(r => r.sourceId === lbId && r.destinationId === webInstanceId)).toBe(true)
   })
 
   it('expands include * for an unscoped deployment view to the whole environment', () => {

--- a/src/lib/dsl/dynamic-view-roundtrip.test.ts
+++ b/src/lib/dsl/dynamic-view-roundtrip.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest'
+import { parseDSL, serializeDSL } from './index'
+
+const BASE_DSL = `
+workspace "Ordering" {
+    model {
+        customer = person "Customer"
+        shop = softwareSystem "Web Shop" {
+            spa = container "Single-Page App"
+            api = container "API"
+            db = container "Database"
+        }
+        customer -> spa "Places order using"
+        spa -> api "Submits order to" "JSON/HTTPS"
+        api -> db "Persists order in" "SQL"
+        api -> db "Reads catalog from" "SQL"
+    }
+    views {
+        dynamic shop "OrderFlow" "How an order flows through the shop" {
+            customer -> spa "Places an order"
+            spa -> api
+            api -> db "Persists order in"
+            autoLayout lr
+        }
+    }
+}
+`
+
+describe('dynamic view parsing', () => {
+  it('parses interaction steps in order with sequence labels', () => {
+    const { workspace: ws, errors } = parseDSL(BASE_DSL)
+    expect(errors).toHaveLength(0)
+    expect(ws.views.dynamicViews).toHaveLength(1)
+
+    const view = ws.views.dynamicViews[0]
+    expect(view.type).toBe('dynamic')
+    expect(view.key).toBe('OrderFlow')
+    expect(view.description).toBe('How an order flows through the shop')
+    expect(view.softwareSystemId).toBe(ws.model.softwareSystems[0].id)
+    expect(view.autoLayout?.direction).toBe('LR')
+
+    expect(view.relationships).toHaveLength(3)
+    expect(view.relationships.map(r => r.order)).toEqual(['1', '2', '3'])
+
+    // Steps reference the actual model relationships
+    const relById = new Map(ws.model.relationships.map(r => [r.id, r]))
+    const step1 = relById.get(view.relationships[0].id)!
+    expect(step1.sourceId).toBe(ws.model.people[0].id)
+
+    // Step 1 carries a description override; step 2 falls back to the model's
+    expect(view.relationships[0].description).toBe('Places an order')
+    expect(view.relationships[1].description).toBeUndefined()
+  })
+
+  it('derives view elements from step endpoints (deduplicated)', () => {
+    const { workspace: ws } = parseDSL(BASE_DSL)
+    const view = ws.views.dynamicViews[0]
+    const sys = ws.model.softwareSystems[0]
+    const ids = view.elements.map(e => e.id)
+    expect(ids).toHaveLength(4)
+    expect(ids).toEqual(expect.arrayContaining([
+      ws.model.people[0].id,
+      sys.containers[0].id,
+      sys.containers[1].id,
+      sys.containers[2].id,
+    ]))
+  })
+
+  it('disambiguates parallel relationships between the same pair by description', () => {
+    const { workspace: ws } = parseDSL(BASE_DSL)
+    const view = ws.views.dynamicViews[0]
+    const persistRel = ws.model.relationships.find(r => r.description === 'Persists order in')!
+    expect(view.relationships[2].id).toBe(persistRel.id)
+  })
+
+  it('records an error and skips steps whose relationship is not in the model', () => {
+    const dsl = `workspace {
+      model {
+        a = softwareSystem "A"
+        b = softwareSystem "B"
+        a -> b "calls"
+      }
+      views {
+        dynamic * "Flow" {
+          a -> b
+          b -> a "no such relationship"
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors.some(e => e.message.includes('does not exist in the model'))).toBe(true)
+    const view = ws.views.dynamicViews[0]
+    expect(view.relationships).toHaveLength(1)
+    expect(view.relationships[0].order).toBe('1')
+  })
+
+  it('flattens parallel-sequence brace groups, numbering continuing through', () => {
+    const dsl = `workspace {
+      model {
+        a = softwareSystem "A"
+        b = softwareSystem "B"
+        c = softwareSystem "C"
+        a -> b "one"
+        b -> c "two"
+        c -> a "three"
+      }
+      views {
+        dynamic * "Flow" {
+          a -> b
+          {
+            b -> c
+          }
+          c -> a
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+    const view = ws.views.dynamicViews[0]
+    expect(view.relationships.map(r => r.order)).toEqual(['1', '2', '3'])
+    expect(view.elements).toHaveLength(3)
+  })
+
+  it('supports container-scoped and unscoped dynamic views', () => {
+    const dsl = `workspace {
+      model {
+        sys = softwareSystem "Sys" {
+          web = container "Web" {
+            ctrl = component "Controller"
+            svc = component "Service"
+          }
+        }
+        ctrl -> svc "delegates to"
+      }
+      views {
+        dynamic web "InsideWeb" {
+          ctrl -> svc
+        }
+        dynamic * "Everything" {
+          ctrl -> svc
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+
+    const scoped = ws.views.dynamicViews[0]
+    expect(scoped.containerId).toBe(ws.model.softwareSystems[0].containers[0].id)
+    expect(scoped.softwareSystemId).toBeUndefined()
+
+    const unscoped = ws.views.dynamicViews[1]
+    expect(unscoped.containerId).toBeUndefined()
+    expect(unscoped.softwareSystemId).toBeUndefined()
+  })
+
+  it('generates a stable key when the DSL omits one', () => {
+    const dsl = `workspace {
+      model {
+        a = softwareSystem "A"
+        b = softwareSystem "B"
+        a -> b "calls"
+      }
+      views {
+        dynamic a {
+          a -> b
+        }
+      }
+    }`
+    const { workspace: ws } = parseDSL(dsl)
+    const view = ws.views.dynamicViews[0]
+    expect(view.key).toBe('Dynamic-a')
+    expect(view.autoKey).toBe(true)
+  })
+})
+
+describe('dynamic view round-trip (serialize → parse)', () => {
+  it('preserves step order, descriptions, and scope through serialize → parse', () => {
+    const { workspace: first } = parseDSL(BASE_DSL)
+    const dsl = serializeDSL(first)
+    const { workspace: second, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+
+    const v1 = first.views.dynamicViews[0]
+    const v2 = second.views.dynamicViews[0]
+    expect(v2.key).toBe(v1.key)
+    expect(v2.description).toBe(v1.description)
+    expect(v2.softwareSystemId).toBe(second.model.softwareSystems[0].id)
+    expect(v2.autoLayout?.direction).toBe('LR')
+
+    expect(v2.relationships).toHaveLength(3)
+    expect(v2.relationships.map(r => r.order)).toEqual(['1', '2', '3'])
+
+    // Step endpoints line up pairwise with the original
+    const rel1 = new Map(first.model.relationships.map(r => [r.id, r]))
+    const rel2 = new Map(second.model.relationships.map(r => [r.id, r]))
+    const endpoints = (v: typeof v1, rels: typeof rel1) =>
+      v.relationships.map(s => {
+        const r = rels.get(s.id)!
+        return `${r.sourceId}->${r.destinationId}`
+      })
+    expect(endpoints(v2, rel2)).toEqual(endpoints(v1, rel1))
+
+    // The description override survives; the fallback step keeps the model description
+    expect(v2.relationships[0].description).toBe('Places an order')
+    const step2Model = rel2.get(v2.relationships[1].id)!
+    expect(step2Model.description).toBe('Submits order to')
+  })
+
+  it('emits interaction steps, not include lines, for dynamic views', () => {
+    const { workspace: first } = parseDSL(BASE_DSL)
+    const dsl = serializeDSL(first)
+    const dynamicBlock = dsl.slice(dsl.indexOf('dynamic '))
+    expect(dynamicBlock).toContain('customer -> spa "Places an order"')
+    expect(dynamicBlock).toContain('spa -> api')
+    expect(dynamicBlock).not.toContain('include')
+  })
+
+  it('round-trips an unscoped dynamic view with a * scope marker', () => {
+    const dsl = `workspace {
+      model {
+        a = softwareSystem "A"
+        b = softwareSystem "B"
+        a -> b "calls"
+      }
+      views {
+        dynamic * "Flow" {
+          a -> b
+        }
+      }
+    }`
+    const { workspace: first } = parseDSL(dsl)
+    const serialized = serializeDSL(first)
+    expect(serialized).toContain('dynamic * "Flow"')
+    const { workspace: second, errors } = parseDSL(serialized)
+    expect(errors).toHaveLength(0)
+    expect(second.views.dynamicViews[0].relationships).toHaveLength(1)
+  })
+})

--- a/src/lib/dsl/dynamic-view-roundtrip.test.ts
+++ b/src/lib/dsl/dynamic-view-roundtrip.test.ts
@@ -73,7 +73,9 @@ describe('dynamic view parsing', () => {
     expect(view.relationships[2].id).toBe(persistRel.id)
   })
 
-  it('records an error and skips steps whose relationship is not in the model', () => {
+  it('accepts a reverse-direction step as a response over the existing relationship', () => {
+    // Structurizr allows `b -> a` as a return message over a model
+    // relationship declared `a -> b`; rejecting it broke valid workspaces.
     const dsl = `workspace {
       model {
         a = softwareSystem "A"
@@ -83,7 +85,38 @@ describe('dynamic view parsing', () => {
       views {
         dynamic * "Flow" {
           a -> b
-          b -> a "no such relationship"
+          b -> a "returns result"
+        }
+      }
+    }`
+    const { workspace: ws, errors } = parseDSL(dsl)
+    expect(errors).toHaveLength(0)
+    const view = ws.views.dynamicViews[0]
+    expect(view.relationships).toHaveLength(2)
+
+    const rel = ws.model.relationships[0]
+    const response = view.relationships[1]
+    expect(response.id).toBe(rel.id)
+    expect(response.response).toBe(true)
+    expect(response.order).toBe('2')
+    expect(response.description).toBe('returns result')
+    // Travel order: the response runs destination -> source.
+    expect(response.sourceId).toBe(rel.destinationId)
+    expect(response.destinationId).toBe(rel.sourceId)
+  })
+
+  it('records an error and skips steps with no relationship in either direction', () => {
+    const dsl = `workspace {
+      model {
+        a = softwareSystem "A"
+        b = softwareSystem "B"
+        c = softwareSystem "C"
+        a -> b "calls"
+      }
+      views {
+        dynamic * "Flow" {
+          a -> b
+          a -> c "no such relationship"
         }
       }
     }`

--- a/src/lib/dsl/parser-deployment.ts
+++ b/src/lib/dsl/parser-deployment.ts
@@ -1,0 +1,459 @@
+// DSL parser — `deploymentEnvironment { ... }` blocks and the deployment
+// element family (deploymentNode, infrastructureNode, containerInstance,
+// softwareSystemInstance).
+//
+// Follows the same conventions as parser-model.ts: every parser takes the
+// shared ContextAwareParser instance, ids come from an assigned identifier
+// (varName) or nextId(), and unknown constructs are skipped leniently.
+
+import type {
+    Model,
+    DeploymentEnvironment,
+    DeploymentNode,
+    InfrastructureNode,
+    ContainerInstance,
+    SoftwareSystemInstance,
+} from '@/types/model'
+import type { ContextAwareParser } from './parser'
+import { nextId, MAX_DEPTH } from './parser'
+import { parseRelationship } from './parser-relationship'
+
+export function parseDeploymentEnvironment(p: ContextAwareParser, model: Model, varName?: string): void {
+    p.advance() // consume 'deploymentEnvironment'
+    const name = p.readString()
+    const id = varName ?? nextId()
+    const env: DeploymentEnvironment = { id, name, deploymentNodes: [] }
+
+    // Register the environment identifier (if any) so deployment views can
+    // reference it by variable. Never register by name — an environment named
+    // like a model element would otherwise shadow that element in resolveRef.
+    p.registerDeploymentElement(id, name, 'deploymentEnvironment', varName)
+
+    p.skipNewlines()
+    if (p.check('LBRACE')) {
+        p.advance()
+        parseDeploymentEnvironmentBody(p, env, model)
+        p.skipNewlines()
+        p.expect('RBRACE')
+    }
+
+    model.deploymentEnvironments.push(env)
+}
+
+function parseDeploymentEnvironmentBody(p: ContextAwareParser, env: DeploymentEnvironment, model: Model): void {
+    p.depth++
+    if (p.depth > MAX_DEPTH) { p.addError('Maximum nesting depth exceeded', p.peek()); p.depth--; return }
+    while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+        p.skipNewlines()
+        if (p.check('RBRACE') || p.peekType() === 'EOF') break
+
+        const token = p.peek()
+
+        if (token.type === 'COMMENT') { p.advance(); continue }
+        if (token.type === 'KEYWORD' && token.value.startsWith('!')) { p.advance(); p.skipToNextLine(); continue }
+
+        if (token.type === 'KEYWORD') {
+            const kw = token.value.toLowerCase()
+
+            if (kw === 'deploymentnode') {
+                const node = parseDeploymentNode(p, model)
+                if (node) env.deploymentNodes.push(node)
+                continue
+            }
+
+            // Deployment groups add instance-scoping we don't model; parse the
+            // body transparently so nodes inside the group are not lost.
+            if (kw === 'group') {
+                p.advance()
+                p.readOptionalString()
+                p.skipNewlines()
+                if (p.match('LBRACE')) {
+                    parseDeploymentEnvironmentBody(p, env, model)
+                    p.skipNewlines()
+                    p.expect('RBRACE')
+                }
+                continue
+            }
+
+            if (kw === 'properties') {
+                p.advance()
+                p.skipNewlines()
+                p.skipBraceBlock()
+                continue
+            }
+
+            p.advance()
+            p.skipUnknownDirective()
+            continue
+        }
+
+        if (token.type === 'IDENTIFIER') {
+            const saved = p.pos
+            p.advance()
+            p.skipNewlines()
+
+            if (p.check('EQUALS')) {
+                p.advance()
+                p.skipNewlines()
+                const vn = token.value
+                if (p.check('KEYWORD') && p.peekValue().toLowerCase() === 'deploymentnode') {
+                    const node = parseDeploymentNode(p, model, vn)
+                    if (node) env.deploymentNodes.push(node)
+                } else {
+                    p.skipUnknownDirective()
+                }
+                continue
+            }
+
+            if (p.check('ARROW')) {
+                p.pos = saved
+                const rel = parseRelationship(p)
+                if (rel) model.relationships.push(rel)
+                continue
+            }
+
+            p.pos = saved
+            p.advance()
+            p.skipUnknownDirective()
+            continue
+        }
+
+        p.advance()
+    }
+    p.depth--
+}
+
+function parseDeploymentNode(p: ContextAwareParser, model: Model, varName?: string): DeploymentNode | null {
+    p.advance() // consume 'deploymentNode'
+    const name = p.readString()
+    const description = p.readOptionalString() || undefined
+    const technology = p.readOptionalString() || undefined
+    const tagsStr = p.readOptionalString()
+
+    const id = varName ?? nextId()
+    const node: DeploymentNode = {
+        id,
+        type: 'deploymentNode',
+        name,
+        description,
+        technology,
+        tags: p.buildTags('Element', 'Deployment Node', tagsStr),
+        properties: {},
+        children: [],
+        infrastructureNodes: [],
+        containerInstances: [],
+        softwareSystemInstances: [],
+    }
+
+    p.registerDeploymentElement(id, name, 'deploymentNode', varName)
+
+    p.skipNewlines()
+    if (p.check('LBRACE')) {
+        p.advance()
+        parseDeploymentNodeBody(p, node, model)
+        p.skipNewlines()
+        p.expect('RBRACE')
+    }
+
+    return node
+}
+
+function parseDeploymentNodeBody(p: ContextAwareParser, node: DeploymentNode, model: Model): void {
+    p.depth++
+    if (p.depth > MAX_DEPTH) { p.addError('Maximum nesting depth exceeded', p.peek()); p.depth--; return }
+    while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+        p.skipNewlines()
+        if (p.check('RBRACE') || p.peekType() === 'EOF') break
+
+        const token = p.peek()
+
+        if (token.type === 'COMMENT') { p.advance(); continue }
+        if (token.type === 'KEYWORD' && token.value.startsWith('!')) { p.advance(); p.skipToNextLine(); continue }
+
+        if (token.type === 'KEYWORD' || token.type === 'IDENTIFIER') {
+            const kw = token.value.toLowerCase()
+
+            if (token.type === 'KEYWORD' && kw === 'deploymentnode') {
+                const child = parseDeploymentNode(p, model)
+                if (child) node.children.push(child)
+                continue
+            }
+            if (token.type === 'KEYWORD' && kw === 'infrastructurenode') {
+                const infra = parseInfrastructureNode(p)
+                if (infra) node.infrastructureNodes.push(infra)
+                continue
+            }
+            if (token.type === 'KEYWORD' && kw === 'containerinstance') {
+                const inst = parseElementInstance(p, 'containerInstance')
+                if (inst) node.containerInstances.push(inst as ContainerInstance)
+                continue
+            }
+            if (token.type === 'KEYWORD' && kw === 'softwaresysteminstance') {
+                const inst = parseElementInstance(p, 'softwareSystemInstance')
+                if (inst) node.softwareSystemInstances.push(inst as SoftwareSystemInstance)
+                continue
+            }
+
+            // `instances` is not a reserved lexer keyword, so accept either token type.
+            if (kw === 'instances') {
+                p.advance()
+                const val = p.peek()
+                if (val.type === 'NUMBER' || val.type === 'STRING' || val.type === 'IDENTIFIER') {
+                    node.instances = p.advance().value
+                }
+                continue
+            }
+
+            if (token.type === 'KEYWORD' && (kw === 'tags' || kw === 'description' || kw === 'technology' || kw === 'url' || kw === 'properties')) {
+                parseDeploymentElementProperty(p, node, kw)
+                continue
+            }
+
+            if (token.type === 'KEYWORD' && kw === 'group') {
+                p.advance()
+                p.readOptionalString()
+                p.skipNewlines()
+                if (p.match('LBRACE')) {
+                    parseDeploymentNodeBody(p, node, model)
+                    p.skipNewlines()
+                    p.expect('RBRACE')
+                }
+                continue
+            }
+
+            if (token.type === 'IDENTIFIER') {
+                const saved = p.pos
+                p.advance()
+                p.skipNewlines()
+
+                if (p.check('EQUALS')) {
+                    p.advance()
+                    p.skipNewlines()
+                    const vn = token.value
+                    if (p.check('KEYWORD')) {
+                        const ekw = p.peekValue().toLowerCase()
+                        if (ekw === 'deploymentnode') {
+                            const child = parseDeploymentNode(p, model, vn)
+                            if (child) node.children.push(child)
+                        } else if (ekw === 'infrastructurenode') {
+                            const infra = parseInfrastructureNode(p, vn)
+                            if (infra) node.infrastructureNodes.push(infra)
+                        } else if (ekw === 'containerinstance') {
+                            const inst = parseElementInstance(p, 'containerInstance', vn)
+                            if (inst) node.containerInstances.push(inst as ContainerInstance)
+                        } else if (ekw === 'softwaresysteminstance') {
+                            const inst = parseElementInstance(p, 'softwareSystemInstance', vn)
+                            if (inst) node.softwareSystemInstances.push(inst as SoftwareSystemInstance)
+                        } else {
+                            p.skipUnknownDirective()
+                        }
+                    } else {
+                        p.skipUnknownDirective()
+                    }
+                    continue
+                }
+
+                if (p.check('ARROW')) {
+                    p.pos = saved
+                    const rel = parseRelationship(p)
+                    if (rel) model.relationships.push(rel)
+                    continue
+                }
+
+                p.pos = saved
+                p.advance()
+                p.skipUnknownDirective()
+                continue
+            }
+
+            p.advance()
+            p.skipUnknownDirective()
+            continue
+        }
+
+        p.advance()
+    }
+    p.depth--
+}
+
+function parseInfrastructureNode(p: ContextAwareParser, varName?: string): InfrastructureNode | null {
+    p.advance() // consume 'infrastructureNode'
+    const name = p.readString()
+    const description = p.readOptionalString() || undefined
+    const technology = p.readOptionalString() || undefined
+    const tagsStr = p.readOptionalString()
+
+    const id = varName ?? nextId()
+    const infra: InfrastructureNode = {
+        id,
+        type: 'infrastructureNode',
+        name,
+        description,
+        technology,
+        tags: p.buildTags('Element', 'Infrastructure Node', tagsStr),
+        properties: {},
+    }
+
+    p.registerDeploymentElement(id, name, 'infrastructureNode', varName)
+
+    p.skipNewlines()
+    if (p.check('LBRACE')) {
+        p.advance()
+        while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+            p.skipNewlines()
+            if (p.check('RBRACE') || p.peekType() === 'EOF') break
+            const t = p.peek()
+            if (t.type === 'COMMENT') { p.advance(); continue }
+            if (t.type === 'KEYWORD' && (t.value.toLowerCase() === 'tags' || t.value.toLowerCase() === 'description' || t.value.toLowerCase() === 'technology' || t.value.toLowerCase() === 'url' || t.value.toLowerCase() === 'properties')) {
+                parseDeploymentElementProperty(p, infra, t.value.toLowerCase())
+                continue
+            }
+            p.advance()
+            p.skipUnknownDirective()
+        }
+        p.skipNewlines()
+        p.expect('RBRACE')
+    }
+
+    return infra
+}
+
+/** Parse `containerInstance <ref>` / `softwareSystemInstance <ref>` including
+ *  optional deployment-group identifiers (ignored) and a trailing tags string. */
+function parseElementInstance(
+    p: ContextAwareParser,
+    type: 'containerInstance' | 'softwareSystemInstance',
+    varName?: string,
+): ContainerInstance | SoftwareSystemInstance | null {
+    const instanceToken = p.advance() // consume the instance keyword
+
+    const refToken = p.peek()
+    if (refToken.type !== 'IDENTIFIER' && refToken.type !== 'STRING' && refToken.type !== 'KEYWORD') {
+        p.addError(`Expected ${type} element reference, got ${refToken.type}`, refToken)
+        p.skipUnknownDirective()
+        return null
+    }
+    const ref = p.advance().value
+    const referencedId = p.resolveRef(ref)
+    if (!referencedId) {
+        p.addError(`Unresolved reference: '${ref}'`, instanceToken)
+    }
+
+    // Optional deployment-group identifiers — not modelled, consume them.
+    while (p.check('IDENTIFIER')) p.advance()
+    const tagsStr = p.readOptionalString()
+
+    const id = varName ?? nextId()
+    const defaultTag = type === 'containerInstance' ? 'Container Instance' : 'Software System Instance'
+    const tags = [defaultTag]
+    if (tagsStr) {
+        for (const t of tagsStr.split(',')) {
+            const trimmed = t.trim()
+            if (trimmed && !tags.includes(trimmed)) tags.push(trimmed)
+        }
+    }
+
+    const referencedName = p.elementsById.get(referencedId ?? '')?.name ?? ref
+    p.registerDeploymentElement(id, referencedName, type, varName)
+
+    const base = { id, tags, properties: {} as Record<string, string> }
+    const instance: ContainerInstance | SoftwareSystemInstance =
+        type === 'containerInstance'
+            ? { ...base, type, containerId: referencedId ?? ref }
+            : { ...base, type, softwareSystemId: referencedId ?? ref }
+
+    p.skipNewlines()
+    if (p.check('LBRACE')) {
+        p.advance()
+        while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+            p.skipNewlines()
+            if (p.check('RBRACE') || p.peekType() === 'EOF') break
+            const t = p.peek()
+            if (t.type === 'COMMENT') { p.advance(); continue }
+            const kw = t.value.toLowerCase()
+            if (t.type === 'KEYWORD' && kw === 'tags') {
+                p.advance()
+                while (p.check('STRING') || p.check('IDENTIFIER')) {
+                    for (const tag of p.advance().value.split(',')) {
+                        const trimmed = tag.trim()
+                        if (trimmed && !instance.tags.includes(trimmed)) instance.tags.push(trimmed)
+                    }
+                }
+                continue
+            }
+            if (t.type === 'KEYWORD' && kw === 'url') {
+                p.advance()
+                const val = p.readOptionalString()
+                if (val !== undefined) instance.url = val
+                continue
+            }
+            if (t.type === 'KEYWORD' && kw === 'properties') {
+                p.advance()
+                p.skipNewlines()
+                if (p.match('LBRACE')) {
+                    while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+                        p.skipNewlines()
+                        if (p.check('RBRACE') || p.peekType() === 'EOF') break
+                        const keyTok = p.peek()
+                        if (keyTok.type !== 'STRING' && keyTok.type !== 'IDENTIFIER') { p.advance(); continue }
+                        const key = p.advance().value
+                        const valTok = p.peek()
+                        if (valTok.type === 'STRING' || valTok.type === 'IDENTIFIER' || valTok.type === 'NUMBER') {
+                            instance.properties[key] = p.advance().value
+                        }
+                    }
+                    p.skipNewlines()
+                    p.expect('RBRACE')
+                }
+                continue
+            }
+            // healthCheck and anything else we don't model
+            p.advance()
+            p.skipUnknownDirective()
+        }
+        p.skipNewlines()
+        p.expect('RBRACE')
+    }
+
+    return instance
+}
+
+/** Property keywords shared by deploymentNode and infrastructureNode bodies. */
+function parseDeploymentElementProperty(p: ContextAwareParser, element: DeploymentNode | InfrastructureNode, keyword: string): void {
+    p.advance()
+
+    if (keyword === 'tags') {
+        while (p.check('STRING') || p.check('IDENTIFIER')) {
+            for (const t of p.advance().value.split(',')) {
+                const trimmed = t.trim()
+                if (trimmed && !element.tags.includes(trimmed)) element.tags.push(trimmed)
+            }
+        }
+    } else if (keyword === 'description') {
+        const val = p.readOptionalString()
+        if (val !== undefined) element.description = val
+    } else if (keyword === 'technology') {
+        const val = p.readOptionalString()
+        if (val !== undefined) element.technology = val
+    } else if (keyword === 'url') {
+        const val = p.readOptionalString()
+        if (val !== undefined) element.url = val
+    } else if (keyword === 'properties') {
+        p.skipNewlines()
+        if (p.match('LBRACE')) {
+            while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+                p.skipNewlines()
+                if (p.check('RBRACE') || p.peekType() === 'EOF') break
+                const keyTok = p.peek()
+                if (keyTok.type !== 'STRING' && keyTok.type !== 'IDENTIFIER') { p.advance(); continue }
+                const key = p.advance().value
+                const valTok = p.peek()
+                if (valTok.type === 'STRING' || valTok.type === 'IDENTIFIER' || valTok.type === 'NUMBER') {
+                    element.properties[key] = p.advance().value
+                }
+            }
+            p.skipNewlines()
+            p.expect('RBRACE')
+        }
+    }
+}

--- a/src/lib/dsl/parser-deployment.ts
+++ b/src/lib/dsl/parser-deployment.ts
@@ -129,6 +129,13 @@ function parseDeploymentNode(p: ContextAwareParser, model: Model, varName?: stri
     const description = p.readOptionalString() || undefined
     const technology = p.readOptionalString() || undefined
     const tagsStr = p.readOptionalString()
+    // Structurizr's positional 5th argument: `deploymentNode <name> [description]
+    // [technology] [tags] [instances]`. Left unconsumed it would sit in front of
+    // the `{`, silently re-parenting the node's children onto its parent.
+    let positionalInstances: string | undefined
+    if (p.check('NUMBER') || p.check('STRING')) {
+        positionalInstances = p.advance().value
+    }
 
     const id = varName ?? nextId()
     const node: DeploymentNode = {
@@ -137,6 +144,7 @@ function parseDeploymentNode(p: ContextAwareParser, model: Model, varName?: stri
         name,
         description,
         technology,
+        instances: positionalInstances,
         tags: p.buildTags('Element', 'Deployment Node', tagsStr),
         properties: {},
         children: [],

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -7,6 +7,7 @@ import { isElementStatus } from '@/types/model'
 import type { ContextAwareParser } from './parser'
 import { nextId, MAX_DEPTH, setUserProperty } from './parser'
 import { parseRelationship } from './parser-relationship'
+import { parseDeploymentEnvironment } from './parser-deployment'
 
 type Element = Person | SoftwareSystem | Container | Component
 
@@ -137,11 +138,8 @@ export function parseModelBody(
                 continue
             }
 
-            if (kw === 'deploymentenvironment' || kw === 'deploymentnode') {
-                p.advance()
-                while (p.check('STRING') || p.check('IDENTIFIER')) p.advance()
-                p.skipNewlines()
-                p.skipBraceBlock()
+            if (kw === 'deploymentenvironment') {
+                parseDeploymentEnvironment(p, model)
                 continue
             }
 
@@ -185,9 +183,11 @@ export function parseModelBody(
                     } else if (elementKw === 'softwaresystem') {
                         const sys = parseSoftwareSystem(p, varName, model)
                         if (sys) model.softwareSystems.push(sys)
+                    } else if (elementKw === 'deploymentenvironment') {
+                        parseDeploymentEnvironment(p, model, varName)
                     } else {
-                        // Unknown element type (e.g. deploymentEnvironment) — skip inline
-                        // args (stopping before any `{`) then skip any following brace block.
+                        // Unknown element type — skip inline args (stopping before
+                        // any `{`) then skip any following brace block.
                         p.skipUnknownDirective()
                     }
                 } else {

--- a/src/lib/dsl/parser-views.ts
+++ b/src/lib/dsl/parser-views.ts
@@ -5,7 +5,7 @@
 // access viewExcludedIds / the resolveRef map without inheriting the full
 // parser class.
 
-import type { Workspace, View, ViewType, AutoLayout, LayoutDirection, Model } from '@/types/model'
+import type { Workspace, View, ViewType, AutoLayout, LayoutDirection, Model, Relationship } from '@/types/model'
 import type { ContextAwareParser } from './parser'
 import { parseStylesBody } from './parser-styles'
 
@@ -252,18 +252,50 @@ function parseAutoLayoutInto(p: ContextAwareParser, view: View): void {
  *  (Structurizr semantics); the view stores the relationship id plus the
  *  step's order label and optional description override. View elements are
  *  derived from the step endpoints. */
+/** Structurizr restricts view keys to [a-zA-Z0-9_-]; foreign DSL can carry
+ *  keys the upstream parser would reject (e.g. quoted keys with spaces).
+ *  Normalize at parse so every downstream consumer — sidecar, serializer,
+ *  key dedup — works with a key that survives re-serialization. An all-
+ *  illegal key normalizes to '' and takes the auto-key path. */
+function sanitizeViewKey(raw: string): string {
+    return raw.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+/** The element plus every descendant in the C4 tree (system -> containers ->
+ *  components). People and components have no descendants. */
+function subtreeIds(model: Model, rootId: string): Set<string> {
+    const ids = new Set<string>([rootId])
+    for (const sys of model.softwareSystems) {
+        if (sys.id === rootId) {
+            for (const c of sys.containers) {
+                ids.add(c.id)
+                for (const comp of c.components) ids.add(comp.id)
+            }
+            return ids
+        }
+        for (const c of sys.containers) {
+            if (c.id === rootId) {
+                for (const comp of c.components) ids.add(comp.id)
+                return ids
+            }
+        }
+    }
+    return ids
+}
+
 function parseDynamicView(p: ContextAwareParser, model: Model): View | null {
     p.advance() // consume 'dynamic'
 
-    // Scope: `*` (unscoped), or a software system / container reference.
+    // Scope: `*` (unscoped), or a software system / container reference —
+    // possibly hierarchical (`sys1.api`).
     let scopeRef: string | undefined
     if (p.check('STAR')) {
         p.advance()
     } else {
-        scopeRef = p.readOptionalStringOrIdentifier()
+        scopeRef = p.readQualifiedRef()?.ref
     }
 
-    const key = p.readOptionalStringOrIdentifier() ?? ''
+    const key = sanitizeViewKey(p.readOptionalStringOrIdentifier() ?? '')
     const positionalDescription = p.readOptionalString()
 
     const view: View = {
@@ -352,42 +384,66 @@ function parseDynamicViewBody(p: ContextAwareParser, view: View, model: Model, o
             }
         }
 
-        // Interaction step: `source -> destination ["description"]`
-        if ((token.type === 'IDENTIFIER' || token.type === 'KEYWORD') && p.tokens[p.pos + 1]?.type === 'ARROW') {
-            const sourceToken = p.advance()
+        // Interaction step: `source -> destination ["description"]`, where
+        // either side may be a hierarchical (dotted) reference.
+        if (p.looksLikeRelationship()) {
+            const source = p.readQualifiedRef()!
+            p.skipNewlines()
             p.advance() // consume ARROW
-            const destToken = p.peek()
-            if (destToken.type !== 'IDENTIFIER' && destToken.type !== 'KEYWORD') {
-                p.addError(`Expected interaction destination, got ${destToken.type}`, destToken)
+            p.skipNewlines()
+            const dest = p.readQualifiedRef()
+            if (!dest) {
+                p.addError(`Expected interaction destination, got ${p.peekType()}`, p.peek())
                 p.skipToNextLine()
                 continue
             }
-            p.advance()
             const stepDescription = p.readOptionalString() || undefined
 
-            const sourceId = p.resolveRef(sourceToken.value)
-            const destId = p.resolveRef(destToken.value)
+            const sourceId = p.resolveRef(source.ref)
+            const destId = p.resolveRef(dest.ref)
             if (!sourceId || !destId) {
-                p.addError(`Unresolved reference in dynamic view: '${!sourceId ? sourceToken.value : destToken.value}'`, sourceToken)
+                p.addError(`Unresolved reference in dynamic view: '${!sourceId ? source.ref : dest.ref}'`, source.token)
                 continue
             }
 
-            // The step must reference an existing model relationship. Prefer a
-            // description match when several connect the same pair.
-            const candidates = model.relationships.filter(
-                r => !r.implied && r.sourceId === sourceId && r.destinationId === destId
-            )
-            const rel = candidates.find(r => stepDescription && r.description === stepDescription) ?? candidates[0]
+            // The step must reference an existing model relationship. Match
+            // tiers mirror what the real Structurizr parser resolves:
+            //   1. exact forward (source -> dest)
+            //   2. hierarchy-implied forward — any relationship between a
+            //      descendant of source and a descendant of dest (Structurizr
+            //      materializes these as parent-level relationships when
+            //      `!impliedRelationships` is on; we match them lazily)
+            //   3/4. the same two reversed — a response message travelling
+            //      back over an existing relationship.
+            // Within a tier, prefer a description match when several qualify.
+            const pick = (rels: Relationship[]) =>
+                rels.find(r => stepDescription && r.description === stepDescription) ?? rels[0]
+            const sourceTree = subtreeIds(model, sourceId)
+            const destTree = subtreeIds(model, destId)
+            const forward = pick(model.relationships.filter(
+                r => r.sourceId === sourceId && r.destinationId === destId,
+            )) ?? pick(model.relationships.filter(
+                r => sourceTree.has(r.sourceId) && destTree.has(r.destinationId),
+            ))
+            const reverse = forward ? undefined : (pick(model.relationships.filter(
+                r => r.sourceId === destId && r.destinationId === sourceId,
+            )) ?? pick(model.relationships.filter(
+                r => destTree.has(r.sourceId) && sourceTree.has(r.destinationId),
+            )))
+            const rel = forward ?? reverse
             if (!rel) {
                 p.addError(
-                    `Dynamic view step references a relationship that does not exist in the model: '${sourceToken.value} -> ${destToken.value}'`,
-                    sourceToken
+                    `Dynamic view step references a relationship that does not exist in the model: '${source.ref} -> ${dest.ref}'`,
+                    source.token,
                 )
                 continue
             }
 
             view.relationships.push({
                 id: rel.id,
+                sourceId,
+                destinationId: destId,
+                response: reverse ? true : undefined,
                 order: String(order.next++),
                 description: stepDescription,
             })
@@ -415,7 +471,7 @@ function parseDeploymentView(p: ContextAwareParser, model: Model): View | null {
     if (p.check('STAR')) {
         p.advance()
     } else {
-        scopeRef = p.readOptionalStringOrIdentifier()
+        scopeRef = p.readQualifiedRef({ allowString: true })?.ref
     }
 
     // Environment: a string name, or an identifier assigned to a
@@ -428,7 +484,7 @@ function parseDeploymentView(p: ContextAwareParser, model: Model): View | null {
         }
     }
 
-    const key = p.readOptionalStringOrIdentifier() ?? ''
+    const key = sanitizeViewKey(p.readOptionalStringOrIdentifier() ?? '')
     const positionalDescription = p.readOptionalString()
 
     const view: View = {

--- a/src/lib/dsl/parser-views.ts
+++ b/src/lib/dsl/parser-views.ts
@@ -14,6 +14,8 @@ interface ViewsContainer {
     systemContextViews: View[]
     containerViews: View[]
     componentViews: View[]
+    dynamicViews: View[]
+    deploymentViews: View[]
 }
 
 /** Generate a stable, unique view key when the DSL doesn't provide one.
@@ -26,13 +28,17 @@ function ensureViewKey(view: View, viewsContainer: ViewsContainer, elementRef: s
         view.type === 'systemLandscape' ? 'SystemLandscape'
         : view.type === 'systemContext' ? 'SystemContext'
         : view.type === 'container' ? 'Containers'
-        : 'Components'
+        : view.type === 'component' ? 'Components'
+        : view.type === 'dynamic' ? 'Dynamic'
+        : 'Deployment'
     const base = elementRef ? `${typeKey}-${elementRef}` : typeKey
     const existing = [
         ...viewsContainer.systemLandscapeViews,
         ...viewsContainer.systemContextViews,
         ...viewsContainer.containerViews,
         ...viewsContainer.componentViews,
+        ...viewsContainer.dynamicViews,
+        ...viewsContainer.deploymentViews,
     ]
     let candidate = base
     let suffix = 2
@@ -106,7 +112,23 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 views.configuration.themes = themes
                 continue
             }
-            if (kw === 'dynamic' || kw === 'deployment' || kw === 'filtered' || kw === 'custom') {
+            if (kw === 'dynamic') {
+                const view = parseDynamicView(p, model)
+                if (view) {
+                    ensureViewKey(view, views, view.softwareSystemId ?? view.containerId)
+                    views.dynamicViews.push(view)
+                }
+                continue
+            }
+            if (kw === 'deployment') {
+                const view = parseDeploymentView(p, model)
+                if (view) {
+                    ensureViewKey(view, views, view.softwareSystemId ?? view.environment)
+                    views.deploymentViews.push(view)
+                }
+                continue
+            }
+            if (kw === 'filtered' || kw === 'custom') {
                 p.advance()
                 while (p.check('STRING') || p.check('IDENTIFIER')) p.advance()
                 p.skipNewlines()
@@ -203,6 +225,241 @@ function parseElementView(p: ContextAwareParser, type: ViewType, model: Model): 
     return view
 }
 
+/** Parse `autoLayout [direction] [rankSep] [nodeSep]` into a view. */
+function parseAutoLayoutInto(p: ContextAwareParser, view: View): void {
+    p.advance() // consume 'autoLayout'
+    const layout: AutoLayout = { direction: 'TB' }
+    if (p.check('IDENTIFIER') || p.check('KEYWORD')) {
+        const dir = p.peekValue().toUpperCase()
+        if (dir === 'TB' || dir === 'BT' || dir === 'LR' || dir === 'RL') {
+            layout.direction = dir as LayoutDirection
+            p.advance()
+        }
+    }
+    if (p.check('NUMBER')) {
+        layout.rankSeparation = parseInt(p.advance().value, 10)
+    }
+    if (p.check('NUMBER')) {
+        layout.nodeSeparation = parseInt(p.advance().value, 10)
+    }
+    view.autoLayout = layout
+}
+
+/** Parse `dynamic <scope|*> [key] [description] { ... }`.
+ *
+ *  The body is an ordered sequence of `source -> destination ["description"]`
+ *  steps. Each step must reference a relationship that exists in the model
+ *  (Structurizr semantics); the view stores the relationship id plus the
+ *  step's order label and optional description override. View elements are
+ *  derived from the step endpoints. */
+function parseDynamicView(p: ContextAwareParser, model: Model): View | null {
+    p.advance() // consume 'dynamic'
+
+    // Scope: `*` (unscoped), or a software system / container reference.
+    let scopeRef: string | undefined
+    if (p.check('STAR')) {
+        p.advance()
+    } else {
+        scopeRef = p.readOptionalStringOrIdentifier()
+    }
+
+    const key = p.readOptionalStringOrIdentifier() ?? ''
+    const positionalDescription = p.readOptionalString()
+
+    const view: View = {
+        type: 'dynamic',
+        key,
+        title: positionalDescription,
+        description: positionalDescription,
+        elements: [],
+        relationships: [],
+    }
+
+    if (scopeRef) {
+        const resolvedId = p.resolveRef(scopeRef)
+        const scopeType = resolvedId ? p.elementsById.get(resolvedId)?.type : undefined
+        if (scopeType === 'container') {
+            view.containerId = resolvedId
+        } else {
+            view.softwareSystemId = resolvedId ?? scopeRef
+        }
+    }
+
+    p.skipNewlines()
+    if (p.match('LBRACE')) {
+        const order = { next: 1 }
+        parseDynamicViewBody(p, view, model, order)
+        p.skipNewlines()
+        p.expect('RBRACE')
+    }
+
+    return view
+}
+
+function parseDynamicViewBody(p: ContextAwareParser, view: View, model: Model, order: { next: number }): void {
+    // Dedup against the view itself — this body recurses for parallel groups,
+    // and a snapshot set would miss elements added by inner/outer levels.
+    const addElement = (id: string) => {
+        if (!view.elements.some(e => e.id === id)) {
+            view.elements.push({ id })
+        }
+    }
+
+    while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
+        p.skipNewlines()
+        if (p.check('RBRACE') || p.peekType() === 'EOF') break
+
+        const token = p.peek()
+
+        if (token.type === 'COMMENT') { p.advance(); continue }
+
+        // Parallel-sequence group: Structurizr numbers these 2a/2b/…; we
+        // flatten them into the running sequence so no step is lost.
+        if (token.type === 'LBRACE') {
+            p.advance()
+            parseDynamicViewBody(p, view, model, order)
+            p.skipNewlines()
+            p.expect('RBRACE')
+            continue
+        }
+
+        if (token.type === 'KEYWORD') {
+            const kw = token.value.toLowerCase()
+
+            if (kw === 'autolayout') {
+                parseAutoLayoutInto(p, view)
+                continue
+            }
+            if (kw === 'title') {
+                p.advance()
+                view.title = p.readOptionalString()
+                continue
+            }
+            if (kw === 'description') {
+                p.advance()
+                view.description = p.readOptionalString()
+                continue
+            }
+            if (kw === 'animation' || kw === 'properties') {
+                p.advance()
+                p.skipNewlines()
+                p.skipBraceBlock()
+                continue
+            }
+            if (kw === 'default') {
+                p.advance()
+                continue
+            }
+        }
+
+        // Interaction step: `source -> destination ["description"]`
+        if ((token.type === 'IDENTIFIER' || token.type === 'KEYWORD') && p.tokens[p.pos + 1]?.type === 'ARROW') {
+            const sourceToken = p.advance()
+            p.advance() // consume ARROW
+            const destToken = p.peek()
+            if (destToken.type !== 'IDENTIFIER' && destToken.type !== 'KEYWORD') {
+                p.addError(`Expected interaction destination, got ${destToken.type}`, destToken)
+                p.skipToNextLine()
+                continue
+            }
+            p.advance()
+            const stepDescription = p.readOptionalString() || undefined
+
+            const sourceId = p.resolveRef(sourceToken.value)
+            const destId = p.resolveRef(destToken.value)
+            if (!sourceId || !destId) {
+                p.addError(`Unresolved reference in dynamic view: '${!sourceId ? sourceToken.value : destToken.value}'`, sourceToken)
+                continue
+            }
+
+            // The step must reference an existing model relationship. Prefer a
+            // description match when several connect the same pair.
+            const candidates = model.relationships.filter(
+                r => !r.implied && r.sourceId === sourceId && r.destinationId === destId
+            )
+            const rel = candidates.find(r => stepDescription && r.description === stepDescription) ?? candidates[0]
+            if (!rel) {
+                p.addError(
+                    `Dynamic view step references a relationship that does not exist in the model: '${sourceToken.value} -> ${destToken.value}'`,
+                    sourceToken
+                )
+                continue
+            }
+
+            view.relationships.push({
+                id: rel.id,
+                order: String(order.next++),
+                description: stepDescription,
+            })
+            addElement(sourceId)
+            addElement(destId)
+            continue
+        }
+
+        if (token.type === 'KEYWORD' || token.type === 'IDENTIFIER') {
+            p.advance()
+            p.skipUnknownDirective()
+            continue
+        }
+
+        p.advance()
+    }
+}
+
+/** Parse `deployment <scope|*> <environment> [key] [description] { ... }`.
+ *  The body is the standard view body (include/exclude/autoLayout/…). */
+function parseDeploymentView(p: ContextAwareParser, model: Model): View | null {
+    p.advance() // consume 'deployment'
+
+    let scopeRef: string | undefined
+    if (p.check('STAR')) {
+        p.advance()
+    } else {
+        scopeRef = p.readOptionalStringOrIdentifier()
+    }
+
+    // Environment: a string name, or an identifier assigned to a
+    // deploymentEnvironment (resolved back to the environment's name).
+    let environment = p.readOptionalStringOrIdentifier()
+    if (environment !== undefined) {
+        const resolved = p.resolveRef(environment)
+        if (resolved && p.elementsById.get(resolved)?.type === 'deploymentEnvironment') {
+            environment = p.elementsById.get(resolved)!.name
+        }
+    }
+
+    const key = p.readOptionalStringOrIdentifier() ?? ''
+    const positionalDescription = p.readOptionalString()
+
+    const view: View = {
+        type: 'deployment',
+        key,
+        title: positionalDescription,
+        description: positionalDescription,
+        environment,
+        elements: [],
+        relationships: [],
+    }
+
+    if (scopeRef) {
+        const resolvedId = p.resolveRef(scopeRef)
+        view.softwareSystemId = resolvedId ?? scopeRef
+    }
+
+    if (environment !== undefined && !model.deploymentEnvironments.some(e => e.name === environment)) {
+        p.addError(`Deployment view references unknown environment '${environment}'`, p.peek())
+    }
+
+    p.skipNewlines()
+    if (p.match('LBRACE')) {
+        parseViewBody(p, view, model)
+        p.skipNewlines()
+        p.expect('RBRACE')
+    }
+
+    return view
+}
+
 function parseViewBody(p: ContextAwareParser, view: View, model: Model): void {
     while (!p.check('RBRACE') && p.peekType() !== 'EOF') {
         p.skipNewlines()
@@ -260,22 +517,7 @@ function parseViewBody(p: ContextAwareParser, view: View, model: Model): void {
             }
 
             if (kw === 'autolayout') {
-                p.advance()
-                const layout: AutoLayout = { direction: 'TB' }
-                if (p.check('IDENTIFIER') || p.check('KEYWORD')) {
-                    const dir = p.peekValue().toUpperCase()
-                    if (dir === 'TB' || dir === 'BT' || dir === 'LR' || dir === 'RL') {
-                        layout.direction = dir as LayoutDirection
-                        p.advance()
-                    }
-                }
-                if (p.check('NUMBER')) {
-                    layout.rankSeparation = parseInt(p.advance().value, 10)
-                }
-                if (p.check('NUMBER')) {
-                    layout.nodeSeparation = parseInt(p.advance().value, 10)
-                }
-                view.autoLayout = layout
+                parseAutoLayoutInto(p, view)
                 continue
             }
 

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -6,9 +6,7 @@ import type {
     Model,
     View,
     ElementInView,
-    Relationship,
     DeploymentNode,
-    DeploymentEnvironment,
 } from '@/types/model'
 import { lex } from './lexer'
 import type { Token, TokenType } from './lexer'
@@ -116,16 +114,6 @@ function expandWildcard(model: Model, view: View): ElementInView[] {
 
 // ─── Deployment helpers ──────────────────────────────────────────────
 
-/** Depth-first walk over an environment's deployment node tree. */
-function walkDeploymentNodes(env: DeploymentEnvironment, visit: (node: DeploymentNode) => void): void {
-    const stack = [...env.deploymentNodes]
-    while (stack.length > 0) {
-        const node = stack.pop()!
-        visit(node)
-        stack.push(...node.children)
-    }
-}
-
 /** Element IDs that belong to the scope system for deployment-view filtering:
  *  the system itself plus its containers. */
 function deploymentScopeIds(model: Model, softwareSystemId: string): Set<string> {
@@ -186,60 +174,6 @@ function expandDeploymentWildcard(model: Model, view: View): ElementInView[] {
     // but ElementInView order does not matter to the canvas).
     const seen = new Set<string>()
     return ids.filter(id => (seen.has(id) ? false : (seen.add(id), true))).map(id => ({ id }))
-}
-
-/** Replicate model relationships between deployment instances within each
- *  environment, mirroring Structurizr's implied instance relationships: if
- *  container A -> container B exists and both have instances in the same
- *  environment, each instance pair gets an implied relationship. */
-function addImpliedInstanceRelationships(model: Model): void {
-    for (const env of model.deploymentEnvironments) {
-        // Map: model element id -> instance ids within this environment
-        const instancesByElement = new Map<string, string[]>()
-        walkDeploymentNodes(env, node => {
-            for (const inst of node.containerInstances) {
-                const list = instancesByElement.get(inst.containerId) ?? []
-                list.push(inst.id)
-                instancesByElement.set(inst.containerId, list)
-            }
-            for (const inst of node.softwareSystemInstances) {
-                const list = instancesByElement.get(inst.softwareSystemId) ?? []
-                list.push(inst.id)
-                instancesByElement.set(inst.softwareSystemId, list)
-            }
-        })
-        if (instancesByElement.size === 0) continue
-
-        const explicitPairs = new Set(
-            model.relationships.filter(r => !r.implied).map(r => `${r.sourceId}→${r.destinationId}`)
-        )
-
-        const implied: Relationship[] = []
-        for (const rel of model.relationships) {
-            if (rel.implied) continue
-            const sourceInstances = instancesByElement.get(rel.sourceId)
-            const destInstances = instancesByElement.get(rel.destinationId)
-            if (!sourceInstances || !destInstances) continue
-            for (const src of sourceInstances) {
-                for (const dst of destInstances) {
-                    if (explicitPairs.has(`${src}→${dst}`)) continue
-                    implied.push({
-                        id: `rel-implied-${src}-${dst}`,
-                        sourceId: src,
-                        destinationId: dst,
-                        description: rel.description,
-                        technology: rel.technology,
-                        interactionStyle: rel.interactionStyle,
-                        lineStyle: rel.lineStyle,
-                        tags: [...rel.tags],
-                        properties: {},
-                        implied: true,
-                    })
-                }
-            }
-        }
-        model.relationships.push(...implied)
-    }
 }
 
 // ─── Public Types ────────────────────────────────────────────────────
@@ -734,11 +668,10 @@ export function parse(input: string): ParseResult {
     // Combine lexer and parser errors
     const errors = [...lexResult.errors, ...result.errors]
 
-    // Post-process: replicate model relationships between deployment instances
-    // (Structurizr's implied instance relationships) BEFORE populating view
-    // relationships, so deployment views pick them up like any other.
+    // Implied instance relationships are NOT materialized here — the canvas
+    // derives them per deployment view via deriveInstanceRelationships(), so
+    // the model only ever holds relationships the user authored.
     const ws = result.workspace
-    addImpliedInstanceRelationships(ws.model)
 
     // Post-process: populate view.relationships from model relationships.
     // The DSL doesn't store relationship refs in views — Structurizr infers them.

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -6,6 +6,9 @@ import type {
     Model,
     View,
     ElementInView,
+    Relationship,
+    DeploymentNode,
+    DeploymentEnvironment,
 } from '@/types/model'
 import { lex } from './lexer'
 import type { Token, TokenType } from './lexer'
@@ -109,6 +112,134 @@ function expandWildcard(model: Model, view: View): ElementInView[] {
     }
 
     return ids.map(id => ({ id }))
+}
+
+// ─── Deployment helpers ──────────────────────────────────────────────
+
+/** Depth-first walk over an environment's deployment node tree. */
+function walkDeploymentNodes(env: DeploymentEnvironment, visit: (node: DeploymentNode) => void): void {
+    const stack = [...env.deploymentNodes]
+    while (stack.length > 0) {
+        const node = stack.pop()!
+        visit(node)
+        stack.push(...node.children)
+    }
+}
+
+/** Element IDs that belong to the scope system for deployment-view filtering:
+ *  the system itself plus its containers. */
+function deploymentScopeIds(model: Model, softwareSystemId: string): Set<string> {
+    const ids = new Set<string>([softwareSystemId])
+    const sys = model.softwareSystems.find(s => s.id === softwareSystemId)
+    if (sys) for (const c of sys.containers) ids.add(c.id)
+    return ids
+}
+
+/** Expand `include *` for a deployment view: every deployment node in the
+ *  view's environment (plus its infrastructure nodes and instances). When the
+ *  view is scoped to a software system, only instances of that system (or its
+ *  containers) are kept, nodes whose subtree contains no kept instance are
+ *  dropped, and infrastructure nodes survive with their parent node. */
+function expandDeploymentWildcard(model: Model, view: View): ElementInView[] {
+    const env = model.deploymentEnvironments.find(e => e.name === view.environment)
+    if (!env) return []
+
+    const scopeIds = view.softwareSystemId ? deploymentScopeIds(model, view.softwareSystemId) : undefined
+
+    const ids: string[] = []
+    const addNode = (node: DeploymentNode): boolean => {
+        const keptChildIds: string[] = []
+        let hasKeptInstance = false
+
+        for (const inst of node.containerInstances) {
+            if (!scopeIds || scopeIds.has(inst.containerId)) {
+                keptChildIds.push(inst.id)
+                hasKeptInstance = true
+            }
+        }
+        for (const inst of node.softwareSystemInstances) {
+            if (!scopeIds || scopeIds.has(inst.softwareSystemId)) {
+                keptChildIds.push(inst.id)
+                hasKeptInstance = true
+            }
+        }
+
+        let hasKeptDescendant = hasKeptInstance
+        for (const child of node.children) {
+            if (addNode(child)) hasKeptDescendant = true
+        }
+
+        // Unscoped views keep every node; scoped views keep only subtrees
+        // that actually deploy something relevant.
+        if (!scopeIds || hasKeptDescendant) {
+            ids.push(node.id)
+            for (const infra of node.infrastructureNodes) ids.push(infra.id)
+            ids.push(...keptChildIds)
+            return true
+        }
+        return false
+    }
+
+    for (const node of env.deploymentNodes) addNode(node)
+
+    // Dedupe while preserving order (child recursion appends before parents,
+    // but ElementInView order does not matter to the canvas).
+    const seen = new Set<string>()
+    return ids.filter(id => (seen.has(id) ? false : (seen.add(id), true))).map(id => ({ id }))
+}
+
+/** Replicate model relationships between deployment instances within each
+ *  environment, mirroring Structurizr's implied instance relationships: if
+ *  container A -> container B exists and both have instances in the same
+ *  environment, each instance pair gets an implied relationship. */
+function addImpliedInstanceRelationships(model: Model): void {
+    for (const env of model.deploymentEnvironments) {
+        // Map: model element id -> instance ids within this environment
+        const instancesByElement = new Map<string, string[]>()
+        walkDeploymentNodes(env, node => {
+            for (const inst of node.containerInstances) {
+                const list = instancesByElement.get(inst.containerId) ?? []
+                list.push(inst.id)
+                instancesByElement.set(inst.containerId, list)
+            }
+            for (const inst of node.softwareSystemInstances) {
+                const list = instancesByElement.get(inst.softwareSystemId) ?? []
+                list.push(inst.id)
+                instancesByElement.set(inst.softwareSystemId, list)
+            }
+        })
+        if (instancesByElement.size === 0) continue
+
+        const explicitPairs = new Set(
+            model.relationships.filter(r => !r.implied).map(r => `${r.sourceId}→${r.destinationId}`)
+        )
+
+        const implied: Relationship[] = []
+        for (const rel of model.relationships) {
+            if (rel.implied) continue
+            const sourceInstances = instancesByElement.get(rel.sourceId)
+            const destInstances = instancesByElement.get(rel.destinationId)
+            if (!sourceInstances || !destInstances) continue
+            for (const src of sourceInstances) {
+                for (const dst of destInstances) {
+                    if (explicitPairs.has(`${src}→${dst}`)) continue
+                    implied.push({
+                        id: `rel-implied-${src}-${dst}`,
+                        sourceId: src,
+                        destinationId: dst,
+                        description: rel.description,
+                        technology: rel.technology,
+                        interactionStyle: rel.interactionStyle,
+                        lineStyle: rel.lineStyle,
+                        tags: [...rel.tags],
+                        properties: {},
+                        implied: true,
+                    })
+                }
+            }
+        }
+        model.relationships.push(...implied)
+    }
 }
 
 // ─── Public Types ────────────────────────────────────────────────────
@@ -325,6 +456,17 @@ export class ContextAwareParser {
         return path
     }
 
+    /** Register a deployment-family element (environment, node, instance).
+     *  Unlike registerElement this never maps the display name, because
+     *  deployment names routinely duplicate model element names (an instance
+     *  shares its container's name) and must not shadow them in resolveRef. */
+    registerDeploymentElement(id: string, name: string, _type: string, varName?: string): void {
+        this.elementsById.set(id, { name, type: _type })
+        if (varName) {
+            this.varToId.set(varName, id)
+        }
+    }
+
     resolveRef(ref: string): string | undefined {
         // Qualified paths win: the same bare variable name may be declared in
         // several scopes, in which case varToId only remembers the last one.
@@ -477,12 +619,15 @@ export class ContextAwareParser {
                 softwareSystems: [],
                 relationships: [],
                 groups: [],
+                deploymentEnvironments: [],
             },
             views: {
                 systemLandscapeViews: [],
                 systemContextViews: [],
                 containerViews: [],
                 componentViews: [],
+                dynamicViews: [],
+                deploymentViews: [],
                 configuration: {
                     styles: { elements: [], relationships: [] },
                 },
@@ -589,23 +734,33 @@ export function parse(input: string): ParseResult {
     // Combine lexer and parser errors
     const errors = [...lexResult.errors, ...result.errors]
 
+    // Post-process: replicate model relationships between deployment instances
+    // (Structurizr's implied instance relationships) BEFORE populating view
+    // relationships, so deployment views pick them up like any other.
+    const ws = result.workspace
+    addImpliedInstanceRelationships(ws.model)
+
     // Post-process: populate view.relationships from model relationships.
     // The DSL doesn't store relationship refs in views — Structurizr infers them.
     // We do the same: for each view, include any model relationship whose source
     // AND destination are both present in that view's element set.
-    const ws = result.workspace
+    // Dynamic views are excluded: their relationship list is an explicit,
+    // ordered interaction sequence built during parsing.
     const allViews = [
         ...ws.views.systemLandscapeViews,
         ...ws.views.systemContextViews,
         ...ws.views.containerViews,
         ...ws.views.componentViews,
+        ...ws.views.deploymentViews,
     ]
     for (const view of allViews) {
         const excluded = parser.getExcludedIdsForView(view)
         const hasWildcard = view.elements.some(e => e.id === '*')
         if (hasWildcard) {
             // Expand `include *` to all elements appropriate for this view type
-            let expanded = expandWildcard(ws.model, view)
+            let expanded = view.type === 'deployment'
+                ? expandDeploymentWildcard(ws.model, view)
+                : expandWildcard(ws.model, view)
             // Apply `exclude` directives after wildcard expansion
             if (excluded.size > 0) {
                 expanded = expanded.filter(e => !excluded.has(e.id))

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -501,12 +501,10 @@ class SerializerContext {
             this.serializeDeploymentEnvironment(env)
         }
 
-        // Relationships. Implied instance relationships are parser-derived
-        // (replicated from container/system relationships) — never emitted.
-        const explicitRels = model.relationships.filter(r => !r.implied)
-        if (explicitRels.length > 0) {
+        // Relationships
+        if (model.relationships.length > 0) {
             this.emitBlank()
-            for (const rel of explicitRels) {
+            for (const rel of model.relationships) {
                 this.serializeRelationship(rel)
             }
         }
@@ -1010,8 +1008,17 @@ class SerializerContext {
         for (const step of view.relationships) {
             const rel = relById.get(step.id)
             if (!rel) continue
-            const sourceRef = this.idToVar.get(rel.sourceId) ?? rel.sourceId
-            const destRef = this.idToVar.get(rel.destinationId) ?? rel.destinationId
+            // Steps carry their own endpoints in travel order: a response
+            // step runs against the relationship's direction, and a
+            // hierarchy-implied step connects different granularity than the
+            // backing relationship. Older workspaces without step endpoints
+            // fall back to the relationship's, reversed for responses.
+            const fromId = step.sourceId
+                ?? (step.response ? rel.destinationId : rel.sourceId)
+            const toId = step.destinationId
+                ?? (step.response ? rel.sourceId : rel.destinationId)
+            const sourceRef = this.idToVar.get(fromId) ?? fromId
+            const destRef = this.idToVar.get(toId) ?? toId
             const description = step.description ?? rel.description
             const line = description
                 ? `${sourceRef} -> ${destRef} "${this.escapeString(description)}"`

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -15,6 +15,9 @@ import type {
     ViewConfiguration,
     Group,
     ModelElement,
+    DeploymentEnvironment,
+    DeploymentNode,
+    InfrastructureNode,
 } from '@/types/model'
 
 const INDENT = '    ' // 4 spaces
@@ -278,6 +281,21 @@ class SerializerContext {
                 }
             }
         }
+
+        // Tolerate workspaces persisted before deployment support existed.
+        for (const env of model.deploymentEnvironments ?? []) {
+            this.registerDeploymentNodes(env.deploymentNodes)
+        }
+    }
+
+    private registerDeploymentNodes(nodes: DeploymentNode[]): void {
+        for (const node of nodes) {
+            this.registerElement(node.id)
+            for (const infra of node.infrastructureNodes) this.registerElement(infra.id)
+            for (const inst of node.containerInstances) this.registerElement(inst.id)
+            for (const inst of node.softwareSystemInstances) this.registerElement(inst.id)
+            this.registerDeploymentNodes(node.children)
+        }
     }
 
     private usedVarNames = new Set<string>()
@@ -476,10 +494,19 @@ class SerializerContext {
 
         this.serializeGroupScope(this.topLevelGroups, element => this.serializeModelElement(element))
 
-        // Relationships
-        if (model.relationships.length > 0) {
+        // Deployment environments (before relationships — instance identifiers
+        // must be defined before any relationship lines that reference them)
+        for (const env of model.deploymentEnvironments ?? []) {
             this.emitBlank()
-            for (const rel of model.relationships) {
+            this.serializeDeploymentEnvironment(env)
+        }
+
+        // Relationships. Implied instance relationships are parser-derived
+        // (replicated from container/system relationships) — never emitted.
+        const explicitRels = model.relationships.filter(r => !r.implied)
+        if (explicitRels.length > 0) {
+            this.emitBlank()
+            for (const rel of explicitRels) {
                 this.serializeRelationship(rel)
             }
         }
@@ -529,6 +556,121 @@ class SerializerContext {
     private serializeModelElement(element: Person | SoftwareSystem): void {
         if (element.type === 'person') this.serializePerson(element)
         else this.serializeSoftwareSystem(element)
+    }
+
+    // ─── Deployment ─────────────────────────────────────────────────
+
+    private serializeDeploymentEnvironment(env: DeploymentEnvironment): void {
+        this.emit(`deploymentEnvironment "${this.escapeString(env.name)}" {`)
+        this.depth++
+        for (let i = 0; i < env.deploymentNodes.length; i++) {
+            if (i > 0) this.emitBlank()
+            this.serializeDeploymentNode(env.deploymentNodes[i])
+        }
+        this.depth--
+        this.emit('}')
+    }
+
+    private serializeDeploymentNode(node: DeploymentNode): void {
+        const varName = this.idToVar.get(node.id)
+        const extraTags = this.getExtraTags(node.tags, ['Element', 'Deployment Node'])
+        const hasProperties = Object.keys(node.properties).length > 0
+
+        const parts: string[] = []
+        parts.push('deploymentNode')
+        parts.push(`"${this.escapeString(node.name)}"`)
+        if (node.description || node.technology || extraTags) {
+            parts.push(`"${this.escapeString(node.description ?? '')}"`)
+        }
+        if (node.technology || extraTags) {
+            parts.push(`"${this.escapeString(node.technology ?? '')}"`)
+        }
+        if (extraTags) parts.push(`"${extraTags}"`)
+
+        const prefix = varName ? `${varName} = ` : ''
+        this.emit(`${prefix}${parts.join(' ')} {`)
+        this.depth++
+
+        if (node.instances !== undefined) this.emit(`instances ${/^\d+$/.test(node.instances) ? node.instances : `"${this.escapeString(node.instances)}"`}`)
+        if (node.url) this.emit(`url "${this.escapeString(node.url)}"`)
+        if (hasProperties) this.serializeProperties(node.properties)
+
+        for (const infra of node.infrastructureNodes) {
+            this.serializeInfrastructureNode(infra)
+        }
+        for (const inst of node.softwareSystemInstances) {
+            this.serializeElementInstance('softwareSystemInstance', inst.id, inst.softwareSystemId, inst.tags, ['Software System Instance'], inst.url, inst.properties)
+        }
+        for (const inst of node.containerInstances) {
+            this.serializeElementInstance('containerInstance', inst.id, inst.containerId, inst.tags, ['Container Instance'], inst.url, inst.properties)
+        }
+        for (const child of node.children) {
+            this.serializeDeploymentNode(child)
+        }
+
+        this.depth--
+        this.emit('}')
+    }
+
+    private serializeInfrastructureNode(infra: InfrastructureNode): void {
+        const varName = this.idToVar.get(infra.id)
+        const extraTags = this.getExtraTags(infra.tags, ['Element', 'Infrastructure Node'])
+        const hasProperties = Object.keys(infra.properties).length > 0
+        const hasBlock = !!infra.url || hasProperties
+
+        const parts: string[] = []
+        parts.push('infrastructureNode')
+        parts.push(`"${this.escapeString(infra.name)}"`)
+        if (infra.description || infra.technology || extraTags) {
+            parts.push(`"${this.escapeString(infra.description ?? '')}"`)
+        }
+        if (infra.technology || extraTags) {
+            parts.push(`"${this.escapeString(infra.technology ?? '')}"`)
+        }
+        if (extraTags) parts.push(`"${extraTags}"`)
+
+        const prefix = varName ? `${varName} = ` : ''
+        if (hasBlock) {
+            this.emit(`${prefix}${parts.join(' ')} {`)
+            this.depth++
+            if (infra.url) this.emit(`url "${this.escapeString(infra.url)}"`)
+            if (hasProperties) this.serializeProperties(infra.properties)
+            this.depth--
+            this.emit('}')
+        } else {
+            this.emit(`${prefix}${parts.join(' ')}`)
+        }
+    }
+
+    private serializeElementInstance(
+        keyword: 'containerInstance' | 'softwareSystemInstance',
+        id: string,
+        referencedId: string,
+        tags: string[],
+        defaultTags: string[],
+        url: string | undefined,
+        properties: Record<string, string>,
+    ): void {
+        const varName = this.idToVar.get(id)
+        const ref = this.idToVar.get(referencedId) ?? referencedId
+        const extraTags = this.getExtraTags(tags, defaultTags)
+        const hasProperties = Object.keys(properties).length > 0
+        const hasBlock = !!url || hasProperties
+
+        const parts: string[] = [keyword, ref]
+        if (extraTags) parts.push(`"${extraTags}"`)
+
+        const prefix = varName ? `${varName} = ` : ''
+        if (hasBlock) {
+            this.emit(`${prefix}${parts.join(' ')} {`)
+            this.depth++
+            if (url) this.emit(`url "${this.escapeString(url)}"`)
+            if (hasProperties) this.serializeProperties(properties)
+            this.depth--
+            this.emit('}')
+        } else {
+            this.emit(`${prefix}${parts.join(' ')}`)
+        }
     }
 
     private serializePerson(person: Person): void {
@@ -743,6 +885,20 @@ class SerializerContext {
             needsBlank = true
         }
 
+        for (const view of views.dynamicViews ?? []) {
+            if (view.autoView) continue
+            if (needsBlank) this.emitBlank()
+            this.serializeDynamicView(view)
+            needsBlank = true
+        }
+
+        for (const view of views.deploymentViews ?? []) {
+            if (view.autoView) continue
+            if (needsBlank) this.emitBlank()
+            this.serializeView(view)
+            needsBlank = true
+        }
+
         // Styles — sanitize and filter once; emission reuses the result.
         const styles = this.emittableStyles(views.configuration)
         if (styles.elements.length > 0 || styles.relationships.length > 0) {
@@ -784,6 +940,14 @@ class SerializerContext {
                 const ref = this.idToVar.get(view.containerId) ?? view.containerId
                 parts.push(ref)
             }
+        } else if (view.type === 'deployment') {
+            parts.push('deployment')
+            if (view.softwareSystemId) {
+                parts.push(this.idToVar.get(view.softwareSystemId) ?? view.softwareSystemId)
+            } else {
+                parts.push('*')
+            }
+            parts.push(`"${this.escapeString(view.environment ?? '')}"`)
         }
 
         // Skip parser-synthesised keys so DSL without explicit view keys
@@ -816,6 +980,45 @@ class SerializerContext {
         }
 
         // Auto layout
+        if (view.autoLayout) {
+            this.serializeAutoLayout(view.autoLayout)
+        }
+
+        this.depth--
+        this.emit('}')
+    }
+
+    /** Dynamic views serialize as an ordered list of interaction steps
+     *  (`source -> destination "description"`), not as include lines. */
+    private serializeDynamicView(view: View): void {
+        const parts: string[] = ['dynamic']
+        const scopeId = view.softwareSystemId ?? view.containerId
+        if (scopeId) {
+            parts.push(this.idToVar.get(scopeId) ?? scopeId)
+        } else {
+            parts.push('*')
+        }
+        if (view.key && !view.autoKey) parts.push(`"${this.escapeString(view.key)}"`)
+
+        this.emit(`${parts.join(' ')} {`)
+        this.depth++
+
+        if (view.title) this.emit(`title "${this.escapeString(view.title)}"`)
+        if (view.description) this.emit(`description "${this.escapeString(view.description)}"`)
+
+        const relById = new Map(this.workspace.model.relationships.map(r => [r.id, r]))
+        for (const step of view.relationships) {
+            const rel = relById.get(step.id)
+            if (!rel) continue
+            const sourceRef = this.idToVar.get(rel.sourceId) ?? rel.sourceId
+            const destRef = this.idToVar.get(rel.destinationId) ?? rel.destinationId
+            const description = step.description ?? rel.description
+            const line = description
+                ? `${sourceRef} -> ${destRef} "${this.escapeString(description)}"`
+                : `${sourceRef} -> ${destRef}`
+            this.emit(line)
+        }
+
         if (view.autoLayout) {
             this.serializeAutoLayout(view.autoLayout)
         }

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -216,6 +216,144 @@ describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance (real CLI)', () => {
         expect(validate(source)).toContain('View keys can only contain')
     })
 
+    // Deployment + dynamic views: the grammar shapes that broke the first
+    // implementation attempt (PR #105), each validated against the real
+    // parser rather than against our own round-trip alone.
+    describe('deployment and dynamic views', () => {
+        const DEPLOYMENT_DSL = `
+workspace "Deploy" {
+  model {
+    sys = softwareSystem "Sys" {
+      web = container "Web"
+      db = container "DB"
+      web -> db "Reads" "JDBC"
+    }
+    ext = softwareSystem "Mainframe"
+    web -> ext "Uses"
+
+    deploymentEnvironment "Live" {
+      deploymentNode "AWS" "" "Amazon Web Services" {
+        deploymentNode "us-east-1" {
+          lb = infrastructureNode "Load Balancer" "Routes traffic" "ELB"
+          deploymentNode "Web Server" "" "Ubuntu" "" 4 {
+            liveWeb = containerInstance web
+          }
+          deploymentNode "DB Server" "" "Ubuntu" {
+            liveDb = containerInstance db
+          }
+        }
+      }
+      deploymentNode "DC" {
+        liveExt = softwareSystemInstance ext
+      }
+      lb -> liveWeb "Forwards to" "HTTPS"
+    }
+  }
+  views {
+    deployment sys "Live" "LiveScoped" {
+      include *
+      autoLayout lr
+    }
+    deployment * "Live" "LiveAll" {
+      include *
+    }
+  }
+}
+`
+        const DYNAMIC_DSL = `
+workspace "Dynamics" {
+  model {
+    user = person "User"
+    sys = softwareSystem "Sys" {
+      spa = container "SPA"
+      api = container "API"
+      db = container "DB"
+      spa -> api "Submits order"
+      api -> db "Persists order"
+    }
+    user -> spa "Uses"
+    user -> sys "Uses the system"
+  }
+  views {
+    dynamic sys "Checkout" {
+      user -> spa "Opens checkout"
+      spa -> api "Submits order"
+      api -> db "Persists order"
+      api -> spa "Returns confirmation"
+      spa -> api "Submits order"
+    }
+  }
+}
+`
+
+        it('the deployment fixture itself is valid upstream', () => {
+            expect(validate(DEPLOYMENT_DSL)).toBeNull()
+        })
+
+        it('the dynamic fixture itself is valid upstream', () => {
+            expect(validate(DYNAMIC_DSL)).toBeNull()
+        })
+
+        it('a parsed deployment workspace re-serializes to DSL Structurizr accepts', () => {
+            const { workspace, errors } = parseDSL(DEPLOYMENT_DSL)
+            expect(errors).toEqual([])
+            expect(validate(serializeDSL(workspace))).toBeNull()
+        })
+
+        it('a parsed dynamic workspace re-serializes to DSL Structurizr accepts', () => {
+            const { workspace, errors } = parseDSL(DYNAMIC_DSL)
+            expect(errors).toEqual([])
+            expect(validate(serializeDSL(workspace))).toBeNull()
+        })
+
+        it('the positional instances argument survives to the real parser', () => {
+            // PR #105 never consumed the 5th positional argument, silently
+            // re-parenting children. Compare what the real parser stores for
+            // our re-serialization against the original.
+            const { workspace, errors } = parseDSL(DEPLOYMENT_DSL)
+            expect(errors).toEqual([])
+            type ExportedNode = {
+                name: string
+                instances?: string | number
+                children?: ExportedNode[]
+                containerInstances?: unknown[]
+                infrastructureNodes?: unknown[]
+            }
+            const nodesOf = (model: Record<string, unknown>): ExportedNode[] => {
+                const m = model.model as { deploymentNodes?: ExportedNode[] } | undefined
+                return m?.deploymentNodes ?? []
+            }
+            const flatten = (nodes: ExportedNode[]): ExportedNode[] =>
+                nodes.flatMap(n => [n, ...flatten(n.children ?? [])])
+
+            const theirs = flatten(nodesOf(exportModel(DEPLOYMENT_DSL)))
+            const ours = flatten(nodesOf(exportModel(serializeDSL(workspace))))
+
+            const summarize = (nodes: ExportedNode[]) => nodes
+                .map(n => ({
+                    name: n.name,
+                    instances: String(n.instances ?? '1'),
+                    containerInstances: (n.containerInstances ?? []).length,
+                    infrastructureNodes: (n.infrastructureNodes ?? []).length,
+                }))
+                .sort((a, b) => a.name.localeCompare(b.name))
+            expect(summarize(ours)).toEqual(summarize(theirs))
+            expect(summarize(theirs).find(n => n.name === 'Web Server')?.instances).toBe('4')
+        })
+
+        it('dynamic steps keep order, repeats, and the response step through re-serialization', () => {
+            const { workspace, errors } = parseDSL(DYNAMIC_DSL)
+            expect(errors).toEqual([])
+            const reparsed = parseDSL(serializeDSL(workspace))
+            expect(reparsed.errors).toEqual([])
+            const view = reparsed.workspace.views.dynamicViews[0]
+            expect(view.relationships.map(s => s.order)).toEqual(['1', '2', '3', '4', '5'])
+            // Step 4 is the response; step 5 repeats step 2's relationship.
+            expect(view.relationships[3].response).toBe(true)
+            expect(view.relationships[4].id).toBe(view.relationships[1].id)
+        })
+    })
+
     it('nested model, container and component groups serialize to DSL Structurizr accepts', () => {
         const { workspace, errors } = parseDSL(`
 workspace "Grouped" {

--- a/src/lib/templates/bigBank.ts
+++ b/src/lib/templates/bigBank.ts
@@ -217,6 +217,7 @@ export function createBigBankSample(): Workspace {
         { id: 'r28', sourceId: 'mainframeFacade', destinationId: 'mainframe', description: 'Makes API calls', technology: 'XML/HTTPS', tags: ['Relationship'], properties: {} },
       ],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: [
@@ -311,6 +312,8 @@ export function createBigBankSample(): Workspace {
           autoLayout: { direction: 'TB' },
         },
       ],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: {
         styles: {
           elements: [

--- a/src/lib/templates/blank.ts
+++ b/src/lib/templates/blank.ts
@@ -26,6 +26,7 @@ export function createBlankWorkspace(scope?: import('@/types/model').WorkspaceSc
         : [],
       relationships: [],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: isSoftwareSystem
@@ -55,6 +56,8 @@ export function createBlankWorkspace(scope?: import('@/types/model').WorkspaceSc
         : [],
       containerViews: [],
       componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: {
         styles: {
           elements: [],

--- a/src/lib/templates/eventDriven.ts
+++ b/src/lib/templates/eventDriven.ts
@@ -125,6 +125,7 @@ export function createEventDrivenTemplate(): Workspace {
         { id: 'r12', sourceId: 'analyst', destinationId: 'dataLake', description: 'Queries for analytics', technology: 'SQL / Athena', tags: ['Relationship'], properties: {} },
       ],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: [
@@ -172,6 +173,8 @@ export function createEventDrivenTemplate(): Workspace {
         },
       ],
       componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: {
         styles: {
           elements: [

--- a/src/lib/templates/microservices.ts
+++ b/src/lib/templates/microservices.ts
@@ -115,6 +115,7 @@ export function createMicroservicesTemplate(): Workspace {
         { id: 'r12', sourceId: 'userService', destinationId: 'rabbitMQ', description: 'Publishes user events', technology: 'AMQP', tags: ['Relationship'], properties: {} },
       ],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: [
@@ -160,6 +161,8 @@ export function createMicroservicesTemplate(): Workspace {
         },
       ],
       componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: {
         styles: {
           elements: [

--- a/src/lib/templates/monolith.ts
+++ b/src/lib/templates/monolith.ts
@@ -91,6 +91,7 @@ export function createMonolithTemplate(): Workspace {
         { id: 'r9', sourceId: 'backendApp', destinationId: 'emailService', description: 'Sends emails via', technology: 'SMTP', tags: ['Relationship'], properties: {} },
       ],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: [
@@ -134,6 +135,8 @@ export function createMonolithTemplate(): Workspace {
         },
       ],
       componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: {
         styles: {
           elements: [

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand'
 import type { WorkspaceState } from '../workspace-types'
 import { validateScope } from '@/lib/scopeValidation'
 import { pushUndoSnapshot } from '../internals'
+import { normalizeWorkspaceShape } from '../workspace-helpers'
 import { getFirstViewKey } from '../workspace-selectors'
 
 /** Workspace lifecycle: load / close / metadata / scope validation, plus
@@ -31,6 +32,9 @@ export const createLifecycleSlice: StateCreator<
   }),
 
   loadWorkspace: (workspace) => {
+    // Files and snapshots written before dynamic/deployment views existed
+    // lack those arrays; fill them before anything iterates VIEW_ARRAY_KEYS.
+    normalizeWorkspaceShape(workspace)
     const firstView = getFirstViewKey(workspace)
     set({
       workspace,

--- a/src/store/slices/undo-slice.ts
+++ b/src/store/slices/undo-slice.ts
@@ -3,7 +3,7 @@ import type { WorkspaceState } from '../workspace-types'
 import { announce } from '@/lib/announce'
 import { validateScope } from '@/lib/scopeValidation'
 import { undoSnapshot } from '../internals'
-import { findViewHelper, clearSelectionDraft } from '../workspace-helpers'
+import { findViewHelper, clearSelectionDraft, normalizeWorkspaceShape } from '../workspace-helpers'
 import { getFirstViewKey } from '../workspace-selectors'
 
 /** Undo / redo history. Other slices append snapshots to undoStack via
@@ -75,6 +75,7 @@ export const createUndoSlice: StateCreator<
     // Wholesale workspace replacement with the same view/selection/scope fixups as
     // undo(), but WITHOUT touching the undo/redo stacks — the caller's batch owns
     // the single undo entry. Used by the AI sweep's replay-from-baseline revert.
+    normalizeWorkspaceShape(ws)
     s.workspace = ws
     const activeStillExists = s.activeViewKey ? !!findViewHelper(ws, s.activeViewKey) : false
     s.activeViewKey = activeStillExists ? s.activeViewKey : getFirstViewKey(ws)

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -124,8 +124,8 @@ export function elementExists(ws: Workspace, id: string): boolean {
   return getElementIndex(ws).has(id)
 }
 
-/** The four view-type array keys — used wherever we need to iterate or locate views by type. */
-export const VIEW_ARRAY_KEYS = ['systemLandscapeViews', 'systemContextViews', 'containerViews', 'componentViews'] as const
+/** The view-type array keys — used wherever we need to iterate or locate views by type. */
+export const VIEW_ARRAY_KEYS = ['systemLandscapeViews', 'systemContextViews', 'containerViews', 'componentViews', 'dynamicViews', 'deploymentViews'] as const
 
 /** Apply a callback to every view in the workspace (mutates views in place). */
 export function forEachView(ws: Workspace, fn: (v: View) => void): void {
@@ -154,6 +154,11 @@ const VIEW_ELEMENT_TYPES: Record<View['type'], ReadonlySet<ModelElement['type']>
   systemContext: new Set<ModelElement['type']>(['person', 'softwareSystem']),
   container: new Set<ModelElement['type']>(['person', 'softwareSystem', 'container']),
   component: new Set<ModelElement['type']>(['person', 'softwareSystem', 'container', 'component']),
+  // Dynamic views show whichever model elements participate in the interactions.
+  dynamic: new Set<ModelElement['type']>(['person', 'softwareSystem', 'container', 'component']),
+  // Deployment views show deployment elements (nodes/instances), which are not
+  // ModelElements — plain model elements are never dropped into them directly.
+  deployment: new Set<ModelElement['type']>(),
 }
 
 /** True when a view of `viewType` is allowed to display an element of `elementType`. */

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -15,6 +15,18 @@ function deepCloneMaybeDraft<T>(value: T): T {
   return structuredClone(isDraft(value) ? (current(value as object) as T) : value)
 }
 
+/** Fill view arrays and model collections that predate their introduction.
+ *  Workspaces persisted (or crash-recovery-snapshotted) before dynamic and
+ *  deployment views existed lack those arrays; every VIEW_ARRAY_KEYS loop and
+ *  allViewsOf spread would throw on them. Run once at every point a workspace
+ *  object from outside the store becomes THE workspace. */
+export function normalizeWorkspaceShape(ws: Workspace): Workspace {
+  ws.views.dynamicViews ??= []
+  ws.views.deploymentViews ??= []
+  ws.model.deploymentEnvironments ??= []
+  return ws
+}
+
 /** Get flat array of all views */
 export function allViewsOf(ws: Workspace): View[] {
   return [
@@ -154,8 +166,10 @@ const VIEW_ELEMENT_TYPES: Record<View['type'], ReadonlySet<ModelElement['type']>
   systemContext: new Set<ModelElement['type']>(['person', 'softwareSystem']),
   container: new Set<ModelElement['type']>(['person', 'softwareSystem', 'container']),
   component: new Set<ModelElement['type']>(['person', 'softwareSystem', 'container', 'component']),
-  // Dynamic views show whichever model elements participate in the interactions.
-  dynamic: new Set<ModelElement['type']>(['person', 'softwareSystem', 'container', 'component']),
+  // Dynamic views derive their element membership from the interaction steps
+  // alone — Structurizr has no `include` for them, so a directly-added element
+  // would silently vanish on save/reload. Nothing may be dropped in directly.
+  dynamic: new Set<ModelElement['type']>(),
   // Deployment views show deployment elements (nodes/instances), which are not
   // ModelElements — plain model elements are never dropped into them directly.
   deployment: new Set<ModelElement['type']>(),

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -11,12 +11,15 @@ function makeWorkspace(): Workspace {
       softwareSystems: [{ id: 'api', type: 'softwareSystem', name: 'API', tags: ['Element', 'Software System'], properties: {}, containers: [] }],
       relationships: [],
       groups: [],
+      deploymentEnvironments: [],
     },
     views: {
       systemLandscapeViews: [],
       systemContextViews: [],
       containerViews: [],
       componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
       configuration: { styles: { elements: [], relationships: [] } },
     },
   }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -130,10 +130,6 @@ export interface Relationship {
   url?: string
   tags: string[]
   properties: Record<string, string>
-  /** True for relationships the parser replicates between deployment
-   *  instances (mirroring Structurizr's implied instance relationships).
-   *  The serializer never emits implied relationships back to DSL. */
-  implied?: boolean
 }
 
 // ─── Views ───────────────────────────────────────────────────────────
@@ -150,6 +146,17 @@ export interface ElementInView {
 
 export interface RelationshipInView {
   id: string
+  /** Dynamic views: the step's own endpoints, in travel order. A step may
+   *  connect elements at a different granularity than the backing
+   *  relationship (hierarchy-implied match, e.g. step `app -> sys` backed by
+   *  `app -> sys.api`), so the arrow is drawn between these, not the
+   *  relationship's endpoints. */
+  sourceId?: string
+  destinationId?: string
+  /** Dynamic views: this step travels AGAINST the model relationship's
+   *  direction (a response/return message — `b -> a` where the model holds
+   *  `a -> b`). Structurizr renders these as reversed arrows. */
+  response?: boolean
   /** Dynamic views: sequence label for this interaction ("1", "2", …).
    *  Interaction order is the array order; this is the rendered label. */
   order?: string

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -66,6 +66,57 @@ export interface Group {
 
 export type ModelElement = Person | SoftwareSystem | Container | Component
 
+// ─── Deployment elements ─────────────────────────────────────────────
+
+export interface DeploymentNode extends BaseElement {
+  type: 'deploymentNode'
+  technology?: string
+  /** Structurizr `instances` — a number or range like "0..N", kept verbatim */
+  instances?: string
+  children: DeploymentNode[]
+  infrastructureNodes: InfrastructureNode[]
+  containerInstances: ContainerInstance[]
+  softwareSystemInstances: SoftwareSystemInstance[]
+}
+
+export interface InfrastructureNode extends BaseElement {
+  type: 'infrastructureNode'
+  technology?: string
+}
+
+/** An instance of a model container running on a deployment node. Instances
+ *  have no name of their own — display data comes from the referenced container. */
+export interface ContainerInstance {
+  id: string
+  type: 'containerInstance'
+  containerId: string
+  tags: string[]
+  properties: Record<string, string>
+  url?: string
+}
+
+/** An instance of a model software system running on a deployment node. */
+export interface SoftwareSystemInstance {
+  id: string
+  type: 'softwareSystemInstance'
+  softwareSystemId: string
+  tags: string[]
+  properties: Record<string, string>
+  url?: string
+}
+
+export interface DeploymentEnvironment {
+  id: string
+  name: string
+  deploymentNodes: DeploymentNode[]
+}
+
+export type DeploymentElement =
+  | DeploymentNode
+  | InfrastructureNode
+  | ContainerInstance
+  | SoftwareSystemInstance
+
 // ─── Relationships ───────────────────────────────────────────────────
 
 export interface Relationship {
@@ -79,11 +130,15 @@ export interface Relationship {
   url?: string
   tags: string[]
   properties: Record<string, string>
+  /** True for relationships the parser replicates between deployment
+   *  instances (mirroring Structurizr's implied instance relationships).
+   *  The serializer never emits implied relationships back to DSL. */
+  implied?: boolean
 }
 
 // ─── Views ───────────────────────────────────────────────────────────
 
-export type ViewType = 'systemLandscape' | 'systemContext' | 'container' | 'component'
+export type ViewType = 'systemLandscape' | 'systemContext' | 'container' | 'component' | 'dynamic' | 'deployment'
 
 export interface ElementInView {
   id: string
@@ -95,6 +150,11 @@ export interface ElementInView {
 
 export interface RelationshipInView {
   id: string
+  /** Dynamic views: sequence label for this interaction ("1", "2", …).
+   *  Interaction order is the array order; this is the rendered label. */
+  order?: string
+  /** Dynamic views: per-step description overriding the model relationship's. */
+  description?: string
 }
 
 export interface AutoLayout {
@@ -118,6 +178,8 @@ export interface View {
   description?: string
   softwareSystemId?: string
   containerId?: string
+  /** Deployment views: the deployment environment name this view renders. */
+  environment?: string
   elements: ElementInView[]
   relationships: RelationshipInView[]
   autoLayout?: AutoLayout
@@ -162,6 +224,7 @@ export interface Model {
   softwareSystems: SoftwareSystem[]
   relationships: Relationship[]
   groups: Group[]
+  deploymentEnvironments: DeploymentEnvironment[]
 }
 
 // ─── Workspace ───────────────────────────────────────────────────────
@@ -178,6 +241,8 @@ export interface Workspace {
     systemContextViews: View[]
     containerViews: View[]
     componentViews: View[]
+    dynamicViews: View[]
+    deploymentViews: View[]
     configuration: ViewConfiguration
   }
 }


### PR DESCRIPTION
Part 1 of 3 for **TEA-81** (dynamic + deployment views), replacing closed PR #105. This PR is the DSL layer only: parse, serialize, and round-trip both view types and the deployment model elements, validated against the real Structurizr parser. Canvas rendering (part 2) and view-management UI (part 3) follow.

## Why the reboot

#105 was closed when GH #109 showed our emitted DSL wasn't Structurizr-conformant; the serializer foundation was rebuilt first (TEA-160, TEA-163). This port re-lands the DSL layer on that foundation — and fixes every DSL-layer defect a review of #105 confirmed:

| #105 defect | Fix here |
|---|---|
| Positional 5th `instances` arg never consumed — silently re-parented children, swallowed siblings, zero errors | Consumed into `node.instances`; conformance test compares our re-serialization's exported model against the original via the real CLI |
| Implied instance relationships materialized with pair-keyed ids that collided for parallel relationships | Never materialized. `deriveInstanceRelationships()` (new `src/lib/deployment.ts`) projects them on demand, ids embed the backing relationship id |
| Implied relationships reverted user edits on every save/reload | Same fix — nothing derived is ever stored or serialized |
| Dynamic steps rejected reverse-direction (response) messages | Matched in either direction; responses stored with `response: true`, re-serialized destination → source |
| Dynamic steps broke on hierarchical (dotted) refs | `readQualifiedRef()` + hierarchy-implied matching (step `app -> sys` matches `app -> sys.api`, mirroring `!impliedRelationships`) |
| Dynamic element membership silently discarded on save | Dynamic views refuse direct element adds (`viewAllowsElementType`); membership derives from steps, as upstream defines it |
| Legacy workspaces without the new view arrays crashed VIEW_ARRAY_KEYS loops | Normalized once at store entry (`loadWorkspace`/`resetWorkspaceTo`) instead of guards scattered per loop |

Also found by the new conformance fixtures: foreign view keys with illegal characters (`dynamic sys3 "Label 680"`) re-serialized to DSL Structurizr rejects — keys are now normalized to the legal charset at parse.

## Oracle coverage

`structurizr-conformance.test.ts` gains a deployment + dynamic section run against the pinned Structurizr CLI in CI:
- both fixtures validated as accepted upstream *before* testing our round-trip
- our re-serialization validated
- `exportModel` comparison proving the positional `instances` value and tree shape reach the real parser identically from original and re-serialized DSL
- step order, repeats, and the response step surviving parse → serialize → parse

## Steps carry their own endpoints

`RelationshipInView` gains optional `sourceId`/`destinationId`/`response`. A step may run against its relationship's direction or connect coarser elements than the backing relationship, so serializing the relationship's endpoints would rewrite the author's diagram. The canvas (part 2) draws steps between these.

## Verification

- `npm run check` — lint, typecheck, 1904 unit tests, build.
- Conformance suite (real Structurizr CLI 2025.11.09): 25 tests including the 6 new deployment/dynamic ones.
- New unit coverage: positional instances corruption regression, derived-relationship id uniqueness for parallel relationships, response steps, hierarchy-implied matching via the IcePanel fixture (which now parses error-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAsfeaQnKQnMR9ZKB6hu7U