### PR TITLE
fix(store): keep deployment trees and dynamic steps consistent through model edits (TEA-81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter: stacked PRs target another PR's branch as their
+  # base, and a filter of [main] left their required checks "Expected -
+  # Waiting" forever (the workflow never triggered).
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/src/store/slices/relationship-slice.ts
+++ b/src/store/slices/relationship-slice.ts
@@ -1,8 +1,25 @@
 import type { StateCreator } from 'zustand'
 import type { WorkspaceState } from '../workspace-types'
-import type { Relationship } from '@/types/model'
+import type { Relationship, View, Workspace } from '@/types/model'
 import { nanoid, pushUndoSnapshot } from '../internals'
 import { allViewsOf, elementExists, forEachView, closeAiSurfaces } from '../workspace-helpers'
+
+/** Drop every step of `relId` from a dynamic view and recompute the view's
+ *  derived element membership from the surviving steps. Dynamic membership
+ *  exists only as a projection of the steps — leaving an element behind after
+ *  its last step dies renders an orphan node until the next reload. */
+function dropDynamicSteps(ws: Workspace, v: View, relId: string): void {
+  const before = v.relationships.length
+  v.relationships = v.relationships.filter(r => r.id !== relId)
+  if (v.relationships.length === before) return
+  const endpoints = new Set<string>()
+  for (const step of v.relationships) {
+    const stepRel = ws.model.relationships.find(r => r.id === step.id)
+    endpoints.add(step.sourceId ?? stepRel?.sourceId ?? '')
+    endpoints.add(step.destinationId ?? stepRel?.destinationId ?? '')
+  }
+  v.elements = v.elements.filter(e => endpoints.has(e.id))
+}
 
 export type RelationshipSlice = Pick<WorkspaceState,
   | 'addRelationship' | 'updateRelationship'
@@ -50,8 +67,12 @@ export const createRelationshipSlice: StateCreator<
           }
         }
       }
-      // Add relationship ref to every view that now has both endpoints
+      // Add relationship ref to every view that now has both endpoints.
+      // Dynamic views are exempt: their relationship list is an ORDERED
+      // interaction sequence — pushing an unnumbered entry would render a
+      // phantom step and serialize it as one the user never authored.
       for (const view of allViewsOf(ws)) {
+        if (view.type === 'dynamic') continue
         const viewElIds = new Set(view.elements.map(e => e.id))
         if (viewElIds.has(sourceId) && viewElIds.has(destinationId)) {
           if (!view.relationships.some(r => r.id === id)) {
@@ -121,6 +142,13 @@ export const createRelationshipSlice: StateCreator<
 
     // Sync view.relationships: keep only in views where both new endpoints exist
     forEachView(ws, (v) => {
+      if (v.type === 'dynamic') {
+        // A dynamic step is authored against specific endpoints; reconnecting
+        // the backing relationship invalidates the step rather than silently
+        // bending the numbered arrow somewhere else.
+        dropDynamicSteps(ws, v, id)
+        return
+      }
       const elIds = new Set(v.elements.map(e => e.id))
       const hasRel = v.relationships.some(r => r.id === id)
       const bothPresent = elIds.has(newSourceId) && elIds.has(newTargetId)
@@ -139,6 +167,10 @@ export const createRelationshipSlice: StateCreator<
     pushUndoSnapshot(s)
     ws.model.relationships = ws.model.relationships.filter(r => r.id !== id)
     forEachView(ws, (v) => {
+      if (v.type === 'dynamic') {
+        dropDynamicSteps(ws, v, id)
+        return
+      }
       v.relationships = v.relationships.filter(r => r.id !== id)
     })
     if (s.selectedRelationshipId === id) s.selectedRelationshipId = null

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -4,7 +4,7 @@ import type {
   ViewType, ElementInView,
 } from '@/types/model'
 import type { CascadeImpact } from './workspace-types'
-import { expandDeploymentElements } from '@/lib/deployment'
+import { expandDeploymentElements, walkDeploymentNodes } from '@/lib/deployment'
 export type { CascadeImpact } from './workspace-types'
 
 /** Deep-clone an object that may be an Immer draft. structuredClone'ing a
@@ -618,16 +618,50 @@ export function cascadeDeleteElements(ws: Workspace, ids: Iterable<string>): Cas
     return true
   })
 
+  // Deployment instances of deleted containers/systems die with them, and
+  // the instances' own ids then cascade through relationships and view refs —
+  // a dangling containerInstance would serialize a reference to the deleted
+  // element and fail to re-parse.
+  const removedInstanceIds = new Set<string>()
+  for (const env of ws.model.deploymentEnvironments ?? []) {
+    walkDeploymentNodes(env, (node) => {
+      node.containerInstances = node.containerInstances.filter((inst) => {
+        if (!allDeletedIds.has(inst.containerId)) return true
+        removedInstanceIds.add(inst.id)
+        return false
+      })
+      node.softwareSystemInstances = node.softwareSystemInstances.filter((inst) => {
+        if (!allDeletedIds.has(inst.softwareSystemId)) return true
+        removedInstanceIds.add(inst.id)
+        return false
+      })
+    })
+  }
+  for (const id of removedInstanceIds) allDeletedIds.add(id)
+
   // Prune relationships referencing any deleted endpoint
   ws.model.relationships = ws.model.relationships.filter(
     (r) => !allDeletedIds.has(r.sourceId) && !allDeletedIds.has(r.destinationId),
   )
   const survivingRelIds = new Set(ws.model.relationships.map((r) => r.id))
+  const survivingRelById = new Map(ws.model.relationships.map((r) => [r.id, r]))
 
   // Prune view element refs + view relationship refs
   forEachView(ws, (v) => {
     v.elements = v.elements.filter((e) => !allDeletedIds.has(e.id))
     v.relationships = v.relationships.filter((r) => survivingRelIds.has(r.id))
+    if (v.type === 'dynamic') {
+      // Dynamic membership is derived from interaction steps; drop elements
+      // whose every step died so they don't linger as orphan nodes (the next
+      // parse would drop them anyway — steps are all that serializes).
+      const stepEndpoints = new Set<string>()
+      for (const step of v.relationships) {
+        const rel = survivingRelById.get(step.id)
+        stepEndpoints.add(step.sourceId ?? rel?.sourceId ?? '')
+        stepEndpoints.add(step.destinationId ?? rel?.destinationId ?? '')
+      }
+      v.elements = v.elements.filter((e) => stepEndpoints.has(e.id))
+    }
   })
 
   // Remove scoped views whose scope element was deleted
@@ -639,6 +673,13 @@ export function cascadeDeleteElements(ws: Workspace, ids: Iterable<string>): Cas
   )
   ws.views.componentViews = ws.views.componentViews.filter(
     (v) => !v.containerId || (!idSet.has(v.containerId) && !deletedContainerIds.has(v.containerId)),
+  )
+  ws.views.deploymentViews = (ws.views.deploymentViews ?? []).filter(
+    (v) => !v.softwareSystemId || !idSet.has(v.softwareSystemId),
+  )
+  ws.views.dynamicViews = (ws.views.dynamicViews ?? []).filter(
+    (v) => (!v.softwareSystemId || !idSet.has(v.softwareSystemId))
+      && (!v.containerId || (!idSet.has(v.containerId) && !deletedContainerIds.has(v.containerId))),
   )
 
   // Drop deleted IDs from group memberships

--- a/src/store/workspace.test.ts
+++ b/src/store/workspace.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useWorkspaceStore, getBreadcrumb, getCreatableTypes, buildElementMap, buildRelationshipMap, canDrillInto, getRelationshipById, getSelectedElement } from './workspace'
 import { MAX_UNDO } from './workspace-types'
 import type { Workspace } from '@/types/model'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
 
 function makeWorkspace(): Workspace {
   return {
@@ -4550,5 +4551,102 @@ describe('removeElementsFromView', () => {
     expect(useWorkspaceStore.getState().undoStack.length).toBe(undoBefore)
     // View must be unchanged
     expect(useWorkspaceStore.getState().workspace!.views.containerViews[0].elements).toEqual([{ id: 'c1' }])
+  })
+})
+
+describe('deployment + dynamic view store integrity', () => {
+  const DSL = `workspace {
+    model {
+      sys = softwareSystem "Sys" {
+        web = container "Web"
+        db = container "DB"
+        web -> db "Reads"
+      }
+      other = softwareSystem "Other"
+      web -> other "Uses"
+      deploymentEnvironment "Live" {
+        deploymentNode "Server" {
+          liveWeb = containerInstance web
+          liveDb = containerInstance db
+        }
+      }
+    }
+    views {
+      deployment sys "Live" "Dep" { include * }
+      dynamic sys "Flow" {
+        web -> db "Reads"
+        db -> web "Returns rows"
+      }
+    }
+  }`
+
+  function load() {
+    const { workspace: ws, errors } = parseDSL(DSL)
+    expect(errors).toHaveLength(0)
+    useWorkspaceStore.getState().loadWorkspace(ws)
+    return useWorkspaceStore.getState().workspace!
+  }
+
+  it('deleting a container prunes its deployment instances so the DSL re-parses', () => {
+    let ws = load()
+    const webId = ws.model.softwareSystems[0].containers.find(c => c.name === 'Web')!.id
+    useWorkspaceStore.getState().deleteElement(webId)
+    ws = useWorkspaceStore.getState().workspace!
+
+    const server = ws.model.deploymentEnvironments[0].deploymentNodes[0]
+    expect(server.containerInstances).toHaveLength(1)
+    expect(server.containerInstances[0].containerId).toBe(
+      ws.model.softwareSystems[0].containers[0].id,
+    )
+
+    // The round trip that used to fail: a dangling instance serialized a
+    // reference to the deleted container.
+    const reparsed = parseDSL(serializeDSL(ws))
+    expect(reparsed.errors).toEqual([])
+  })
+
+  it('deleting the scope system drops its deployment and dynamic views', () => {
+    let ws = load()
+    const sysId = ws.model.softwareSystems[0].id
+    useWorkspaceStore.getState().deleteElement(sysId)
+    ws = useWorkspaceStore.getState().workspace!
+    expect(ws.views.deploymentViews).toHaveLength(0)
+    expect(ws.views.dynamicViews).toHaveLength(0)
+  })
+
+  it('drawing a new relationship elsewhere adds no phantom step to a dynamic view', () => {
+    let ws = load()
+    const webId = ws.model.softwareSystems[0].containers.find(c => c.name === 'Web')!.id
+    const dbId = ws.model.softwareSystems[0].containers.find(c => c.name === 'DB')!.id
+    const before = ws.views.dynamicViews[0].relationships.length
+
+    useWorkspaceStore.getState().addRelationship(webId, dbId, 'Writes')
+    ws = useWorkspaceStore.getState().workspace!
+    const view = ws.views.dynamicViews[0]
+    // Still exactly the authored steps, every one numbered.
+    expect(view.relationships).toHaveLength(before)
+    expect(view.relationships.every(r => r.order !== undefined)).toBe(true)
+  })
+
+  it('deleting a stepped relationship removes its steps and orphaned members', () => {
+    let ws = load()
+    const rel = ws.model.relationships.find(r => r.description === 'Reads')!
+    useWorkspaceStore.getState().deleteRelationship(rel.id)
+    ws = useWorkspaceStore.getState().workspace!
+    const view = ws.views.dynamicViews[0]
+    // Both steps rode on that relationship (forward + response).
+    expect(view.relationships).toHaveLength(0)
+    expect(view.elements).toHaveLength(0)
+  })
+
+  it('reconnecting a stepped relationship invalidates its steps instead of bending them', () => {
+    let ws = load()
+    const rel = ws.model.relationships.find(r => r.description === 'Reads')!
+    const otherId = ws.model.softwareSystems.find(s => s.name === 'Other')!.id
+    const webId = ws.model.softwareSystems[0].containers.find(c => c.name === 'Web')!.id
+    useWorkspaceStore.getState().reconnectRelationship(rel.id, webId, otherId)
+    ws = useWorkspaceStore.getState().workspace!
+    expect(ws.views.dynamicViews[0].relationships).toHaveLength(0)
+    expect(ws.views.dynamicViews[0].elements).toHaveLength(0)
   })
 })


### PR DESCRIPTION
Part 3 of 3 for **TEA-81**, stacked on #138 (which stacks on #137). Store-integrity fixes from the PR #105 review — the view-management UI itself (create-view dialog with environment picker, view switcher, welcome integration) already landed with the canvas commit in #138.

## Fixes

- **Cascade delete prunes the deployment tree** (review finding: dangling `containerInstance` refs serialized into DSL that failed to re-parse). Instances of deleted containers/systems die with them, their ids cascade through relationship + view-ref pruning, and deployment/dynamic views scoped to a deleted element are dropped like other scoped views. Regression test round-trips the post-delete workspace through the parser.
- **No phantom steps**: `addRelationship` no longer pushes an unnumbered entry into dynamic views that happen to contain both endpoints — a dynamic view's relationship list is an authored, ordered sequence.
- **Reconnect/delete invalidate steps**: reconnecting or deleting a relationship that backs dynamic steps removes those steps and recomputes the view's derived membership, instead of bending numbered arrows to new endpoints or leaving orphan nodes.

## Verification

`npm run check` — 1924 unit tests (5 new covering each fix), lint, typecheck, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAsfeaQnKQnMR9ZKB6hu7U