### PR TITLE
recover: AI integrity hardening + viewport-restore fix orphaned by a July branch reset

### DIFF
--- a/src/components/ai/AiPanel.tsx
+++ b/src/components/ai/AiPanel.tsx
@@ -350,6 +350,9 @@ function AppView({
     const base = baseline
     if (!base) return
     const store = useWorkspaceStore.getState()
+    // Pre-call ref, for TRANSACTIONAL rollback below — captured before
+    // setBatchApplying(true) so it matches the baseline that call snapshots.
+    const preWs = store.workspace
     store.setBatchApplying(true)
     try {
       store.resetWorkspaceTo(base)
@@ -357,6 +360,15 @@ function AppView({
       // Replay skips are real information: a kept change whose target came from
       // a now-reverted entry quietly stops applying — say so.
       setSkipNotice(ops.length ? summarizeSkips(applyEditPlan({ operations: ops }, storeEditActions(), base)) : null)
+    } catch (err) {
+      // TRANSACTIONAL APPLY: applyEditPlan is designed to never throw, but this
+      // guards a defective store action from leaving a half-replayed model with
+      // a dangling undo snapshot. Restore the exact pre-call ref — since it's
+      // also what setBatchApplying(true) captured as its baseline, the finally
+      // below's setBatchApplying(false) sees "unchanged" and rolls the
+      // undo/redo stacks back too.
+      store.resetWorkspaceTo(preWs ?? base)
+      throw err
     } finally {
       store.setBatchApplying(false)
     }

--- a/src/components/ai/aiHelpers.transaction.test.ts
+++ b/src/components/ai/aiHelpers.transaction.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from '@/store/workspace'
+import { makeWorkspace } from '@/lib/ai/testFixture'
+import { applyPlanToStore } from './aiHelpers'
+import { generateDiagramStream, reviewArchitectureStream } from '@/lib/ai/features'
+import type { AiProvider } from '@/lib/ai/types'
+import type { EditPlan } from '@/lib/ai'
+
+describe('applyPlanToStore — transactional apply', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().loadWorkspace(makeWorkspace())
+    // Undo/redo stacks aren't reset by loadWorkspace in every path this suite
+    // cares about — start each test from a clean slate explicitly.
+    useWorkspaceStore.setState({ undoStack: [], redoStack: [] })
+  })
+
+  it('rolls back the workspace and undo/redo stacks when a store action throws mid-apply', () => {
+    const ws = useWorkspaceStore.getState().workspace!
+    const preWsJson = JSON.stringify(ws)
+    const preUndoLen = useWorkspaceStore.getState().undoStack.length
+    const preRedoLen = useWorkspaceStore.getState().redoStack.length
+
+    // Wrap the real addRelationship so the 2nd invocation throws — simulating a
+    // defective store action mid-batch, without needing an adversarial plan.
+    const orig = useWorkspaceStore.getState().addRelationship
+    let calls = 0
+    useWorkspaceStore.setState({
+      addRelationship: (...args: Parameters<typeof orig>) => {
+        calls++
+        if (calls === 2) throw new Error('boom: simulated store failure')
+        return orig(...args)
+      },
+    })
+
+    const plan: EditPlan = {
+      operations: [
+        { op: 'addRelationship', source: 'admin', destination: 'web', description: 'Administers' },
+        { op: 'addRelationship', source: 'admin', destination: 'db', description: 'Administers' },
+      ],
+    }
+
+    try {
+      expect(() => applyPlanToStore(plan, ws)).toThrow('boom: simulated store failure')
+    } finally {
+      useWorkspaceStore.setState({ addRelationship: orig })
+    }
+
+    const after = useWorkspaceStore.getState()
+    expect(JSON.stringify(after.workspace)).toBe(preWsJson)
+    expect(after.undoStack.length).toBe(preUndoLen)
+    expect(after.redoStack.length).toBe(preRedoLen)
+  })
+
+  it('applying a multi-op plan grows undoStack by exactly 1, and one undo() fully reverts it', () => {
+    const ws = useWorkspaceStore.getState().workspace!
+    const preWsJson = JSON.stringify(ws)
+    const preUndoLen = useWorkspaceStore.getState().undoStack.length
+
+    const plan: EditPlan = {
+      operations: [
+        { op: 'addPerson', ref: 'p1', name: 'Support Agent' },
+        { op: 'addSoftwareSystem', ref: 's1', name: 'Billing' },
+        { op: 'addRelationship', source: 'p1', destination: 's1', description: 'Uses' },
+        { op: 'updateElement', id: 'web', description: 'Storefront UI (updated)' },
+      ],
+    }
+    const result = applyPlanToStore(plan, ws)
+    expect(result.appliedCount).toBe(4)
+    expect(result.skippedCount).toBe(0)
+
+    expect(useWorkspaceStore.getState().undoStack.length).toBe(preUndoLen + 1)
+
+    useWorkspaceStore.getState().undo()
+    expect(JSON.stringify(useWorkspaceStore.getState().workspace)).toBe(preWsJson)
+  })
+
+  it('two sequential per-item applies grow undoStack by 2; one undo() reverts only the second', () => {
+    const ws = useWorkspaceStore.getState().workspace!
+    const preUndoLen = useWorkspaceStore.getState().undoStack.length
+
+    const plan1: EditPlan = { operations: [{ op: 'addPerson', ref: 'p1', name: 'Auditor' }] }
+    applyPlanToStore(plan1, ws)
+    const afterFirst = useWorkspaceStore.getState().workspace!
+    const afterFirstJson = JSON.stringify(afterFirst)
+    expect(useWorkspaceStore.getState().undoStack.length).toBe(preUndoLen + 1)
+
+    const plan2: EditPlan = { operations: [{ op: 'addPerson', ref: 'p2', name: 'Support' }] }
+    applyPlanToStore(plan2, afterFirst)
+    expect(useWorkspaceStore.getState().undoStack.length).toBe(preUndoLen + 2)
+
+    useWorkspaceStore.getState().undo()
+    expect(JSON.stringify(useWorkspaceStore.getState().workspace)).toBe(afterFirstJson)
+    expect(useWorkspaceStore.getState().undoStack.length).toBe(preUndoLen + 1)
+  })
+})
+
+describe('streaming AI calls — abort safety', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().loadWorkspace(makeWorkspace())
+    useWorkspaceStore.setState({ undoStack: [], redoStack: [] })
+  })
+
+  function abortError() {
+    const e = new Error('aborted')
+    e.name = 'AbortError'
+    return e
+  }
+
+  it('reviewArchitectureStream never mutates the store when aborted mid-stream', async () => {
+    const preJson = JSON.stringify(useWorkspaceStore.getState())
+    const partial = '{"findings": [{"title": "Something"'
+    const provider: AiProvider = {
+      async complete() { return '' },
+      async completeJson<T>(): Promise<T> { return {} as T },
+      async completeStream(req) {
+        req.onText(partial)
+        throw abortError()
+      },
+    }
+    const ws = useWorkspaceStore.getState().workspace!
+    await expect(
+      reviewArchitectureStream(provider, ws, null, () => {}),
+    ).rejects.toThrow()
+    expect(JSON.stringify(useWorkspaceStore.getState())).toBe(preJson)
+  })
+
+  it('generateDiagramStream never mutates the store when aborted mid-stream', async () => {
+    const preJson = JSON.stringify(useWorkspaceStore.getState())
+    const provider: AiProvider = {
+      async complete() { return '' },
+      async completeJson<T>(): Promise<T> { return {} as T },
+      async completeStream(req) {
+        req.onText('workspace "Shop" {\n')
+        throw abortError()
+      },
+    }
+    await expect(
+      generateDiagramStream(provider, 'a shop', () => {}),
+    ).rejects.toThrow()
+    expect(JSON.stringify(useWorkspaceStore.getState())).toBe(preJson)
+  })
+})

--- a/src/components/ai/aiHelpers.ts
+++ b/src/components/ai/aiHelpers.ts
@@ -4,7 +4,11 @@ import {
   aiErrorMessage, applyEditPlan, summarizeSkips, flattenElements,
   type EditActions, type ApplyResult, type EditPlan,
 } from '@/lib/ai'
+import { checkModelIntegrity } from '@/lib/modelIntegrity'
+import { createLogger } from '@/lib/logger'
 import type { Workspace } from '@/types/model'
+
+const log = createLogger('ai:apply')
 
 // ─── run state (shared by every feature body) ───────────────────────
 
@@ -86,8 +90,29 @@ export function applyPlanToStore(plan: EditPlan, ws: Workspace, opts?: { batched
   let result: ApplyResult = { applied: [], appliedCount: 0, skippedCount: 0 }
   try {
     result = applyEditPlan(plan, storeEditActions(), liveBefore)
+  } catch (err) {
+    // TRANSACTIONAL APPLY: applyEditPlan is designed to never throw, but this
+    // guards against a defective store action (or a future regression) leaving
+    // a half-applied model with a dangling undo snapshot. Restore the exact
+    // pre-apply workspace ref — when we own the batch, that ref is the same
+    // one `setBatchApplying(true)` captured as its baseline, so the `finally`
+    // below sees "unchanged" and rolls the undo/redo stacks back too (see the
+    // unchanged-check in ui-slice.ts's setBatchApplying). When the caller owns
+    // the batch (opts.batched), the same reasoning applies to THEIR baseline,
+    // since it was captured synchronously from the same pre-apply workspace.
+    useWorkspaceStore.getState().resetWorkspaceTo(liveBefore)
+    throw err
   } finally {
     if (ownBatch) s.setBatchApplying(false)
+  }
+  // DEV INTEGRITY ASSERT: never runs in production bundles — the env guard is
+  // load-bearing, not the (unnecessary) tree-shaking of the static import.
+  if (import.meta.env.DEV || import.meta.env.MODE === 'test') {
+    const postWs = useWorkspaceStore.getState().workspace
+    if (postWs) {
+      const violations = checkModelIntegrity(postWs)
+      if (violations.length) log.error('post-apply model integrity violations', violations)
+    }
   }
   const updated = useWorkspaceStore.getState().workspace
   const newIds = updated ? flattenElements(updated).filter((e) => !before.has(e.id)).map((e) => e.id) : []

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -523,7 +523,7 @@ export default function Canvas() {
     if (!pending) return
     const rf = rfInitInstance.current
     if (!rf) {
-      if (restoreAttempts.current++ < 30) requestAnimationFrame(tryRestoreViewport)
+      if (restoreAttempts.current++ < MAX_MEASURE_ATTEMPTS) requestAnimationFrame(tryRestoreViewport)
       else { restorePending.current = null; restoreAttempts.current = 0 }
       return
     }

--- a/src/lib/ai/operations.invariants.test.ts
+++ b/src/lib/ai/operations.invariants.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from '@/store/workspace'
+import { storeEditActions } from '@/components/ai/aiHelpers'
+import { applyEditPlan } from './operations'
+import { toEditPlan } from './schema'
+import { makeWorkspace } from './testFixture'
+import { checkModelIntegrity } from '@/lib/modelIntegrity'
+import type { EditOp } from './types'
+
+// Adversarial/property suite for applyEditPlan, run against the REAL zustand
+// store (not the fake EditActions used in operations.test.ts). Every plan —
+// handcrafted or randomly generated — must, after being routed through the
+// production sanitizer `toEditPlan` and applied to a real store, leave
+// checkModelIntegrity reporting zero violations. This is the executable
+// evidence for constitution items 4 (post-apply integrity), 5 (no ref
+// shadowing) and 6 (no hierarchy escape via update).
+
+function freshWorkspace() { return makeWorkspace() }
+
+beforeEach(() => {
+  useWorkspaceStore.getState().loadWorkspace(freshWorkspace())
+})
+
+function apply(operations: unknown[]) {
+  const plan = toEditPlan({ operations })
+  const ws = useWorkspaceStore.getState().workspace!
+  const actions = storeEditActions()
+  let result
+  expect(() => { result = applyEditPlan(plan, actions, ws) }).not.toThrow()
+  return { plan, result: result! }
+}
+
+describe('applyEditPlan — handcrafted adversarial cases (real store)', () => {
+  it('ref shadowing an existing id: the existing element is untouched and later ops addressing the id hit the original', () => {
+    // 'shop' already exists (a software system). A malicious/careless plan
+    // reuses it as a `ref` for a brand-new person, then tries to rename "shop"
+    // via that ref. The rename must land on nothing new — it must resolve back
+    // to the ORIGINAL 'shop' system, not the new person.
+    const before = useWorkspaceStore.getState().workspace!
+    const shopBefore = before.model.softwareSystems.find((s) => s.id === 'shop')!
+    const { result } = apply([
+      { op: 'addPerson', ref: 'shop', name: 'Shadow Person' },
+      { op: 'updateElement', id: 'shop', name: 'Renamed Shop' },
+    ] satisfies EditOp[])
+    const after = useWorkspaceStore.getState().workspace!
+    const shopAfter = after.model.softwareSystems.find((s) => s.id === 'shop')!
+    // The update landed on the original software system (renamed), not a
+    // shadow — proving 'shop' the token still resolves to the pre-existing id.
+    expect(shopAfter.name).toBe('Renamed Shop')
+    expect(shopAfter.id).toBe(shopBefore.id)
+    // The new person was still created (just under its OWN real id, since the
+    // 'shop' ref binding was refused).
+    const people = after.model.people.map((p) => p.name)
+    expect(people).toContain('Shadow Person')
+    expect(result.appliedCount).toBe(2)
+    expect(checkModelIntegrity(after)).toEqual([])
+  })
+
+  it('duplicate refs in one plan: first registration wins', () => {
+    const { result } = apply([
+      { op: 'addSoftwareSystem', ref: 'dup', name: 'First Sys' },
+      { op: 'addSoftwareSystem', ref: 'dup', name: 'Second Sys' },
+      // Targets the 'dup' ref — must resolve to the FIRST system.
+      { op: 'updateElement', id: 'dup', description: 'Targets first' },
+    ] satisfies EditOp[])
+    const ws = useWorkspaceStore.getState().workspace!
+    const first = ws.model.softwareSystems.find((s) => s.name === 'First Sys')!
+    const second = ws.model.softwareSystems.find((s) => s.name === 'Second Sys')!
+    expect(first.description).toBe('Targets first')
+    expect(second.description).not.toBe('Targets first')
+    expect(result.appliedCount).toBe(3)
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+
+  it('deleting an element also referenced by a same-plan relationship does not corrupt the model', () => {
+    const { result } = apply([
+      { op: 'addSoftwareSystem', ref: 'ephemeral', name: 'Ephemeral' },
+      { op: 'addRelationship', source: 'web', destination: 'ephemeral', description: 'Calls' },
+      { op: 'deleteElement', id: 'ephemeral' },
+    ] satisfies EditOp[])
+    const ws = useWorkspaceStore.getState().workspace!
+    // deleteElement is ranked last, so the relationship was created first, then
+    // cascade-deleted along with its endpoint — no dangling relationship left.
+    expect(ws.model.relationships.some((r) => r.destinationId === 'ephemeral')).toBe(false)
+    expect(result.appliedCount).toBe(3)
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+
+  it('External flip is blocked when the system has pre-existing containers', () => {
+    const { result } = apply([
+      { op: 'updateElement', id: 'shop', location: 'External' },
+    ] satisfies EditOp[])
+    const ws = useWorkspaceStore.getState().workspace!
+    const shop = ws.model.softwareSystems.find((s) => s.id === 'shop')!
+    expect(shop.location).not.toBe('External')
+    expect(result.appliedCount).toBe(0)
+    expect(result.applied[0]).toMatchObject({ ok: false, reason: 'system has containers' })
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+
+  it('External flip is blocked when the containers were added earlier in the SAME plan', () => {
+    const { result } = apply([
+      { op: 'addSoftwareSystem', ref: 'sys', name: 'Freshly Made' },
+      { op: 'addContainer', ref: 'c1', parent: 'sys', name: 'API' },
+      { op: 'updateElement', id: 'sys', location: 'External' },
+    ] satisfies EditOp[])
+    const ws = useWorkspaceStore.getState().workspace!
+    const sys = ws.model.softwareSystems.find((s) => s.name === 'Freshly Made')!
+    expect(sys.location).not.toBe('External')
+    expect(sys.containers.length).toBe(1)
+    expect(result.appliedCount).toBe(2) // add + addContainer applied, updateElement skipped
+    expect(result.skippedCount).toBe(1)
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+
+  it('External flip is ALLOWED for a container-less system', () => {
+    const { result } = apply([
+      { op: 'addSoftwareSystem', ref: 'sys', name: 'Empty Sys' },
+      { op: 'updateElement', id: 'sys', location: 'External' },
+    ] satisfies EditOp[])
+    const ws = useWorkspaceStore.getState().workspace!
+    const sys = ws.model.softwareSystems.find((s) => s.name === 'Empty Sys')!
+    expect(sys.location).toBe('External')
+    expect(result.appliedCount).toBe(2)
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+
+  it('addView with a wrong-kind scope is skipped, not applied', () => {
+    const { result } = apply([
+      // component view scoped to a software system, not a container — wrong kind
+      { op: 'addView', viewType: 'component', scope: 'shop' },
+    ] satisfies EditOp[])
+    const ws = useWorkspaceStore.getState().workspace!
+    expect(ws.views.componentViews.length).toBe(0)
+    expect(result.appliedCount).toBe(0)
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+
+  it('op fields using __proto__/constructor as ref/name tokens cause no prototype pollution', () => {
+    const { result } = apply([
+      { op: 'addSoftwareSystem', ref: '__proto__', name: 'constructor' },
+      { op: 'addPerson', ref: 'constructor', name: '__proto__' },
+      { op: 'updateElement', id: '__proto__', description: 'x' },
+      { op: 'addRelationship', source: '__proto__', destination: 'constructor' },
+    ] satisfies EditOp[])
+    expect((({}) as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('polluted')
+    const ws = useWorkspaceStore.getState().workspace!
+    expect(checkModelIntegrity(ws)).toEqual([])
+    // Just asserting no throw / no pollution; the tokens are still treated as
+    // ordinary (if odd) strings so some ops may legitimately apply.
+    expect(result.appliedCount + result.skippedCount).toBe(4)
+  })
+
+  it('a plan of 250+ mixed ops applies without throwing and counts add up', () => {
+    const ops: EditOp[] = []
+    for (let i = 0; i < 60; i++) {
+      ops.push({ op: 'addSoftwareSystem', ref: `sys${i}`, name: `Sys ${i}` })
+      ops.push({ op: 'addContainer', ref: `c${i}`, parent: `sys${i}`, name: `Container ${i}` })
+      ops.push({ op: 'addRelationship', source: `sys${i}`, destination: `c${i}` })
+      ops.push({ op: 'updateElement', id: `sys${i}`, description: `Desc ${i}` })
+    }
+    expect(ops.length).toBeGreaterThanOrEqual(240)
+    const { result } = apply(ops)
+    expect(result.appliedCount + result.skippedCount).toBe(ops.length)
+    const ws = useWorkspaceStore.getState().workspace!
+    expect(checkModelIntegrity(ws)).toEqual([])
+  })
+})
+
+// ─── Seeded property/fuzz section ──────────────────────────────────────
+//
+// Deterministic mulberry32 PRNG with a fixed literal seed — never Math.random()
+// or Date.now(), so failures are 100% reproducible.
+
+function mulberry32(seed: number) {
+  let a = seed
+  return function rand() {
+    a |= 0; a = (a + 0x6D2B79F5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const SEED = 0xC4_4E_20_26 // fixed literal seed — deterministic, reproducible
+const rand = mulberry32(SEED)
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(rand() * arr.length)]
+}
+
+const EXISTING_IDS = ['shop', 'web', 'db', 'cart', 'cust', 'r1']
+const EXISTING_NAMES = ['Shop', 'Web App', 'Database', 'Cart', 'Customer']
+
+const TOKEN_POOL = (): string[] => [
+  ...EXISTING_IDS,
+  'freshRefA', 'freshRefB', 'freshRefC',
+  'shop', // colliding ref again
+  '',
+  'x'.repeat(10000), // very long string
+  'unicode-🐙-Ω- -name', // unicode + embedded control char
+  'control-heavy',
+  ...EXISTING_NAMES, // name collisions
+  '__proto__', 'constructor', 'prototype',
+]
+
+function randomToken(): string { return pick(TOKEN_POOL()) }
+
+const VIEW_TYPES = ['systemLandscape', 'systemContext', 'container', 'component'] as const
+
+function randomOp(): unknown {
+  const kind = pick([
+    'addPerson', 'addSoftwareSystem', 'addContainer', 'addComponent',
+    'addRelationship', 'updateElement', 'updateRelationship', 'deleteElement',
+    'addView', 'garbage',
+  ])
+  switch (kind) {
+    case 'addPerson':
+      return { op: 'addPerson', ref: randomToken(), name: randomToken(), description: randomToken() }
+    case 'addSoftwareSystem':
+      return { op: 'addSoftwareSystem', ref: randomToken(), name: randomToken(), external: pick([true, false, undefined]) }
+    case 'addContainer':
+      return { op: 'addContainer', ref: randomToken(), parent: randomToken(), name: randomToken(), technology: randomToken() }
+    case 'addComponent':
+      return { op: 'addComponent', ref: randomToken(), parent: randomToken(), name: randomToken() }
+    case 'addRelationship': {
+      // sometimes deliberately self-referencing
+      const src = randomToken()
+      const dst = pick([randomToken(), src])
+      return { op: 'addRelationship', source: src, destination: dst, description: randomToken() }
+    }
+    case 'updateElement':
+      return {
+        op: 'updateElement',
+        id: randomToken(),
+        name: pick([randomToken(), undefined]),
+        location: pick(['Internal', 'External', 'sideways', undefined]),
+        tags: pick([[randomToken(), randomToken()], undefined, 'not-an-array']),
+        status: pick(['Live', 'Planned', 'Deprecated', 'Removed', 'Bogus', undefined]),
+        owner: pick([randomToken(), undefined]),
+      }
+    case 'updateRelationship':
+      return { op: 'updateRelationship', id: randomToken(), description: randomToken() }
+    case 'deleteElement':
+      return { op: 'deleteElement', id: randomToken() }
+    case 'addView':
+      return { op: 'addView', viewType: pick(VIEW_TYPES), scope: randomToken(), title: randomToken() }
+    default:
+      // Deliberately malformed / unknown-shape garbage that must be dropped by
+      // toEditPlan (or, if it slips through, must not crash the applier).
+      return pick([
+        { op: 'unknownOp', ref: 'x' },
+        { notAnOp: true },
+        null,
+        42,
+        'a string, not an object',
+        { op: 'updateElement' }, // missing id
+        { op: 'addPerson', ref: 'r' }, // missing name
+      ])
+  }
+}
+
+function randomPlanOps(n: number): unknown[] {
+  const count = 1 + Math.floor(rand() * n)
+  return Array.from({ length: count }, () => randomOp())
+}
+
+describe('applyEditPlan — seeded property/fuzz suite (real store)', () => {
+  const ROUNDS = 320
+
+  for (let i = 0; i < ROUNDS; i++) {
+    it(`fuzz round ${i}: toEditPlan → applyEditPlan preserves model integrity`, () => {
+      useWorkspaceStore.getState().loadWorkspace(freshWorkspace())
+      const rawOps = randomPlanOps(40)
+      const plan = toEditPlan({ operations: rawOps })
+      const ws = useWorkspaceStore.getState().workspace!
+      const actions = storeEditActions()
+
+      let result
+      expect(() => { result = applyEditPlan(plan, actions, ws) }).not.toThrow()
+
+      const after = useWorkspaceStore.getState().workspace!
+      expect(checkModelIntegrity(after)).toEqual([])
+      expect(result!.appliedCount + result!.skippedCount).toBe(plan.operations.length)
+    })
+  }
+})

--- a/src/lib/ai/operations.test.ts
+++ b/src/lib/ai/operations.test.ts
@@ -264,13 +264,17 @@ describe('applyEditPlan — parent-type and existence guards', () => {
   })
 
   it('forwards a valid updateElement location and drops a bogus one', () => {
+    // 'shop' has containers, so (post TEA-6x "no hierarchy escape via update")
+    // it can no longer be flipped External here — use 'admin' (a container-less
+    // person) for the valid-location half of this test; the bogus-value half is
+    // unrelated to that guard and keeps using 'web'.
     const ws = makeWorkspace()
     const actions = fakeActions()
     applyEditPlan({ operations: [
-      { op: 'updateElement', id: 'shop', location: 'External' },
+      { op: 'updateElement', id: 'admin', location: 'External' },
       { op: 'updateElement', id: 'web', location: 'sideways' as 'External' },
     ] }, actions, ws)
-    expect(actions.updateElement).toHaveBeenCalledWith('shop', expect.objectContaining({ location: 'External' }))
+    expect(actions.updateElement).toHaveBeenCalledWith('admin', expect.objectContaining({ location: 'External' }))
     expect(actions.updateElement).toHaveBeenCalledWith('web', expect.objectContaining({ location: undefined }))
   })
 
@@ -280,9 +284,11 @@ describe('applyEditPlan — parent-type and existence guards', () => {
     // text box). If the applier always included name/description/technology
     // keys — even when the op didn't set them — a location-only op (e.g. "mark
     // this system external") would silently wipe the element's description.
+    // Uses 'admin' (container-less) since 'shop' can no longer be flipped
+    // External — see the "no hierarchy escape via update" tests below.
     const ws = makeWorkspace()
     const actions = fakeActions()
-    applyEditPlan({ operations: [{ op: 'updateElement', id: 'shop', location: 'External' }] }, actions, ws)
+    applyEditPlan({ operations: [{ op: 'updateElement', id: 'admin', location: 'External' }] }, actions, ws)
     const patch = vi.mocked(actions.updateElement).mock.calls[0][1]
     expect(patch).not.toHaveProperty('name')
     expect(patch).not.toHaveProperty('description')
@@ -291,6 +297,11 @@ describe('applyEditPlan — parent-type and existence guards', () => {
 
   it('reproduces the reported bug end-to-end: marking a system external keeps its description', () => {
     const ws = makeWorkspace() // 'shop' has description 'The store'
+    // Strip 'shop's containers for this test: the original bug was about the
+    // description field being wiped by a location-only patch, which is
+    // orthogonal to the (separately tested) "no hierarchy escape via update"
+    // guard that now blocks flipping a container-holding system External.
+    ws.model.softwareSystems[0].containers = []
     const actions: EditActions = {
       ...fakeActions(),
       updateElement: (id, patch) => { applyElementPatch(ws, id, patch) },
@@ -299,6 +310,31 @@ describe('applyEditPlan — parent-type and existence guards', () => {
     const shop = ws.model.softwareSystems.find((s) => s.id === 'shop')!
     expect(shop.location).toBe('External')
     expect(shop.description).toBe('The store')
+  })
+
+  it('no hierarchy escape via update: skips flipping a system with containers to External', () => {
+    const ws = makeWorkspace() // 'shop' has containers 'web' and 'db'
+    const actions = fakeActions()
+    const result = applyEditPlan({ operations: [
+      { op: 'updateElement', id: 'shop', location: 'External' },
+    ] }, actions, ws)
+    expect(actions.updateElement).not.toHaveBeenCalled()
+    expect(result.appliedCount).toBe(0)
+    expect(result.applied[0]).toMatchObject({ ok: false, reason: 'system has containers' })
+  })
+
+  it('no hierarchy escape via update: blocks the flip even when the containers were added earlier in the same plan', () => {
+    const ws = makeWorkspace()
+    const actions = fakeActions()
+    const result = applyEditPlan({ operations: [
+      { op: 'addSoftwareSystem', ref: 'sys', name: 'Billing' },
+      { op: 'addContainer', ref: 'c1', parent: 'sys', name: 'API' },
+      { op: 'updateElement', id: 'sys', location: 'External' },
+    ] }, actions, ws)
+    expect(actions.updateElement).not.toHaveBeenCalled()
+    expect(result.appliedCount).toBe(2)
+    expect(result.skippedCount).toBe(1)
+    expect(result.applied.find((a) => a.op.op === 'updateElement')).toMatchObject({ ok: false, reason: 'system has containers' })
   })
 
   it('an updateRelationship that only sets description does not touch technology, and vice versa', () => {

--- a/src/lib/ai/operations.ts
+++ b/src/lib/ai/operations.ts
@@ -116,6 +116,13 @@ export function applyEditPlan(
     else if (el.type === 'container') containerIds.add(el.id)
   }
   const relIds = new Set(ws.model.relationships.map((r) => r.id))
+  // Snapshot of ids that existed BEFORE this plan ran — used by register() to
+  // refuse a ref binding that collides with a pre-existing id (no shadowing).
+  const preExistingIds = new Set(validIds)
+  // Same-plan `addContainer` parents, tracked so a same-batch updateElement that
+  // flips a just-created system External can be blocked too (see the external
+  // flip check in updateElement below), not just pre-existing containers.
+  const sameplanContainerParents = new Set<string>()
   // Current tags per element, so an updateElement.tags op can MERGE (add) rather
   // than replace — see mergeTags. Built from the raw model (flattenElements drops
   // tags). Newly-created elements ARE seeded too (see register): the edit prompt
@@ -136,6 +143,15 @@ export function applyEditPlan(
   const externalSystemIds = new Set(
     ws.model.softwareSystems.filter((s) => s.location === 'External').map((s) => s.id),
   )
+  // Pre-existing software systems that already have at least one container —
+  // used to block an updateElement from flipping them External (see the
+  // "external flip" check in the updateElement case below; NO HIERARCHY ESCAPE
+  // VIA UPDATE). A same-plan addContainer also marks its parent here via
+  // sameplanContainerParents, so a system that only gained containers earlier
+  // in THIS plan is protected too.
+  const systemsWithContainers = new Set(
+    ws.model.softwareSystems.filter((s) => Array.isArray(s.containers) && s.containers.length > 0).map((s) => s.id),
+  )
   const applied: AppliedOp[] = []
 
   // Register a newly-created element so later ops can target it by ref, id, or name.
@@ -143,7 +159,12 @@ export function applyEditPlan(
   // Container …); seeding them lets a same-plan updateElement.tags op merge rather
   // than clobber them (see tagsById / mergeTags).
   const register = (ref: string, id: string, name: string, tags: string[]) => {
-    refMap.set(ref, id)
+    // No ref shadowing: refuse to bind `ref` when it collides with a
+    // pre-existing element id or with a ref already registered earlier in this
+    // plan (existing-wins / first-wins). The element is still created — only
+    // the colliding token binding is skipped, so later ops addressing that
+    // token keep resolving to the original element via validIds/refMap.
+    if (ref && !preExistingIds.has(ref) && !refMap.has(ref)) refMap.set(ref, id)
     validIds.add(id)
     tagsById.set(id, tags)
     const key = name.trim().toLowerCase()
@@ -214,6 +235,7 @@ export function applyEditPlan(
         const id = actions.addContainer(parentId, op.name.trim())
         register(op.ref, id, op.name, ['Element', 'Container'])
         containerIds.add(id)
+        sameplanContainerParents.add(parentId)
         const desc = optStr(op.description), tech = optStr(op.technology)
         if (desc || tech) actions.updateElement(id, { description: desc, technology: tech })
         ok(op)
@@ -248,6 +270,14 @@ export function applyEditPlan(
         // (created container, unset status/owner).
         const id = resolveExact(op.id)
         if (!id) { skip(op, 'element not found'); break }
+        // NO HIERARCHY ESCAPE VIA UPDATE: a software system with containers
+        // (pre-existing or added earlier in this same plan) can't be flipped
+        // External — that would produce an External system with containers,
+        // which checkModelIntegrity flags. Skip the whole op rather than
+        // silently drop just the location field.
+        if (op.location === 'External' && (systemsWithContainers.has(id) || sameplanContainerParents.has(id))) {
+          skip(op, 'system has containers'); break
+        }
         const name = optStr(op.name)
         const description = optStr(op.description)
         const technology = optStr(op.technology)

--- a/src/lib/ai/schema.test.ts
+++ b/src/lib/ai/schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { toEditPlan, toReviewResult, toDescribeResult } from './schema'
+import {
+  toEditPlan, toReviewResult, toDescribeResult, sanitizeEditOp,
+  MAX_PLAN_OPS, MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH, MAX_TECHNOLOGY_LENGTH,
+  MAX_OWNER_LENGTH, MAX_TITLE_LENGTH, MAX_ID_FIELD_LENGTH, MAX_TAGS_COUNT, MAX_TAG_LENGTH,
+} from './schema'
+import type { EditOp } from './types'
 
 describe('tolerant sanitizers', () => {
   it('toEditPlan keeps valid operations and drops malformed ones', () => {
@@ -46,5 +51,290 @@ describe('tolerant sanitizers', () => {
     const res = toDescribeResult({ elements: [{ id: 'a', description: 'x' }, { id: 'b' }], relationships: 'oops' })
     expect(res.elements).toEqual([{ id: 'a', description: 'x' }])
     expect(res.relationships).toEqual([])
+  })
+})
+
+describe('sanitizeEditOp and cap enforcement', () => {
+  describe('text field truncation', () => {
+    it('truncates name to MAX_NAME_LENGTH', () => {
+      const longName = 'a'.repeat(MAX_NAME_LENGTH + 10)
+      const op: EditOp = { op: 'addPerson', ref: 'p', name: longName }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.name).toBe('a'.repeat(MAX_NAME_LENGTH))
+      expect(sanitized!.name.length).toBe(MAX_NAME_LENGTH)
+    })
+
+    it('truncates description to MAX_DESCRIPTION_LENGTH', () => {
+      const longDesc = 'b'.repeat(MAX_DESCRIPTION_LENGTH + 10)
+      const op: EditOp = { op: 'updateElement', id: 'x', description: longDesc }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.description.length).toBe(MAX_DESCRIPTION_LENGTH)
+    })
+
+    it('truncates technology to MAX_TECHNOLOGY_LENGTH', () => {
+      const longTech = 'c'.repeat(MAX_TECHNOLOGY_LENGTH + 10)
+      const op: EditOp = { op: 'addContainer', ref: 'c', parent: 'p', name: 'Svc', technology: longTech }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.technology!.length).toBe(MAX_TECHNOLOGY_LENGTH)
+    })
+
+    it('truncates owner to MAX_OWNER_LENGTH', () => {
+      const longOwner = 'd'.repeat(MAX_OWNER_LENGTH + 10)
+      const op: EditOp = { op: 'updateElement', id: 'x', owner: longOwner }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.owner!.length).toBe(MAX_OWNER_LENGTH)
+    })
+
+    it('truncates title to MAX_TITLE_LENGTH', () => {
+      const longTitle = 'e'.repeat(MAX_TITLE_LENGTH + 10)
+      const op: EditOp = { op: 'addView', viewType: 'systemLandscape', title: longTitle }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.title!.length).toBe(MAX_TITLE_LENGTH)
+    })
+  })
+
+  describe('control character stripping', () => {
+    it('strips C0 control characters from name field', () => {
+      const op: EditOp = { op: 'addPerson', ref: 'p', name: 'User\x00\x01\x02Name' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.name).toBe('UserName')
+    })
+
+    it('preserves newline in description field', () => {
+      const op: EditOp = { op: 'updateElement', id: 'x', description: 'Line 1\nLine 2' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.description).toBe('Line 1\nLine 2')
+    })
+
+    it('preserves tab in description field', () => {
+      const op: EditOp = { op: 'updateElement', id: 'x', description: 'Prefix\tData' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.description).toBe('Prefix\tData')
+    })
+
+    it('removes control chars but preserves newline and tab together in description', () => {
+      const op: EditOp = { op: 'updateElement', id: 'x', description: 'Start\x01\n\tEnd' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.description).toBe('Start\n\tEnd')
+    })
+
+    it('strips control chars (but not newline/tab) from technology field', () => {
+      const op: EditOp = { op: 'addContainer', ref: 'c', parent: 'p', name: 'S', technology: 'Java\x00Node\tJS\nRust' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      // Tab and newline should be stripped from non-description fields
+      expect(sanitized!.technology).toBe('JavaNodeJSRust')
+    })
+  })
+
+  describe('id-field length limits', () => {
+    it('drops op if ref exceeds MAX_ID_FIELD_LENGTH', () => {
+      const longRef = 'x'.repeat(MAX_ID_FIELD_LENGTH + 1)
+      const op: EditOp = { op: 'addPerson', ref: longRef, name: 'Person' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).toBeNull()
+    })
+
+    it('drops op if id exceeds MAX_ID_FIELD_LENGTH', () => {
+      const longId = 'y'.repeat(MAX_ID_FIELD_LENGTH + 1)
+      const op: EditOp = { op: 'updateElement', id: longId }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).toBeNull()
+    })
+
+    it('drops op if parent exceeds MAX_ID_FIELD_LENGTH', () => {
+      const longParent = 'z'.repeat(MAX_ID_FIELD_LENGTH + 1)
+      const op: EditOp = { op: 'addContainer', ref: 'c', name: 'Svc', parent: longParent }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).toBeNull()
+    })
+
+    it('drops op if source exceeds MAX_ID_FIELD_LENGTH', () => {
+      const longSource = 'a'.repeat(MAX_ID_FIELD_LENGTH + 1)
+      const op: EditOp = { op: 'addRelationship', source: longSource, destination: 'd' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).toBeNull()
+    })
+
+    it('drops op if destination exceeds MAX_ID_FIELD_LENGTH', () => {
+      const longDest = 'b'.repeat(MAX_ID_FIELD_LENGTH + 1)
+      const op: EditOp = { op: 'addRelationship', source: 's', destination: longDest }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).toBeNull()
+    })
+
+    it('drops op if scope exceeds MAX_ID_FIELD_LENGTH', () => {
+      const longScope = 'c'.repeat(MAX_ID_FIELD_LENGTH + 1)
+      const op: EditOp = { op: 'addView', viewType: 'systemContext', scope: longScope }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).toBeNull()
+    })
+
+    it('keeps op if ref is exactly MAX_ID_FIELD_LENGTH', () => {
+      const ref = 'x'.repeat(MAX_ID_FIELD_LENGTH)
+      const op: EditOp = { op: 'addPerson', ref, name: 'Person' }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.ref).toBe(ref)
+    })
+  })
+
+  describe('tags capping', () => {
+    it('caps tags array to MAX_TAGS_COUNT', () => {
+      const tags = Array.from({ length: MAX_TAGS_COUNT + 5 }, (_, i) => `tag${i}`)
+      const op: EditOp = { op: 'updateElement', id: 'x', tags }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.tags).toHaveLength(MAX_TAGS_COUNT)
+    })
+
+    it('keeps only first MAX_TAGS_COUNT tags', () => {
+      const tags = Array.from({ length: MAX_TAGS_COUNT + 3 }, (_, i) => `tag${i}`)
+      const op: EditOp = { op: 'updateElement', id: 'x', tags }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.tags).toEqual(tags.slice(0, MAX_TAGS_COUNT))
+    })
+
+    it('drops tags longer than MAX_TAG_LENGTH', () => {
+      const longTag = 'x'.repeat(MAX_TAG_LENGTH + 1)
+      const tags = ['short', longTag, 'ok']
+      const op: EditOp = { op: 'updateElement', id: 'x', tags }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.tags).toEqual(['short', 'ok'])
+    })
+
+    it('trims tags but keeps tag within length limit', () => {
+      const tags = ['  spaced  ', ' ' + 'x'.repeat(MAX_TAG_LENGTH - 2) + ' ']
+      const op: EditOp = { op: 'updateElement', id: 'x', tags }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.tags).toEqual(['spaced', 'x'.repeat(MAX_TAG_LENGTH - 2)])
+    })
+
+    it('drops empty tags after trimming', () => {
+      const tags = ['  ', 'valid', '   ', 'also-valid']
+      const op: EditOp = { op: 'updateElement', id: 'x', tags }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.tags).toEqual(['valid', 'also-valid'])
+    })
+
+    it('omits tags field if all tags are invalid/empty', () => {
+      const tags = ['  ', '   ', '\t']
+      const op: EditOp = { op: 'updateElement', id: 'x', tags }
+      const sanitized = sanitizeEditOp(op)
+      expect(sanitized).not.toBeNull()
+      expect(sanitized!.tags).toBeUndefined()
+    })
+  })
+
+  describe('non-string location/viewType rejection', () => {
+    it('rejects op with non-string location via isEditOp', () => {
+      const op: Record<string, unknown> = { op: 'updateElement', id: 'x', location: 123 }
+      // isEditOp should reject this since location is not a string
+      const isValid = (typeof op === 'object' && op !== null && 'op' in op && typeof op.location === 'string')
+      expect(isValid).toBe(false)
+    })
+
+    it('rejects op with non-string viewType via isEditOp', () => {
+      const op: Record<string, unknown> = { op: 'addView', viewType: { type: 'system' } }
+      // isEditOp should reject this since viewType is not a string
+      const isValid = (typeof op === 'object' && op !== null && 'op' in op && typeof op.viewType === 'string')
+      expect(isValid).toBe(false)
+    })
+  })
+})
+
+describe('plan size cap', () => {
+  it('keeps only first MAX_PLAN_OPS valid operations', () => {
+    const ops = Array.from({ length: MAX_PLAN_OPS + 10 }, (_, i) => ({
+      op: 'updateElement' as const,
+      id: `id${i}`,
+    }))
+    const plan = toEditPlan({ operations: ops })
+    expect(plan.operations).toHaveLength(MAX_PLAN_OPS)
+  })
+
+  it('301 valid operations reduced to 300 kept', () => {
+    const ops = Array.from({ length: 301 }, (_, i) => ({
+      op: 'updateElement' as const,
+      id: `id${i}`,
+    }))
+    const plan = toEditPlan({ operations: ops })
+    expect(plan.operations).toHaveLength(MAX_PLAN_OPS)
+  })
+})
+
+describe('review finding ops/options sanitization', () => {
+  it('sanitizes operations in finding.operations', () => {
+    const longName = 'a'.repeat(MAX_NAME_LENGTH + 10)
+    const res = toReviewResult({
+      findings: [{
+        title: 't',
+        detail: 'd',
+        category: 'naming',
+        severity: 'high',
+        elementIds: [],
+        suggestion: 's',
+        operations: [{ op: 'addPerson', ref: 'p', name: longName }],
+      }],
+    })
+    expect(res.findings).toHaveLength(1)
+    expect(res.findings[0].operations).toHaveLength(1)
+    expect(res.findings[0].operations![0].name).toBe('a'.repeat(MAX_NAME_LENGTH))
+  })
+
+  it('sanitizes operations in finding.options', () => {
+    const longName = 'b'.repeat(MAX_NAME_LENGTH + 5)
+    const res = toReviewResult({
+      findings: [{
+        title: 't',
+        detail: 'd',
+        category: 'boundary',
+        severity: 'high',
+        elementIds: [],
+        suggestion: 's',
+        options: [
+          {
+            label: 'Fix 1',
+            operations: [{ op: 'addPerson', ref: 'p1', name: longName }],
+          },
+        ],
+      }],
+    })
+    expect(res.findings[0].options).toHaveLength(1)
+    expect(res.findings[0].options![0].operations[0].name).toBe('b'.repeat(MAX_NAME_LENGTH))
+  })
+
+  it('drops options with ops that fail sanitization (oversized id)', () => {
+    const longRef = 'x'.repeat(MAX_ID_FIELD_LENGTH + 1)
+    const res = toReviewResult({
+      findings: [{
+        title: 't',
+        detail: 'd',
+        category: 'security',
+        severity: 'high',
+        elementIds: [],
+        suggestion: 's',
+        options: [
+          {
+            label: 'Fix 1',
+            operations: [{ op: 'addPerson', ref: longRef, name: 'Person' }],
+          },
+        ],
+      }],
+    })
+    expect(res.findings[0].options).toBeUndefined()
   })
 })

--- a/src/lib/ai/schema.ts
+++ b/src/lib/ai/schema.ts
@@ -75,6 +75,36 @@ export const ELEMENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Live', 'Plan
 /** Valid view-type values (mirrors ViewType). */
 export const VIEW_TYPE_VALUES: ReadonlySet<string> = new Set(['systemLandscape', 'systemContext', 'container', 'component'])
 
+// ─── Sanitizer caps ─────────────────────────────────────────────────
+// Bounds on op-count and text-field lengths to defend against runaway/adversarial model output.
+
+/** Maximum number of valid operations in a single plan. */
+export const MAX_PLAN_OPS = 300
+
+/** Maximum length (chars) for name fields. */
+export const MAX_NAME_LENGTH = 200
+
+/** Maximum length (chars) for description fields. */
+export const MAX_DESCRIPTION_LENGTH = 2000
+
+/** Maximum length (chars) for technology fields. */
+export const MAX_TECHNOLOGY_LENGTH = 100
+
+/** Maximum length (chars) for owner fields. */
+export const MAX_OWNER_LENGTH = 120
+
+/** Maximum length (chars) for title fields. */
+export const MAX_TITLE_LENGTH = 120
+
+/** Maximum length (chars) for id-like fields (ref, id, parent, source, destination, scope). */
+export const MAX_ID_FIELD_LENGTH = 512
+
+/** Maximum number of tags in a tags array. */
+export const MAX_TAGS_COUNT = 20
+
+/** Maximum length (chars) per tag. */
+export const MAX_TAG_LENGTH = 80
+
 export const editSchema = {
   type: 'object',
   additionalProperties: false,
@@ -104,6 +134,8 @@ function hasValidOpFieldTypes(value: Record<string, unknown>): boolean {
   // status enum value is validated leniently in the applier so a slightly-off
   // status doesn't discard an otherwise-valid update.
   if (value.tags !== undefined && !isStringArray(value.tags)) return false
+  if (value.location !== undefined && typeof value.location !== 'string') return false
+  if (value.viewType !== undefined && typeof value.viewType !== 'string') return false
   return value.status === undefined || typeof value.status === 'string'
 }
 
@@ -187,27 +219,109 @@ function dropLog(kind: string, kept: number, total: number): void {
   if (kept < total) log.warn(`Dropped ${total - kept} malformed ${kind} from the model response`, { kept, total })
 }
 
+/** Strip C0 control characters (U+0000 through U+001F) from a string, preserving
+ *  newline and tab when keepLinebreaks is true. */
+function stripControlChars(s: string, keepLinebreaks: boolean): string {
+  if (keepLinebreaks) {
+    // Keep \n (0x0A) and \t (0x09); strip the rest of C0 range (0x00-0x1F)
+    return s.split('').filter(c => {
+      const code = c.charCodeAt(0)
+      return code >= 0x20 || code === 0x09 || code === 0x0A
+    }).join('')
+  }
+  // Strip all C0 control characters (0x00-0x1F)
+  return s.split('').filter(c => c.charCodeAt(0) >= 0x20).join('')
+}
+
+/** Sanitize an EditOp: truncate text fields, strip control chars, enforce id-field
+ *  length limits, and cap tags. Returns the sanitized op or null if the op should
+ *  be dropped entirely (e.g., an id-field exceeds MAX_ID_FIELD_LENGTH). */
+export function sanitizeEditOp(op: EditOp): EditOp | null {
+  // Check id-fields first: if any exceed MAX_ID_FIELD_LENGTH, drop the whole op
+  const opAny = op as unknown as Record<string, unknown>
+  const idFields = ['ref', 'id', 'parent', 'source', 'destination', 'scope'] as const
+  for (const field of idFields) {
+    if (field in opAny && typeof opAny[field] === 'string') {
+      if ((opAny[field] as string).length > MAX_ID_FIELD_LENGTH) {
+        return null // Drop the whole op
+      }
+    }
+  }
+
+  const result: Record<string, unknown> = { ...op }
+
+  // Truncate and strip control chars from text fields
+  if (typeof result.name === 'string') {
+    result.name = stripControlChars(result.name, false).slice(0, MAX_NAME_LENGTH)
+  }
+  if (typeof result.description === 'string') {
+    result.description = stripControlChars(result.description, true).slice(0, MAX_DESCRIPTION_LENGTH)
+  }
+  if (typeof result.technology === 'string') {
+    result.technology = stripControlChars(result.technology, false).slice(0, MAX_TECHNOLOGY_LENGTH)
+  }
+  if (typeof result.owner === 'string') {
+    result.owner = stripControlChars(result.owner, false).slice(0, MAX_OWNER_LENGTH)
+  }
+  if (typeof result.title === 'string') {
+    result.title = stripControlChars(result.title, false).slice(0, MAX_TITLE_LENGTH)
+  }
+
+  // Sanitize tags: cap count, trim, drop empty/long tags
+  if (Array.isArray(result.tags)) {
+    const tags = result.tags
+      .slice(0, MAX_TAGS_COUNT)
+      .map((t) => {
+        if (typeof t === 'string') {
+          const trimmed = t.trim()
+          return trimmed.length <= MAX_TAG_LENGTH ? trimmed : null
+        }
+        return null
+      })
+      .filter((t): t is string => t !== null && t.length > 0)
+    result.tags = tags.length > 0 ? tags : undefined
+  }
+
+  return result as unknown as EditOp
+}
+
 /** Filter an `{ operations }` envelope down to valid operations. */
 export function toEditPlan(value: unknown): EditPlan {
   const ops = isRecord(value) && Array.isArray(value.operations) ? value.operations : []
-  const operations = ops.filter(isEditOp)
-  dropLog('operations', operations.length, ops.length)
-  return { operations }
+  const validOps = ops.filter(isEditOp)
+  const sanitized = validOps.map(sanitizeEditOp).filter((op): op is EditOp => op !== null)
+
+  // Cap at MAX_PLAN_OPS
+  if (sanitized.length > MAX_PLAN_OPS) {
+    dropLog('operations due to plan size cap', MAX_PLAN_OPS, sanitized.length)
+    sanitized.length = MAX_PLAN_OPS
+  }
+
+  dropLog('operations', sanitized.length, ops.length)
+  return { operations: sanitized }
 }
 
 export function toReviewFinding(value: unknown): ReviewFinding | null {
   if (!isRecord(value)) return null
   if (typeof value.title !== 'string' || typeof value.detail !== 'string' || typeof value.suggestion !== 'string') return null
   const severity: ReviewFinding['severity'] = value.severity === 'high' || value.severity === 'low' ? value.severity : 'medium'
-  const ops = Array.isArray(value.operations) ? value.operations.filter(isEditOp) : []
-  // Keep only options that have a label and at least one valid operation.
+
+  // Sanitize finding operations
+  const ops = Array.isArray(value.operations)
+    ? value.operations.filter(isEditOp).map(sanitizeEditOp).filter((op): op is EditOp => op !== null)
+    : []
+
+  // Keep only options that have a label and at least one valid operation
   const options = Array.isArray(value.options)
     ? value.options.flatMap((o): ReviewFixOption[] => {
         if (!isRecord(o) || typeof o.label !== 'string' || !o.label.trim()) return []
-        const oops = Array.isArray(o.operations) ? o.operations.filter(isEditOp) : []
+        const oops = Array.isArray(o.operations)
+          ? o.operations.filter(isEditOp).map(sanitizeEditOp).filter((op): op is EditOp => op !== null)
+          : []
         return oops.length ? [{ label: o.label, operations: oops }] : []
       })
     : []
+
   return {
     title: value.title,
     detail: value.detail,

--- a/src/lib/modelIntegrity.test.ts
+++ b/src/lib/modelIntegrity.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { checkModelIntegrity } from './modelIntegrity'
+import { makeWorkspace } from './ai/testFixture'
+import type { Workspace } from '@/types/model'
+
+/** Deep clone helper — keeps each test's mutation isolated from the shared fixture. */
+function clone(ws: Workspace): Workspace {
+  return JSON.parse(JSON.stringify(ws)) as Workspace
+}
+
+describe('checkModelIntegrity', () => {
+  it('returns no violations for the intact fixture', () => {
+    expect(checkModelIntegrity(makeWorkspace())).toEqual([])
+  })
+
+  it('(a) flags duplicate ids across elements/relationships', () => {
+    const ws = clone(makeWorkspace())
+    // Make the "admin" person share an id with the "shop" software system.
+    ws.model.people[1].id = 'shop'
+    const violations = checkModelIntegrity(ws)
+    expect(violations.some(v => v.code === 'duplicate-id')).toBe(true)
+  })
+
+  it('(b) flags a relationship with a dangling source/destination', () => {
+    const ws = clone(makeWorkspace())
+    ws.model.relationships[0].sourceId = 'does-not-exist'
+    const violations = checkModelIntegrity(ws)
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'dangling-relationship', relationshipId: 'r1' }),
+    ])
+  })
+
+  it('(c) flags structural hierarchy damage — missing containers array', () => {
+    const ws = clone(makeWorkspace())
+    // @ts-expect-error deliberately corrupting the shape
+    ws.model.softwareSystems[0].containers = null
+    const violations = checkModelIntegrity(ws)
+    expect(violations.some(v => v.code === 'malformed-containers')).toBe(true)
+  })
+
+  it('(c) flags structural hierarchy damage — missing components array', () => {
+    const ws = clone(makeWorkspace())
+    // @ts-expect-error deliberately corrupting the shape
+    ws.model.softwareSystems[0].containers[0].components = 'not-an-array'
+    const violations = checkModelIntegrity(ws)
+    expect(violations.some(v => v.code === 'malformed-components')).toBe(true)
+  })
+
+  it('(c) flags non-object entries in containers/components arrays', () => {
+    const ws = clone(makeWorkspace())
+    // @ts-expect-error deliberately corrupting the shape
+    ws.model.softwareSystems[0].containers.push('bogus')
+    const violations = checkModelIntegrity(ws)
+    expect(violations.some(v => v.code === 'malformed-container-entry')).toBe(true)
+  })
+
+  it('(d) flags an External software system that has containers', () => {
+    const ws = clone(makeWorkspace())
+    ws.model.softwareSystems[0].location = 'External'
+    const violations = checkModelIntegrity(ws)
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'external-system-has-containers', elementId: 'shop' }),
+    ])
+  })
+
+  it('(e) flags a view whose scope reference does not resolve', () => {
+    const ws = clone(makeWorkspace())
+    ws.views.systemContextViews.push({
+      type: 'systemContext',
+      key: 'ctx1',
+      softwareSystemId: 'nope',
+      elements: [],
+      relationships: [],
+    })
+    const violations = checkModelIntegrity(ws)
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'bad-view-scope', viewKey: 'ctx1' }),
+    ])
+  })
+
+  it('(e) flags a component view scoped to a software system instead of a container', () => {
+    const ws = clone(makeWorkspace())
+    ws.views.componentViews.push({
+      type: 'component',
+      key: 'comp1',
+      containerId: 'shop', // wrong kind — should be a container id, not a software system id
+      elements: [],
+      relationships: [],
+    })
+    const violations = checkModelIntegrity(ws)
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'bad-view-scope', viewKey: 'comp1' }),
+    ])
+  })
+
+  it('(e) flags a view element/relationship entry referencing a missing id', () => {
+    const ws = clone(makeWorkspace())
+    ws.views.containerViews.push({
+      type: 'container',
+      key: 'con1',
+      softwareSystemId: 'shop',
+      elements: [{ id: 'ghost' }],
+      relationships: [{ id: 'ghost-rel' }],
+    })
+    const violations = checkModelIntegrity(ws)
+    expect(violations.filter(v => v.code === 'dangling-view-ref')).toHaveLength(2)
+    expect(violations.every(v => v.viewKey === 'con1')).toBe(true)
+  })
+
+  it('(f) flags an element whose tags is not a string array', () => {
+    const ws = clone(makeWorkspace())
+    // @ts-expect-error deliberately corrupting the shape
+    ws.model.people[0].tags = 'not-an-array'
+    const violations = checkModelIntegrity(ws)
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'bad-tags', elementId: 'cust' }),
+    ])
+  })
+
+  it('(f) flags a relationship whose tags contains a non-string entry', () => {
+    const ws = clone(makeWorkspace())
+    // @ts-expect-error deliberately corrupting the shape
+    ws.model.relationships[0].tags = ['ok', 42]
+    const violations = checkModelIntegrity(ws)
+    expect(violations).toEqual([
+      expect.objectContaining({ code: 'bad-tags', relationshipId: 'r1' }),
+    ])
+  })
+
+  it('never throws on a structurally mangled workspace and reports violations instead', () => {
+    const ws = clone(makeWorkspace())
+    // @ts-expect-error deliberately corrupting the shape at every level
+    ws.model.softwareSystems[0].containers = null
+    // @ts-expect-error deliberately corrupting the shape
+    ws.model.relationships = 'nope'
+    // @ts-expect-error deliberately corrupting the shape
+    ws.views = undefined
+
+    expect(() => checkModelIntegrity(ws)).not.toThrow()
+    const violations = checkModelIntegrity(ws)
+    expect(violations.some(v => v.code === 'malformed-containers')).toBe(true)
+  })
+
+  it('never throws on a completely empty/garbage workspace', () => {
+    // @ts-expect-error deliberately testing a garbage top-level shape
+    expect(() => checkModelIntegrity(null)).not.toThrow()
+    // @ts-expect-error deliberately testing a garbage top-level shape
+    expect(checkModelIntegrity(null)).toEqual([])
+    // @ts-expect-error deliberately testing a garbage top-level shape
+    expect(() => checkModelIntegrity({})).not.toThrow()
+  })
+})

--- a/src/lib/modelIntegrity.ts
+++ b/src/lib/modelIntegrity.ts
@@ -1,0 +1,254 @@
+// Model-integrity checker — a pure, non-throwing oracle used to certify that a
+// workspace's structural invariants hold after AI-driven edits are applied.
+//
+// This is intentionally *separate* from src/lib/scopeValidation.ts, which is a
+// stricter, user-facing lint (workspace-scope rules, "can containers exist
+// here" etc). This module instead answers a narrower, lower-level question:
+// "is this Workspace even a well-formed model?" — duplicate ids, dangling
+// relationships, broken hierarchy nesting, and views that point at nothing.
+// It exists so tests (and, in dev builds, the store) can assert zero
+// violations after every EditPlan apply, no matter how adversarial the plan.
+import type { Component, Container, Model, ModelElement, Person, Relationship, SoftwareSystem, View, Workspace } from '@/types/model'
+
+export interface IntegrityViolation {
+  code: string
+  message: string
+  elementId?: string
+  relationshipId?: string
+  viewKey?: string
+}
+
+/** Element plus which container (system id / container id) it was found nested under, if any. */
+interface WalkedElement {
+  element: ModelElement
+  kind: ModelElement['type']
+}
+
+/**
+ * Walk the model defensively, tolerating any shape of corruption (missing
+ * arrays, non-array values, non-object entries) without throwing. Returns
+ * every element found, plus a running list of structural violations
+ * discovered along the way (missing containers/components arrays, non-object
+ * array entries).
+ */
+function walkElements(model: Model | undefined | null, violations: IntegrityViolation[]): WalkedElement[] {
+  const out: WalkedElement[] = []
+  if (!model || typeof model !== 'object') return out
+
+  const people = Array.isArray(model.people) ? model.people : []
+  for (const p of people) {
+    if (p && typeof p === 'object') out.push({ element: p as Person, kind: 'person' })
+  }
+
+  const systems = Array.isArray(model.softwareSystems) ? model.softwareSystems : []
+  for (const s of systems) {
+    if (!s || typeof s !== 'object') continue
+    const system = s as SoftwareSystem
+    out.push({ element: system, kind: 'softwareSystem' })
+
+    // (c) structural hierarchy damage — missing/malformed containers array.
+    if (!('containers' in system) || !Array.isArray(system.containers)) {
+      violations.push({
+        code: 'malformed-containers',
+        message: `Software system "${String(system.name ?? system.id)}" has a missing or non-array "containers" field.`,
+        elementId: typeof system.id === 'string' ? system.id : undefined,
+      })
+      continue
+    }
+
+    for (const c of system.containers) {
+      if (!c || typeof c !== 'object') {
+        violations.push({
+          code: 'malformed-container-entry',
+          message: `Software system "${String(system.name ?? system.id)}" has a non-object entry in its "containers" array.`,
+          elementId: typeof system.id === 'string' ? system.id : undefined,
+        })
+        continue
+      }
+      const container = c as Container
+      out.push({ element: container, kind: 'container' })
+
+      if (!('components' in container) || !Array.isArray(container.components)) {
+        violations.push({
+          code: 'malformed-components',
+          message: `Container "${String(container.name ?? container.id)}" has a missing or non-array "components" field.`,
+          elementId: typeof container.id === 'string' ? container.id : undefined,
+        })
+        continue
+      }
+
+      for (const cmp of container.components) {
+        if (!cmp || typeof cmp !== 'object') {
+          violations.push({
+            code: 'malformed-component-entry',
+            message: `Container "${String(container.name ?? container.id)}" has a non-object entry in its "components" array.`,
+            elementId: typeof container.id === 'string' ? container.id : undefined,
+          })
+          continue
+        }
+        out.push({ element: cmp as Component, kind: 'component' })
+      }
+    }
+  }
+
+  return out
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(v => typeof v === 'string')
+}
+
+/** Checks a workspace's model + views for structural integrity. Never throws. */
+export function checkModelIntegrity(ws: Workspace): IntegrityViolation[] {
+  const violations: IntegrityViolation[] = []
+  if (!ws || typeof ws !== 'object') return violations
+
+  const walked = walkElements(ws.model, violations)
+
+  // (a) duplicate ids across all elements and relationships share one namespace.
+  const seenIds = new Set<string>()
+  const elementIdToKind = new Map<string, ModelElement['type']>()
+  for (const { element, kind } of walked) {
+    const id = element && typeof element.id === 'string' ? element.id : undefined
+    if (!id) continue
+    if (seenIds.has(id)) {
+      violations.push({
+        code: 'duplicate-id',
+        message: `Id "${id}" is used by more than one element or relationship.`,
+        elementId: id,
+      })
+    } else {
+      seenIds.add(id)
+    }
+    // First occurrence wins for kind-based lookups (views/relationships).
+    if (!elementIdToKind.has(id)) elementIdToKind.set(id, kind)
+  }
+
+  const relationships: Relationship[] = Array.isArray(ws.model?.relationships) ? ws.model.relationships : []
+  for (const rel of relationships) {
+    if (!rel || typeof rel !== 'object') continue
+    const id = typeof rel.id === 'string' ? rel.id : undefined
+    if (id) {
+      if (seenIds.has(id)) {
+        violations.push({
+          code: 'duplicate-id',
+          message: `Id "${id}" is used by more than one element or relationship.`,
+          relationshipId: id,
+        })
+      } else {
+        seenIds.add(id)
+      }
+    }
+
+    // (b) dangling relationship endpoints.
+    const sourceOk = typeof rel.sourceId === 'string' && elementIdToKind.has(rel.sourceId)
+    const destOk = typeof rel.destinationId === 'string' && elementIdToKind.has(rel.destinationId)
+    if (!sourceOk || !destOk) {
+      violations.push({
+        code: 'dangling-relationship',
+        message: `Relationship "${id ?? '?'}" has a source or destination that does not resolve to an existing element.`,
+        relationshipId: id,
+      })
+    }
+  }
+
+  // (d) external systems must not have containers.
+  const systems = Array.isArray(ws.model?.softwareSystems) ? ws.model.softwareSystems : []
+  for (const s of systems) {
+    if (!s || typeof s !== 'object') continue
+    const system = s as SoftwareSystem
+    if (system.location === 'External' && Array.isArray(system.containers) && system.containers.length > 0) {
+      violations.push({
+        code: 'external-system-has-containers',
+        message: `Software system "${String(system.name ?? system.id)}" is marked External but has ${system.containers.length} container(s).`,
+        elementId: typeof system.id === 'string' ? system.id : undefined,
+      })
+    }
+  }
+
+  // (f) tags must be a string array on every element (and relationships, for good measure).
+  for (const { element } of walked) {
+    if (!isStringArray(element?.tags)) {
+      violations.push({
+        code: 'bad-tags',
+        message: `Element "${String(element?.name ?? element?.id)}" has a "tags" field that is not a string array.`,
+        elementId: typeof element?.id === 'string' ? element.id : undefined,
+      })
+    }
+  }
+  for (const rel of relationships) {
+    if (!rel || typeof rel !== 'object') continue
+    if (!isStringArray(rel.tags)) {
+      violations.push({
+        code: 'bad-tags',
+        message: `Relationship "${String(rel.id)}" has a "tags" field that is not a string array.`,
+        relationshipId: typeof rel.id === 'string' ? rel.id : undefined,
+      })
+    }
+  }
+
+  // (e) view scope + element/relationship reference resolution.
+  const relIds = new Set(relationships.filter(r => r && typeof r === 'object' && typeof r.id === 'string').map(r => r.id))
+  const views = ws.views && typeof ws.views === 'object' ? ws.views : undefined
+
+  function checkViewRefs(view: View) {
+    const key = typeof view?.key === 'string' ? view.key : undefined
+    const viewElements = Array.isArray(view?.elements) ? view.elements : []
+    for (const ve of viewElements) {
+      if (!ve || typeof ve !== 'object' || typeof ve.id !== 'string' || !elementIdToKind.has(ve.id)) {
+        violations.push({
+          code: 'dangling-view-ref',
+          message: `View "${key ?? '?'}" references an element id that does not exist in the model.`,
+          viewKey: key,
+        })
+      }
+    }
+    const viewRelationships = Array.isArray(view?.relationships) ? view.relationships : []
+    for (const vr of viewRelationships) {
+      if (!vr || typeof vr !== 'object' || typeof vr.id !== 'string' || !relIds.has(vr.id)) {
+        violations.push({
+          code: 'dangling-view-ref',
+          message: `View "${key ?? '?'}" references a relationship id that does not exist in the model.`,
+          viewKey: key,
+        })
+      }
+    }
+  }
+
+  function checkScope(view: View, field: 'softwareSystemId' | 'containerId', wantKind: ModelElement['type']) {
+    const key = typeof view?.key === 'string' ? view.key : undefined
+    const scopeId = view ? (view as unknown as Record<string, unknown>)[field] : undefined
+    if (typeof scopeId !== 'string' || elementIdToKind.get(scopeId) !== wantKind) {
+      violations.push({
+        code: 'bad-view-scope',
+        message: `View "${key ?? '?'}" has a scope reference that does not resolve to an existing ${wantKind}.`,
+        viewKey: key,
+      })
+    }
+  }
+
+  if (views) {
+    // systemLandscapeViews have no element/container scope — only ref checks apply.
+    for (const v of Array.isArray(views.systemLandscapeViews) ? views.systemLandscapeViews : []) {
+      if (!v || typeof v !== 'object') continue
+      checkViewRefs(v)
+    }
+    for (const v of Array.isArray(views.systemContextViews) ? views.systemContextViews : []) {
+      if (!v || typeof v !== 'object') continue
+      checkScope(v, 'softwareSystemId', 'softwareSystem')
+      checkViewRefs(v)
+    }
+    for (const v of Array.isArray(views.containerViews) ? views.containerViews : []) {
+      if (!v || typeof v !== 'object') continue
+      checkScope(v, 'softwareSystemId', 'softwareSystem')
+      checkViewRefs(v)
+    }
+    for (const v of Array.isArray(views.componentViews) ? views.componentViews : []) {
+      if (!v || typeof v !== 'object') continue
+      checkScope(v, 'containerId', 'container')
+      checkViewRefs(v)
+    }
+  }
+
+  return violations
+}


### PR DESCRIPTION
Recovers ~1,200 lines of finished, tested work that was orphaned on **2026-07-12** when local main was reset to origin (`branch: Reset to origin/main` in the reflog) — the commits were never pushed or PR'd, and survived only in the object store. Found while investigating "lost UI/feature changes from before the big UI update" (the AI/BYOK batch, #91).

## What's recovered (cherry-picked in original order)

| Commit | What it is |
|---|---|
| `41c162b` | **Model-integrity checker** — `checkModelIntegrity(ws)`, a pure non-throwing oracle for duplicate ids, dangling relationship endpoints, broken nesting, External systems with containers, bad view refs (254 lines + 152 test lines) |
| `2f5b45d` | **applyEditPlan integrity guards** — no ref-shadowing (a plan ref can't hijack a pre-existing id), no hierarchy escape (can't flip a container-holding system External, including same-plan creates) |
| `f3310ce` | **Schema sanitizer hardening** + the integration: transactional apply rollback in `applyPlanToStore` and the AiPanel revert/replay path (restores the exact pre-apply ref so undo/redo stacks roll back too), plus a dev/test-only integrity assert after every AI apply |
| `649eab2` | **Test coverage**: transactional apply, single-undo, stream-abort safety (288 + 142 lines) |
| `3497ba7` | **Viewport-restore fix** from the deleted `tea-ai-byok-features` branch (pre-#91): restore path used a 30-attempt rAF cap while the sibling fit path allows 60 (`MAX_MEASURE_ATTEMPTS`) — the flakiness this fixes was documented in the July reconciliation report and never addressed |

Two more orphans turned out to already be in main and were skipped as empty picks: the tag-merge restore (`534d4a7`, landed via #93) and the TEA-162 connection-point follow-up (`5d00572`, included in the #132 squash).

## Conflicts resolved

`operations.ts` — main's `register()` had gained the tag-seeding parameter (via #93); merged so both behaviors coexist (tag seeding + the no-shadowing guard).

## Also parked, not merged

- `rescue/*` branches pin every recovered object against gc.
- Three stashes from the same July session hold DSL-parser WIP that predates the TEA-160/163 parser rewrites — likely superseded; left for manual review (`git stash list`).

## Verification

`npm run check` — lint, typecheck, build, **2,285 unit tests** (main: 1,904 — the recovery adds ~380 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAsfeaQnKQnMR9ZKB6hu7U