### PR TITLE
feat(canvas): dynamic view step editor (TEA-237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state is saved alongside positions and survives a reload. Requested in
   [#108](https://github.com/c4hero/c4hero/issues/108).
 
+- **Edit dynamic view steps visually.** The add panel on a dynamic view is now
+  a step editor: add interactions between in-scope elements (picking the
+  reverse of an existing relationship authors a response step; a brand-new
+  pair creates the model relationship too), reorder with the sequence
+  renumbering automatically, override per-step descriptions inline, and
+  delete steps — membership follows the steps, edits are undoable, and the
+  result serializes losslessly.
+
 ### Fixed
 
 - **Parallel interaction sequences now number exactly like Structurizr.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state is saved alongside positions and survives a reload. Requested in
   [#108](https://github.com/c4hero/c4hero/issues/108).
 
+- **Author deployment topology visually.** The add panel on a deployment view
+  edits the environment's topology: add deployment nodes (top-level or
+  nested), infrastructure nodes, and container / software-system instances;
+  rename nodes inline; delete anything with its subtree cascading through
+  relationships and view membership. Scoped views pick up only instances of
+  their system, positions survive topology edits, everything is undoable, and
+  the result serializes to DSL the real Structurizr parser accepts.
 - **Edit dynamic view steps visually.** The add panel on a dynamic view is now
   a step editor: add interactions between in-scope elements (picking the
   reverse of an existing relationship authors a response step; a brand-new

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -4,7 +4,7 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 
 ## C4 modelling
 
-- Visual editing for **people, software systems, containers, and components** — the full C4 element vocabulary. **Deployment nodes, infrastructure nodes, and container / software-system instances** render on the canvas and round-trip through the DSL; authoring deployment topology is DSL-side for now.
+- Visual editing for **people, software systems, containers, and components** — the full C4 element vocabulary. **Deployment nodes, infrastructure nodes, and container / software-system instances** render on the canvas, round-trip through the DSL, and are authored visually from the add panel on a deployment view: nest nodes, place instances and infrastructure, rename inline, and delete with the subtree cascading.
 - All six view types: **system landscape, system context, container, component, dynamic, and deployment**.
 - **Dynamic views** render an ordered interaction sequence — each step carries its numbered badge and an optional per-step description on the edge. Steps are edited visually from the add panel: add (including response steps travelling back over an existing relationship), reorder, describe, and delete, with the sequence renumbering automatically.
 - **Deployment views** render the deployment environment as nested deployment-node boundaries wrapping the container / system instances and infrastructure nodes that run inside them.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -6,7 +6,7 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 
 - Visual editing for **people, software systems, containers, and components** — the full C4 element vocabulary. **Deployment nodes, infrastructure nodes, and container / software-system instances** render on the canvas and round-trip through the DSL; authoring deployment topology is DSL-side for now.
 - All six view types: **system landscape, system context, container, component, dynamic, and deployment**.
-- **Dynamic views** render an ordered interaction sequence — each step carries its numbered badge and an optional per-step description on the edge.
+- **Dynamic views** render an ordered interaction sequence — each step carries its numbered badge and an optional per-step description on the edge. Steps are edited visually from the add panel: add (including response steps travelling back over an existing relationship), reorder, describe, and delete, with the sequence renumbering automatically.
 - **Deployment views** render the deployment environment as nested deployment-node boundaries wrapping the container / system instances and infrastructure nodes that run inside them.
 - Drill-through navigation between views (zoom into a system → its containers; zoom into a container → its components). View history with back navigation.
 - **Boundaries are first-class.** Container and component views auto-render the parent system / container as a labelled boundary around its members; deployment views nest one boundary per deployment node.

--- a/e2e/panels/deployment-topology-editor.spec.ts
+++ b/e2e/panels/deployment-topology-editor.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../fixtures/workspace'
+
+const DSL = `workspace "Topology" {
+  model {
+    sys = softwareSystem "Sys" {
+      web = container "Web"
+      db = container "DB"
+    }
+    web -> db "Reads"
+    deploymentEnvironment "Live" {
+      server = deploymentNode "Server" {
+        liveWeb = containerInstance web
+      }
+    }
+  }
+  views {
+    deployment * "Live" "Dep" {
+      include *
+      autolayout lr
+    }
+  }
+}`
+
+test.describe('Deployment topology editor', () => {
+  test('lists the topology and authors nodes, instances, and deletes', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(DSL)
+    await workspace.setView('Dep')
+    await page.getByRole('button', { name: 'Add element' }).click()
+
+    const panel = page.locator('[data-flyout="add-element"]')
+    const rows = panel.locator('[data-topology-row]')
+    await expect(panel.getByText('Deployment topology — Live')).toBeVisible()
+    await expect(panel.locator('[data-topology-row="node"]')).toHaveCount(1)
+    await expect(panel.locator('[data-topology-row="instance"]')).toHaveCount(1)
+
+    // Add a nested deployment node under Server.
+    await panel.getByLabel('Element kind').selectOption('node')
+    await panel.getByLabel('Host deployment node').selectOption({ label: 'Server' })
+    await panel.getByRole('button', { name: 'Add topology element' }).click()
+    await expect(panel.locator('[data-topology-row="node"]')).toHaveCount(2)
+    await expect(rows.getByText('New Deployment Node', { exact: true })).toBeVisible()
+
+    // Rename it inline.
+    await rows.getByText('New Deployment Node', { exact: true }).click()
+    await panel.getByLabel('Rename New Deployment Node').fill('Pod')
+    await panel.getByLabel('Rename New Deployment Node').press('Enter')
+    await expect(rows.getByText('Pod', { exact: true })).toBeVisible()
+
+    // Put a DB container instance inside it — the canvas gains the node.
+    await panel.getByLabel('Element kind').selectOption('containerInstance')
+    await panel.getByLabel('Host deployment node').selectOption({ label: 'Server › Pod' })
+    await panel.getByLabel('Instance of').selectOption({ label: 'DB (Sys)' })
+    await panel.getByRole('button', { name: 'Add topology element' }).click()
+    await expect(panel.locator('[data-topology-row="instance"]')).toHaveCount(2)
+    await expect(page.locator('.react-flow').getByText('DB', { exact: true })).toBeVisible()
+    // The Pod boundary now wraps its instance on the canvas.
+    await expect(page.locator('.react-flow').getByText('Pod', { exact: true })).toBeVisible()
+    // The derived web -> db edge appears between the two instances.
+    await expect(page.locator('.react-flow__edge')).toHaveCount(1)
+
+    // Delete the Pod node — its instance goes with it.
+    await panel.getByRole('button', { name: 'Delete Pod' }).click()
+    await expect(panel.locator('[data-topology-row="node"]')).toHaveCount(1)
+    await expect(panel.locator('[data-topology-row="instance"]')).toHaveCount(1)
+    await expect(page.locator('.react-flow__edge')).toHaveCount(0)
+  })
+})

--- a/e2e/panels/dynamic-step-editor.spec.ts
+++ b/e2e/panels/dynamic-step-editor.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../fixtures/workspace'
+
+const DSL = `workspace "Steps" {
+  model {
+    user = person "User"
+    sys = softwareSystem "Sys" {
+      web = container "Web"
+      api = container "Api"
+    }
+    user -> web "Uses"
+    web -> api "Calls"
+  }
+  views {
+    dynamic sys "Flow" {
+      user -> web "Opens app"
+      web -> api "Calls"
+      autolayout lr
+    }
+  }
+}`
+
+test.describe('Dynamic step editor', () => {
+  test('lists, adds, reorders, and deletes steps from the add panel', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(DSL)
+    await workspace.setView('Flow')
+    await page.getByRole('button', { name: 'Add element' }).click()
+
+    const panel = page.locator('[data-flyout="add-element"]')
+    await expect(panel.getByText('Interaction steps')).toBeVisible()
+    await expect(panel.locator('[data-step-row]')).toHaveCount(2)
+
+    // Add a response step: Api → Web travels back over the existing web->api
+    // relationship instead of creating a new one.
+    await panel.getByLabel('Step source').selectOption({ label: 'Api' })
+    await panel.getByLabel('Step destination').selectOption({ label: 'Web' })
+    await panel.getByLabel('Step description').fill('Returns data')
+    await panel.getByRole('button', { name: 'Add step' }).click()
+
+    await expect(panel.locator('[data-step-row]')).toHaveCount(3)
+    // The canvas now shows three numbered edges.
+    await expect(page.locator('.react-flow__edge')).toHaveCount(3)
+    await expect(page.locator('.react-flow').getByLabel('Step 3')).toBeVisible()
+    await expect(page.locator('.react-flow').getByText('Returns data')).toBeVisible()
+
+    // Reorder: move the new step up — badges renumber.
+    await panel.getByRole('button', { name: 'Move step 3 up' }).click()
+    const secondRow = panel.locator('[data-step-row]').nth(1)
+    await expect(secondRow).toContainText('Api → Web')
+
+    // Delete it — back to the original two steps.
+    await panel.getByRole('button', { name: 'Delete step 2' }).click()
+    await expect(panel.locator('[data-step-row]')).toHaveCount(2)
+    await expect(page.locator('.react-flow__edge')).toHaveCount(2)
+
+    // The surviving steps kept their content and renumbered 1..2.
+    await expect(panel.locator('[data-step-row]').nth(0)).toContainText('User → Web')
+    await expect(panel.locator('[data-step-row]').nth(1)).toContainText('Web → Api')
+  })
+
+  test('editing a step description shows on the canvas edge', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(DSL)
+    await workspace.setView('Flow')
+    await page.getByRole('button', { name: 'Add element' }).click()
+
+    const panel = page.locator('[data-flyout="add-element"]')
+    await expect(panel.getByText('Interaction steps')).toBeVisible()
+    await panel.locator('[data-step-row]').nth(0).getByText('Opens app').click()
+    await panel.getByLabel('Step 1 description').fill('Opens the storefront')
+    await panel.getByLabel('Step 1 description').press('Enter')
+
+    await expect(page.locator('.react-flow').getByText('Opens the storefront')).toBeVisible()
+  })
+})

--- a/src/components/layout/AddElementPanel.tsx
+++ b/src/components/layout/AddElementPanel.tsx
@@ -4,6 +4,7 @@ import { useBreakpoint } from '@/hooks/useBreakpoint'
 import type { ModelElement } from '@/types/model'
 import { scopeAllowsContainers } from '@/lib/scopeValidation'
 import DynamicStepsEditor from './DynamicStepsEditor'
+import DeploymentTopologyEditor from './DeploymentTopologyEditor'
 import { TYPE_ICONS, TYPE_COLORS, TYPE_LABELS } from '@/lib/elementMeta'
 import {
   UserRound,
@@ -115,12 +116,9 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
         ref={panelRef}
         className="glass-flyout"
         data-flyout="add-element"
-        style={{ position: 'absolute', left: 56, top: 0, zIndex: 50, width: 280 }}
+        style={{ position: 'absolute', left: 56, top: 0, zIndex: 50, width: 300 }}
       >
-        <div style={{ padding: '12px 14px', color: 'var(--color-text-muted)', fontSize: 12, lineHeight: 1.5 }}>
-          Deployment topology (nodes, instances, infrastructure) is authored in
-          the DSL for now — edit the workspace file to change it.
-        </div>
+        <DeploymentTopologyEditor view={view} />
       </div>
     )
   }

--- a/src/components/layout/AddElementPanel.tsx
+++ b/src/components/layout/AddElementPanel.tsx
@@ -3,6 +3,7 @@ import { useWorkspaceStore, getCreatableTypes, getActiveView, getFocalScopeId, b
 import { useBreakpoint } from '@/hooks/useBreakpoint'
 import type { ModelElement } from '@/types/model'
 import { scopeAllowsContainers } from '@/lib/scopeValidation'
+import DynamicStepsEditor from './DynamicStepsEditor'
 import { TYPE_ICONS, TYPE_COLORS, TYPE_LABELS } from '@/lib/elementMeta'
 import {
   UserRound,
@@ -94,12 +95,21 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
   const view = getActiveView(workspace, activeViewKey)
   const viewElementIds = new Set(view?.elements.map((e) => e.id) ?? [])
 
-  // Dynamic and deployment views have no creatable element types yet — say
-  // so instead of rendering a dead-end empty panel.
-  if (view?.type === 'dynamic' || view?.type === 'deployment') {
-    const hint = view.type === 'dynamic'
-      ? 'Dynamic view steps are authored in the DSL for now — edit the workspace file to add or reorder interaction steps.'
-      : 'Deployment topology (nodes, instances, infrastructure) is authored in the DSL for now — edit the workspace file to change it.'
+  // Dynamic views get the interaction-step editor; deployment views have no
+  // creatable element types yet — say so instead of an empty dead end.
+  if (view?.type === 'dynamic') {
+    return (
+      <div
+        ref={panelRef}
+        className="glass-flyout"
+        data-flyout="add-element"
+        style={{ position: 'absolute', left: 56, top: 0, zIndex: 50, width: 300 }}
+      >
+        <DynamicStepsEditor view={view} />
+      </div>
+    )
+  }
+  if (view?.type === 'deployment') {
     return (
       <div
         ref={panelRef}
@@ -108,7 +118,8 @@ export default function AddElementPanel({ onClose }: { onClose: () => void }) {
         style={{ position: 'absolute', left: 56, top: 0, zIndex: 50, width: 280 }}
       >
         <div style={{ padding: '12px 14px', color: 'var(--color-text-muted)', fontSize: 12, lineHeight: 1.5 }}>
-          {hint}
+          Deployment topology (nodes, instances, infrastructure) is authored in
+          the DSL for now — edit the workspace file to change it.
         </div>
       </div>
     )

--- a/src/components/layout/DeploymentTopologyEditor.tsx
+++ b/src/components/layout/DeploymentTopologyEditor.tsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from 'react'
+import { useWorkspaceStore } from '@/store/workspace'
+import type { DeploymentNode, View, Workspace } from '@/types/model'
+import { Boxes, HardDrive, Plus, Trash2 } from 'lucide-react'
+
+type Row = {
+  id: string
+  depth: number
+  kind: 'node' | 'infra' | 'instance'
+  label: string
+  sublabel?: string
+  renamable: boolean
+}
+
+type NodePath = { id: string; path: string }
+
+function elementNameById(ws: Workspace): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const sys of ws.model.softwareSystems) {
+    map.set(sys.id, sys.name)
+    for (const c of sys.containers) map.set(c.id, c.name)
+  }
+  return map
+}
+
+function collectRows(ws: Workspace, view: View): { rows: Row[]; paths: NodePath[] } {
+  const env = (ws.model.deploymentEnvironments ?? []).find(e => e.name === view.environment)
+  const rows: Row[] = []
+  const paths: NodePath[] = []
+  const names = elementNameById(ws)
+  const walk = (node: DeploymentNode, depth: number, prefix: string) => {
+    const path = prefix ? `${prefix} › ${node.name}` : node.name
+    rows.push({ id: node.id, depth, kind: 'node', label: node.name, sublabel: node.technology, renamable: true })
+    paths.push({ id: node.id, path })
+    for (const infra of node.infrastructureNodes) {
+      rows.push({ id: infra.id, depth: depth + 1, kind: 'infra', label: infra.name, sublabel: infra.technology ?? 'Infrastructure', renamable: true })
+    }
+    for (const inst of node.containerInstances) {
+      rows.push({ id: inst.id, depth: depth + 1, kind: 'instance', label: names.get(inst.containerId) ?? inst.containerId, sublabel: 'Container instance', renamable: false })
+    }
+    for (const inst of node.softwareSystemInstances) {
+      rows.push({ id: inst.id, depth: depth + 1, kind: 'instance', label: names.get(inst.softwareSystemId) ?? inst.softwareSystemId, sublabel: 'System instance', renamable: false })
+    }
+    for (const child of node.children) walk(child, depth + 1, path)
+  }
+  for (const node of env?.deploymentNodes ?? []) walk(node, 0, '')
+  return { rows, paths }
+}
+
+const selectStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  fontSize: 12,
+  padding: '4px 6px',
+  borderRadius: 'var(--radius-sm)',
+  border: '1px solid var(--color-border)',
+  background: 'var(--color-surface-2)',
+  color: 'var(--color-text-primary)',
+}
+
+type AddKind = 'node' | 'infra' | 'containerInstance' | 'systemInstance'
+
+/** Deployment topology editor for the active deployment view. Rendered
+ *  inside the Add Element flyout shell. */
+export default function DeploymentTopologyEditor({ view }: { view: View }) {
+  const workspace = useWorkspaceStore((s) => s.workspace)
+  const [kind, setKind] = useState<AddKind>('node')
+  const [hostId, setHostId] = useState('')
+  const [elementId, setElementId] = useState('')
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameText, setRenameText] = useState('')
+
+  const { rows, paths } = useMemo(
+    () => (workspace ? collectRows(workspace, view) : { rows: [], paths: [] }),
+    [workspace, view],
+  )
+  const containers = useMemo(
+    () => (workspace?.model.softwareSystems ?? []).flatMap(s => s.containers.map(c => ({ id: c.id, name: `${c.name} (${s.name})` }))),
+    [workspace],
+  )
+  const systems = workspace?.model.softwareSystems ?? []
+
+  if (!workspace || !view.environment) return null
+  const environment = view.environment
+
+  const needsHost = kind !== 'node' // deployment nodes may be top-level
+  const needsElement = kind === 'containerInstance' || kind === 'systemInstance'
+  const canAdd = (!needsHost || hostId !== '') && (!needsElement || elementId !== '')
+
+  const add = () => {
+    const store = useWorkspaceStore.getState()
+    if (kind === 'node') store.addDeploymentNode(environment, hostId || null)
+    else if (kind === 'infra') store.addInfrastructureNode(environment, hostId)
+    else if (kind === 'containerInstance') store.addContainerInstance(environment, hostId, elementId)
+    else store.addSoftwareSystemInstance(environment, hostId, elementId)
+  }
+
+  const commitRename = (id: string) => {
+    useWorkspaceStore.getState().renameDeploymentElement(environment, id, renameText)
+    setRenamingId(null)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <div style={{ padding: '10px 12px 4px' }}>
+        <span className="flyout-label">Deployment topology — {environment}</span>
+      </div>
+
+      <div style={{ overflowY: 'auto', maxHeight: 240, padding: '2px 6px' }}>
+        {rows.length === 0 && (
+          <div style={{ padding: '6px 8px', fontSize: 12, color: 'var(--color-text-muted)' }}>
+            No deployment nodes yet — add the first one below.
+          </div>
+        )}
+        {rows.map((row) => (
+          <div
+            key={row.id}
+            data-topology-row={row.kind}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '3px 6px',
+              paddingLeft: 6 + row.depth * 14,
+              borderRadius: 'var(--radius-sm)',
+            }}
+          >
+            <span style={{ color: 'var(--color-text-muted)', flexShrink: 0, display: 'inline-flex' }}>
+              {row.kind === 'node' ? <Boxes size={12} /> : <HardDrive size={12} />}
+            </span>
+            {renamingId === row.id ? (
+              <input
+                autoFocus
+                value={renameText}
+                aria-label={`Rename ${row.label}`}
+                onChange={(e) => setRenameText(e.target.value)}
+                onBlur={() => commitRename(row.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitRename(row.id)
+                  if (e.key === 'Escape') setRenamingId(null)
+                }}
+                style={{ ...selectStyle, flex: 1 }}
+              />
+            ) : (
+              <span
+                onClick={() => { if (row.renamable) { setRenamingId(row.id); setRenameText(row.label) } }}
+                title={row.renamable ? 'Rename' : undefined}
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  fontSize: 12,
+                  color: 'var(--color-text-primary)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  cursor: row.renamable ? 'text' : 'default',
+                }}
+              >
+                {row.label}
+                {row.sublabel && (
+                  <span style={{ marginLeft: 6, fontSize: 10, color: 'var(--color-text-muted)' }}>{row.sublabel}</span>
+                )}
+              </span>
+            )}
+            <button
+              aria-label={`Delete ${row.label}`}
+              onClick={() => useWorkspaceStore.getState().deleteElements([row.id])}
+              style={{
+                display: 'inline-flex',
+                padding: 2,
+                background: 'none',
+                border: 'none',
+                borderRadius: 'var(--radius-sm)',
+                color: 'var(--color-danger, #e5484d)',
+                cursor: 'pointer',
+                flexShrink: 0,
+              }}
+            >
+              <Trash2 size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ borderTop: '1px solid var(--color-border)', padding: '8px 12px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <span className="flyout-label">Add</span>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <select aria-label="Element kind" value={kind} onChange={(e) => setKind(e.target.value as AddKind)} style={selectStyle}>
+            <option value="node">Deployment node</option>
+            <option value="infra">Infrastructure node</option>
+            <option value="containerInstance">Container instance</option>
+            <option value="systemInstance">System instance</option>
+          </select>
+          <select aria-label="Host deployment node" value={hostId} onChange={(e) => setHostId(e.target.value)} style={selectStyle}>
+            {kind === 'node' && <option value="">Top level</option>}
+            {kind !== 'node' && <option value="">Inside…</option>}
+            {paths.map(p => <option key={p.id} value={p.id}>{p.path}</option>)}
+          </select>
+        </div>
+        {needsElement && (
+          <select aria-label="Instance of" value={elementId} onChange={(e) => setElementId(e.target.value)} style={selectStyle}>
+            <option value="">
+              {kind === 'containerInstance' ? 'Container…' : 'System…'}
+            </option>
+            {kind === 'containerInstance'
+              ? containers.map(c => <option key={c.id} value={c.id}>{c.name}</option>)
+              : systems.map(sys => <option key={sys.id} value={sys.id}>{sys.name}</option>)}
+          </select>
+        )}
+        <button
+          aria-label="Add topology element"
+          disabled={!canAdd}
+          onClick={add}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 4,
+            padding: '4px 10px',
+            fontSize: 12,
+            fontWeight: 500,
+            borderRadius: 'var(--radius-sm)',
+            border: '1px solid var(--color-border)',
+            background: 'var(--color-surface-2)',
+            color: 'var(--color-text-primary)',
+            cursor: canAdd ? 'pointer' : 'not-allowed',
+            opacity: canAdd ? 1 : 0.5,
+          }}
+        >
+          <Plus size={12} /> Add
+        </button>
+        <span style={{ fontSize: 10, color: 'var(--color-text-muted)' }}>
+          Click a node's name to rename it. Deleting a node removes everything
+          inside it.
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/DynamicStepsEditor.tsx
+++ b/src/components/layout/DynamicStepsEditor.tsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from 'react'
+import { useWorkspaceStore } from '@/store/workspace'
+import type { View } from '@/types/model'
+import { eligibleStepElements } from '@/lib/dynamicSteps'
+import { ArrowDown, ArrowUp, CornerUpLeft, Plus, Trash2 } from 'lucide-react'
+
+const iconButtonStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: 2,
+  background: 'none',
+  border: 'none',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--color-text-muted)',
+  cursor: 'pointer',
+}
+
+const selectStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  fontSize: 12,
+  padding: '4px 6px',
+  borderRadius: 'var(--radius-sm)',
+  border: '1px solid var(--color-border)',
+  background: 'var(--color-surface-2)',
+  color: 'var(--color-text-primary)',
+}
+
+/** Ordered interaction-step editor for the active dynamic view. Rendered
+ *  inside the Add Element flyout shell. */
+export default function DynamicStepsEditor({ view }: { view: View }) {
+  const workspace = useWorkspaceStore((s) => s.workspace)
+  const selectRelationship = useWorkspaceStore((s) => s.selectRelationship)
+  const [sourceId, setSourceId] = useState('')
+  const [destinationId, setDestinationId] = useState('')
+  const [description, setDescription] = useState('')
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  const [editText, setEditText] = useState('')
+
+  const elements = useMemo(
+    () => (workspace ? eligibleStepElements(workspace, view) : []),
+    [workspace, view],
+  )
+  const nameOf = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const el of elements) map.set(el.id, el.name)
+    return map
+  }, [elements])
+
+  if (!workspace) return null
+  const relById = new Map(workspace.model.relationships.map(r => [r.id, r]))
+
+  const addStep = () => {
+    if (!sourceId || !destinationId || sourceId === destinationId) return
+    useWorkspaceStore.getState().addDynamicStep(view.key, sourceId, destinationId, description.trim() || undefined)
+    setDescription('')
+  }
+
+  const commitEdit = (index: number) => {
+    useWorkspaceStore.getState().updateDynamicStepDescription(view.key, index, editText)
+    setEditingIndex(null)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <div style={{ padding: '10px 12px 4px' }}>
+        <span className="flyout-label">Interaction steps</span>
+      </div>
+
+      <div style={{ overflowY: 'auto', maxHeight: 240, padding: '2px 6px' }}>
+        {view.relationships.length === 0 && (
+          <div style={{ padding: '6px 8px', fontSize: 12, color: 'var(--color-text-muted)' }}>
+            No steps yet — add the first interaction below.
+          </div>
+        )}
+        {view.relationships.map((step, index) => {
+          const rel = relById.get(step.id)
+          const from = step.sourceId ?? (step.response ? rel?.destinationId : rel?.sourceId)
+          const to = step.destinationId ?? (step.response ? rel?.sourceId : rel?.destinationId)
+          const label = `${nameOf.get(from ?? '') ?? from ?? '?'} → ${nameOf.get(to ?? '') ?? to ?? '?'}`
+          const stepDescription = step.description ?? rel?.description
+          return (
+            <div
+              key={`${step.id}-${index}`}
+              data-step-row
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '4px 6px',
+                borderRadius: 'var(--radius-sm)',
+              }}
+            >
+              <span
+                aria-label={`Step ${step.order}`}
+                style={{
+                  minWidth: 18,
+                  textAlign: 'center',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  borderRadius: 9,
+                  padding: '1px 4px',
+                  background: 'var(--color-surface-3)',
+                  color: 'var(--color-text-secondary)',
+                  flexShrink: 0,
+                }}
+              >
+                {step.order}
+              </span>
+              <button
+                onClick={() => selectRelationship(step.id)}
+                title={stepDescription || label}
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  textAlign: 'left',
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, color: 'var(--color-text-primary)' }}>
+                  {step.response && <CornerUpLeft size={10} style={{ flexShrink: 0, color: 'var(--color-text-muted)' }} aria-label="Response" />}
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</span>
+                </span>
+                {editingIndex === index ? (
+                  <input
+                    autoFocus
+                    value={editText}
+                    aria-label={`Step ${step.order} description`}
+                    onChange={(e) => setEditText(e.target.value)}
+                    onBlur={() => commitEdit(index)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitEdit(index)
+                      if (e.key === 'Escape') setEditingIndex(null)
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    style={{ ...selectStyle, width: '100%', marginTop: 2 }}
+                  />
+                ) : (
+                  <span
+                    onClick={(e) => { e.stopPropagation(); setEditingIndex(index); setEditText(stepDescription ?? '') }}
+                    title="Edit description"
+                    style={{
+                      display: 'block',
+                      fontSize: 11,
+                      color: 'var(--color-text-muted)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {stepDescription || 'No description'}
+                  </span>
+                )}
+              </button>
+              <span style={{ display: 'flex', flexShrink: 0 }}>
+                <button
+                  aria-label={`Move step ${step.order} up`}
+                  disabled={index === 0}
+                  onClick={() => useWorkspaceStore.getState().moveDynamicStep(view.key, index, 'up')}
+                  style={{ ...iconButtonStyle, opacity: index === 0 ? 0.3 : 1 }}
+                >
+                  <ArrowUp size={12} />
+                </button>
+                <button
+                  aria-label={`Move step ${step.order} down`}
+                  disabled={index === view.relationships.length - 1}
+                  onClick={() => useWorkspaceStore.getState().moveDynamicStep(view.key, index, 'down')}
+                  style={{ ...iconButtonStyle, opacity: index === view.relationships.length - 1 ? 0.3 : 1 }}
+                >
+                  <ArrowDown size={12} />
+                </button>
+                <button
+                  aria-label={`Delete step ${step.order}`}
+                  onClick={() => useWorkspaceStore.getState().deleteDynamicStep(view.key, index)}
+                  style={{ ...iconButtonStyle, color: 'var(--color-danger, #e5484d)' }}
+                >
+                  <Trash2 size={12} />
+                </button>
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <div style={{ borderTop: '1px solid var(--color-border)', padding: '8px 12px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <span className="flyout-label">Add step</span>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <select aria-label="Step source" value={sourceId} onChange={(e) => setSourceId(e.target.value)} style={selectStyle}>
+            <option value="">From…</option>
+            {elements.map(el => <option key={el.id} value={el.id}>{el.name}</option>)}
+          </select>
+          <select aria-label="Step destination" value={destinationId} onChange={(e) => setDestinationId(e.target.value)} style={selectStyle}>
+            <option value="">To…</option>
+            {elements.map(el => <option key={el.id} value={el.id}>{el.name}</option>)}
+          </select>
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <input
+            aria-label="Step description"
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') addStep() }}
+            style={selectStyle}
+          />
+          <button
+            aria-label="Add step"
+            disabled={!sourceId || !destinationId || sourceId === destinationId}
+            onClick={addStep}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              padding: '4px 10px',
+              fontSize: 12,
+              fontWeight: 500,
+              borderRadius: 'var(--radius-sm)',
+              border: '1px solid var(--color-border)',
+              background: 'var(--color-surface-2)',
+              color: 'var(--color-text-primary)',
+              cursor: !sourceId || !destinationId || sourceId === destinationId ? 'not-allowed' : 'pointer',
+              opacity: !sourceId || !destinationId || sourceId === destinationId ? 0.5 : 1,
+              flexShrink: 0,
+            }}
+          >
+            <Plus size={12} /> Add
+          </button>
+        </div>
+        <span style={{ fontSize: 10, color: 'var(--color-text-muted)' }}>
+          Picking the reverse of an existing relationship adds a response step.
+          Editing renumbers steps 1..n.
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -353,6 +353,30 @@ workspace "Dynamics" {
             expect(view.relationships[4].id).toBe(view.relationships[1].id)
         })
 
+        it('store-authored deployment topology serializes to DSL Structurizr accepts', async () => {
+            const { useWorkspaceStore } = await import('@/store/workspace')
+            const { workspace, errors } = parseDSL(DEPLOYMENT_DSL)
+            expect(errors).toEqual([])
+            useWorkspaceStore.getState().loadWorkspace(workspace)
+            const store = useWorkspaceStore.getState()
+            const ws = () => useWorkspaceStore.getState().workspace!
+
+            const env = ws().model.deploymentEnvironments![0]
+            const host = env.deploymentNodes[0]
+            const podId = store.addDeploymentNode(env.name, host.id)
+            expect(podId).not.toBe('')
+            store.renameDeploymentElement(env.name, podId, 'Pod')
+            const infraId = store.addInfrastructureNode(env.name, podId)
+            const container = ws().model.softwareSystems.flatMap(s => s.containers)[0]
+            const instId = store.addContainerInstance(env.name, podId, container.id)
+            // Explicit relationship between deployment elements — the
+            // serializer must emit it AFTER the environment block so the
+            // identifiers exist when the single-pass parser reads it.
+            store.addRelationship(infraId, instId, 'routes to')
+
+            expect(validate(serializeDSL(ws()))).toBeNull()
+        })
+
         it('parallel-sequence numbering matches the real parser, before and after re-serialization', () => {
             const PARALLEL_DSL = `
 workspace "Parallel" {

--- a/src/lib/dynamicSteps.ts
+++ b/src/lib/dynamicSteps.ts
@@ -1,0 +1,19 @@
+import type { ModelElement, View, Workspace } from '@/types/model'
+
+/** Elements a dynamic view's steps may connect, mirroring what the real
+ *  Structurizr parser accepts (verified against CLI v2025.11.09):
+ *  unscoped — people and software systems only; system-scoped — plus
+ *  containers; container-scoped — plus the scoped container's components. */
+export function eligibleStepElements(ws: Workspace, view: View): ModelElement[] {
+  const out: ModelElement[] = [...ws.model.people, ...ws.model.softwareSystems]
+  if (view.softwareSystemId || view.containerId) {
+    for (const system of ws.model.softwareSystems) out.push(...system.containers)
+  }
+  if (view.containerId) {
+    const scoped = ws.model.softwareSystems
+      .flatMap(s => s.containers)
+      .find(c => c.id === view.containerId)
+    out.push(...(scoped?.components ?? []))
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/store/deployment-authoring.test.ts
+++ b/src/store/deployment-authoring.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from './workspace'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+
+const DSL = `workspace {
+  model {
+    sys = softwareSystem "Sys" {
+      web = container "Web"
+      db = container "DB"
+    }
+    other = softwareSystem "Other"
+    web -> db "Reads"
+    deploymentEnvironment "Live" {
+      server = deploymentNode "Server" {
+        liveWeb = containerInstance web
+      }
+    }
+  }
+  views {
+    deployment * "Live" "Dep" { include * }
+  }
+}`
+
+function load() {
+  const { workspace: ws, errors } = parseDSL(DSL)
+  expect(errors).toHaveLength(0)
+  useWorkspaceStore.getState().loadWorkspace(ws)
+}
+
+function ws() {
+  return useWorkspaceStore.getState().workspace!
+}
+
+function env() {
+  return ws().model.deploymentEnvironments![0]
+}
+
+function depView() {
+  return ws().views.deploymentViews[0]
+}
+
+describe('deployment topology authoring', () => {
+  beforeEach(() => {
+    load()
+  })
+
+  it('adds a top-level and a nested deployment node, and the view picks both up', () => {
+    const topId = useWorkspaceStore.getState().addDeploymentNode('Live', null)
+    expect(topId).not.toBe('')
+    const nestedId = useWorkspaceStore.getState().addDeploymentNode('Live', topId)
+    expect(env().deploymentNodes).toHaveLength(2)
+    const top = env().deploymentNodes.find(n => n.id === topId)!
+    expect(top.children[0].id).toBe(nestedId)
+    for (const id of [topId, nestedId]) {
+      expect(depView().elements.some(e => e.id === id)).toBe(true)
+    }
+  })
+
+  it('adds infrastructure and instances to a host node', () => {
+    const serverId = env().deploymentNodes[0].id
+    const infraId = useWorkspaceStore.getState().addInfrastructureNode('Live', serverId)
+    const dbId = ws().model.softwareSystems[0].containers.find(c => c.name === 'DB')!.id
+    const instId = useWorkspaceStore.getState().addContainerInstance('Live', serverId, dbId)
+    const otherId = ws().model.softwareSystems.find(s => s.name === 'Other')!.id
+    const sysInstId = useWorkspaceStore.getState().addSoftwareSystemInstance('Live', serverId, otherId)
+
+    const server = env().deploymentNodes[0]
+    expect(server.infrastructureNodes.some(i => i.id === infraId)).toBe(true)
+    expect(server.containerInstances.some(i => i.id === instId)).toBe(true)
+    expect(server.softwareSystemInstances.some(i => i.id === sysInstId)).toBe(true)
+    for (const id of [infraId, instId, sysInstId]) {
+      expect(depView().elements.some(e => e.id === id)).toBe(true)
+    }
+    // The derived instance relationship (web -> db) now has both instance
+    // endpoints in the environment, so the canvas edge builder can draw it —
+    // covered by deploymentViewRelationships, membership is what we assert.
+  })
+
+  it('scoped deployment views only pick up instances of their system', () => {
+    // Add a scoped view for sys, then instances of sys's container and Other.
+    useWorkspaceStore.getState().addView('deployment', ws().model.softwareSystems[0].id, 'SysDep', { environment: 'Live' })
+    const serverId = env().deploymentNodes[0].id
+    const otherId = ws().model.softwareSystems.find(s => s.name === 'Other')!.id
+    const sysInstId = useWorkspaceStore.getState().addSoftwareSystemInstance('Live', serverId, otherId)
+    const scoped = ws().views.deploymentViews.find(v => v.softwareSystemId)!
+    expect(scoped.elements.some(e => e.id === sysInstId)).toBe(false)
+    expect(depView().elements.some(e => e.id === sysInstId)).toBe(true)
+  })
+
+  it('preserves positions of surviving elements across a topology change', () => {
+    const serverId = env().deploymentNodes[0].id
+    const v = depView()
+    const el = v.elements.find(e => e.id === serverId)!
+    el.x = 123
+    el.y = 456
+    useWorkspaceStore.getState().addInfrastructureNode('Live', serverId)
+    const after = depView().elements.find(e => e.id === serverId)!
+    expect(after.x).toBe(123)
+    expect(after.y).toBe(456)
+  })
+
+  it('renames nodes and infrastructure, not instances', () => {
+    const serverId = env().deploymentNodes[0].id
+    useWorkspaceStore.getState().renameDeploymentElement('Live', serverId, 'App Server')
+    expect(env().deploymentNodes[0].name).toBe('App Server')
+    const instId = env().deploymentNodes[0].containerInstances[0].id
+    useWorkspaceStore.getState().renameDeploymentElement('Live', instId, 'nope')
+    expect(env().deploymentNodes[0].containerInstances[0]).not.toHaveProperty('name', 'nope')
+  })
+
+  it('deleting an instance directly prunes it and its view refs', () => {
+    const instId = env().deploymentNodes[0].containerInstances[0].id
+    useWorkspaceStore.getState().deleteElements([instId])
+    expect(env().deploymentNodes[0].containerInstances).toHaveLength(0)
+    expect(depView().elements.some(e => e.id === instId)).toBe(false)
+    // The post-delete workspace still parses.
+    const { errors } = parseDSL(serializeDSL(ws()))
+    expect(errors).toHaveLength(0)
+  })
+
+  it('deleting a deployment node takes its subtree, and explicit relationships to it, with it', () => {
+    const serverId = env().deploymentNodes[0].id
+    const infraId = useWorkspaceStore.getState().addInfrastructureNode('Live', serverId)
+    const nestedId = useWorkspaceStore.getState().addDeploymentNode('Live', serverId)
+    const instId = env().deploymentNodes[0].containerInstances[0].id
+    // An explicit relationship touching the infra node
+    useWorkspaceStore.getState().addRelationship(infraId, instId, 'routes to')
+    expect(ws().model.relationships.some(r => r.sourceId === infraId)).toBe(true)
+
+    useWorkspaceStore.getState().deleteElements([serverId])
+    expect(env().deploymentNodes).toHaveLength(0)
+    expect(ws().model.relationships.some(r => r.sourceId === infraId)).toBe(false)
+    for (const id of [serverId, infraId, nestedId, instId]) {
+      expect(depView().elements.some(e => e.id === id)).toBe(false)
+    }
+    const { errors } = parseDSL(serializeDSL(ws()))
+    expect(errors).toHaveLength(0)
+  })
+
+  it('authored topology round-trips through the DSL', () => {
+    const serverId = env().deploymentNodes[0].id
+    const nestedId = useWorkspaceStore.getState().addDeploymentNode('Live', serverId)
+    useWorkspaceStore.getState().renameDeploymentElement('Live', nestedId, 'Pod')
+    useWorkspaceStore.getState().addInfrastructureNode('Live', nestedId)
+    const dbId = ws().model.softwareSystems[0].containers.find(c => c.name === 'DB')!.id
+    useWorkspaceStore.getState().addContainerInstance('Live', nestedId, dbId)
+
+    const { workspace: reparsed, errors } = parseDSL(serializeDSL(ws()))
+    expect(errors).toHaveLength(0)
+    const reEnv = reparsed.model.deploymentEnvironments![0]
+    const pod = reEnv.deploymentNodes[0].children.find(n => n.name === 'Pod')!
+    expect(pod).toBeDefined()
+    expect(pod.infrastructureNodes).toHaveLength(1)
+    expect(pod.containerInstances).toHaveLength(1)
+    // The reparsed instance references the DB container by its id
+    const reDb = reparsed.model.softwareSystems[0].containers.find(c => c.name === 'DB')!
+    expect(pod.containerInstances[0].containerId).toBe(reDb.id)
+  })
+
+  it('topology edits are undoable', () => {
+    const serverId = env().deploymentNodes[0].id
+    useWorkspaceStore.getState().addInfrastructureNode('Live', serverId)
+    expect(env().deploymentNodes[0].infrastructureNodes).toHaveLength(1)
+    useWorkspaceStore.getState().undo()
+    expect(env().deploymentNodes[0].infrastructureNodes).toHaveLength(0)
+  })
+
+  it('no-ops cleanly on bad input', () => {
+    expect(useWorkspaceStore.getState().addDeploymentNode('Nope', null)).toBe('')
+    expect(useWorkspaceStore.getState().addInfrastructureNode('Live', 'missing')).toBe('')
+    expect(useWorkspaceStore.getState().addContainerInstance('Live', env().deploymentNodes[0].id, 'missing')).toBe('')
+    expect(env().deploymentNodes).toHaveLength(1)
+  })
+})

--- a/src/store/dynamic-steps.test.ts
+++ b/src/store/dynamic-steps.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from './workspace'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+import { eligibleStepElements } from '@/lib/dynamicSteps'
+
+const DSL = `workspace {
+  model {
+    user = person "User"
+    sys = softwareSystem "Sys" {
+      web = container "Web"
+      api = container "Api"
+    }
+    other = softwareSystem "Other"
+    user -> web "Uses"
+    web -> api "Calls"
+    api -> other "Notifies"
+  }
+  views {
+    container sys "Containers" { include * }
+    dynamic sys "Flow" {
+      user -> web "Opens app"
+      web -> api "Calls"
+    }
+  }
+}`
+
+function load() {
+  const { workspace: ws, errors } = parseDSL(DSL)
+  expect(errors).toHaveLength(0)
+  useWorkspaceStore.getState().loadWorkspace(ws)
+  return useWorkspaceStore.getState().workspace!
+}
+
+function view() {
+  return useWorkspaceStore.getState().workspace!.views.dynamicViews[0]
+}
+
+function idOf(name: string): string {
+  const ws = useWorkspaceStore.getState().workspace!
+  const all = [
+    ...ws.model.people,
+    ...ws.model.softwareSystems,
+    ...ws.model.softwareSystems.flatMap(s => s.containers),
+  ]
+  return all.find(el => el.name === name)!.id
+}
+
+describe('dynamic step editing', () => {
+  beforeEach(() => {
+    load()
+  })
+
+  it('adds a step over an existing forward relationship without creating a duplicate', () => {
+    const relCount = useWorkspaceStore.getState().workspace!.model.relationships.length
+    useWorkspaceStore.getState().addDynamicStep('Flow', idOf('Web'), idOf('Api'), 'Retries')
+    const v = view()
+    expect(v.relationships).toHaveLength(3)
+    expect(v.relationships[2].order).toBe('3')
+    expect(v.relationships[2].description).toBe('Retries')
+    expect(v.relationships[2].response).toBeUndefined()
+    // Reused the existing web -> api relationship
+    expect(useWorkspaceStore.getState().workspace!.model.relationships).toHaveLength(relCount)
+    expect(v.relationships[2].id).toBe(v.relationships[1].id)
+  })
+
+  it('adds a response step when only the reverse relationship exists', () => {
+    useWorkspaceStore.getState().addDynamicStep('Flow', idOf('Api'), idOf('Web'), 'Returns data')
+    const v = view()
+    const step = v.relationships[2]
+    expect(step.response).toBe(true)
+    expect(step.sourceId).toBe(idOf('Api'))
+    expect(step.destinationId).toBe(idOf('Web'))
+    // Backed by the existing forward relationship
+    expect(step.id).toBe(v.relationships[1].id)
+  })
+
+  it('creates the model relationship when none exists, and syncs it into non-dynamic views', () => {
+    const before = useWorkspaceStore.getState().workspace!.model.relationships.length
+    useWorkspaceStore.getState().addDynamicStep('Flow', idOf('Web'), idOf('Other'), 'Streams events')
+    const ws = useWorkspaceStore.getState().workspace!
+    expect(ws.model.relationships).toHaveLength(before + 1)
+    const created = ws.model.relationships[ws.model.relationships.length - 1]
+    expect(created.description).toBe('Streams events')
+    // The container view holds both endpoints, so it picks the relationship up…
+    const containerView = ws.views.containerViews[0]
+    expect(containerView.relationships.some(r => r.id === created.id)).toBe(true)
+    // …and the step does NOT duplicate the description as an override.
+    expect(view().relationships[2].description).toBeUndefined()
+    // The new endpoint joins the dynamic view's membership.
+    expect(view().elements.some(e => e.id === idOf('Other'))).toBe(true)
+  })
+
+  it('reorders steps and renumbers sequentially', () => {
+    useWorkspaceStore.getState().moveDynamicStep('Flow', 1, 'up')
+    const v = view()
+    expect(v.relationships.map(r => r.order)).toEqual(['1', '2'])
+    expect(v.relationships[0].description).toBe('Calls')
+    expect(v.relationships[1].description).toBe('Opens app')
+    // No-ops at the boundaries
+    useWorkspaceStore.getState().moveDynamicStep('Flow', 0, 'up')
+    expect(view().relationships[0].description).toBe('Calls')
+  })
+
+  it('deletes a step, renumbers, and drops elements with no surviving steps', () => {
+    useWorkspaceStore.getState().deleteDynamicStep('Flow', 0)
+    const v = view()
+    expect(v.relationships).toHaveLength(1)
+    expect(v.relationships[0].order).toBe('1')
+    expect(v.relationships[0].description).toBe('Calls')
+    // 'User' only appeared in the deleted step
+    expect(v.elements.some(e => e.id === idOf('User'))).toBe(false)
+    expect(v.elements.some(e => e.id === idOf('Web'))).toBe(true)
+  })
+
+  it('updates and clears a step description override', () => {
+    useWorkspaceStore.getState().updateDynamicStepDescription('Flow', 1, 'Calls with retry')
+    expect(view().relationships[1].description).toBe('Calls with retry')
+    // Setting it back to the relationship's own description clears the override
+    useWorkspaceStore.getState().updateDynamicStepDescription('Flow', 1, 'Calls')
+    expect(view().relationships[1].description).toBeUndefined()
+  })
+
+  it('step edits are undoable', () => {
+    useWorkspaceStore.getState().deleteDynamicStep('Flow', 0)
+    expect(view().relationships).toHaveLength(1)
+    useWorkspaceStore.getState().undo()
+    const v = view()
+    expect(v.relationships).toHaveLength(2)
+    expect(v.relationships[0].description).toBe('Opens app')
+  })
+
+  it('an edited view serializes to DSL that re-parses to the same steps', () => {
+    useWorkspaceStore.getState().addDynamicStep('Flow', idOf('Api'), idOf('Web'), 'Returns data')
+    useWorkspaceStore.getState().moveDynamicStep('Flow', 2, 'up')
+    const ws = useWorkspaceStore.getState().workspace!
+    const { workspace: reparsed, errors } = parseDSL(serializeDSL(ws))
+    expect(errors).toHaveLength(0)
+    const original = ws.views.dynamicViews[0]
+    const roundTripped = reparsed.views.dynamicViews[0]
+    expect(roundTripped.relationships.map(r => r.order)).toEqual(original.relationships.map(r => r.order))
+    expect(roundTripped.relationships[1].response).toBe(true)
+  })
+
+  it('ignores invalid input: self-steps, unknown elements, non-dynamic views', () => {
+    const before = view().relationships.length
+    useWorkspaceStore.getState().addDynamicStep('Flow', idOf('Web'), idOf('Web'))
+    useWorkspaceStore.getState().addDynamicStep('Flow', 'nope', idOf('Web'))
+    useWorkspaceStore.getState().addDynamicStep('Containers', idOf('Web'), idOf('Api'))
+    expect(view().relationships).toHaveLength(before)
+    expect(useWorkspaceStore.getState().workspace!.views.containerViews[0].relationships).toHaveLength(3)
+  })
+
+  it('eligibleStepElements follows the oracle-verified scope rules', () => {
+    const ws = useWorkspaceStore.getState().workspace!
+    const dynamicView = ws.views.dynamicViews[0] // scoped to sys
+    const names = eligibleStepElements(ws, dynamicView).map(e => e.name)
+    expect(names).toContain('User')
+    expect(names).toContain('Other')
+    expect(names).toContain('Web')
+    // Unscoped: people + systems only
+    const unscoped = { ...dynamicView, softwareSystemId: undefined, containerId: undefined }
+    const unscopedNames = eligibleStepElements(ws, unscoped).map(e => e.name)
+    expect(unscopedNames).toContain('User')
+    expect(unscopedNames).not.toContain('Web')
+  })
+})

--- a/src/store/slices/deployment-slice.ts
+++ b/src/store/slices/deployment-slice.ts
@@ -1,0 +1,162 @@
+import type { StateCreator } from 'zustand'
+import type { WorkspaceState } from '../workspace-types'
+import type { DeploymentEnvironment, DeploymentNode, Workspace } from '@/types/model'
+import { nanoid, pushUndoSnapshot } from '../internals'
+import { expandDeploymentElements, walkDeploymentNodes } from '@/lib/deployment'
+
+function envByName(ws: Workspace, environment: string): DeploymentEnvironment | undefined {
+  return (ws.model.deploymentEnvironments ?? []).find(e => e.name === environment)
+}
+
+function nodeById(env: DeploymentEnvironment, id: string): DeploymentNode | undefined {
+  let found: DeploymentNode | undefined
+  walkDeploymentNodes(env, (node) => {
+    if (node.id === id) found = node
+  })
+  return found
+}
+
+/** Recompute every deployment view of `environment` from the canonical
+ *  membership rules (the same expansion `include *` parses to), keeping the
+ *  positions of elements that survive. */
+function refreshDeploymentViews(ws: Workspace, environment: string): void {
+  for (const v of ws.views.deploymentViews ?? []) {
+    if (v.environment !== environment) continue
+    const existing = new Map(v.elements.map(e => [e.id, e]))
+    v.elements = expandDeploymentElements(ws.model, v.environment, v.softwareSystemId)
+      .map(e => existing.get(e.id) ?? e)
+  }
+}
+
+export type DeploymentSlice = Pick<WorkspaceState,
+  | 'addDeploymentNode' | 'addInfrastructureNode'
+  | 'addContainerInstance' | 'addSoftwareSystemInstance'
+  | 'renameDeploymentElement'
+>
+
+export const createDeploymentSlice: StateCreator<
+  WorkspaceState,
+  [['zustand/immer', never]],
+  [],
+  DeploymentSlice
+> = (set) => ({
+  addDeploymentNode: (environment, parentNodeId) => {
+    const id = nanoid(8)
+    let created = false
+    set((s) => {
+      if (!s.workspace) return
+      const env = envByName(s.workspace, environment)
+      if (!env) return
+      const parent = parentNodeId ? nodeById(env, parentNodeId) : undefined
+      if (parentNodeId && !parent) return
+      pushUndoSnapshot(s)
+      const node: DeploymentNode = {
+        id,
+        type: 'deploymentNode',
+        name: 'New Deployment Node',
+        tags: ['Element', 'Deployment Node'],
+        properties: {},
+        children: [],
+        infrastructureNodes: [],
+        containerInstances: [],
+        softwareSystemInstances: [],
+      }
+      ;(parent ? parent.children : env.deploymentNodes).push(node)
+      refreshDeploymentViews(s.workspace, environment)
+      s.layoutVersion += 1
+      created = true
+    })
+    return created ? id : ''
+  },
+
+  addInfrastructureNode: (environment, hostNodeId) => {
+    const id = nanoid(8)
+    let created = false
+    set((s) => {
+      if (!s.workspace) return
+      const env = envByName(s.workspace, environment)
+      const host = env ? nodeById(env, hostNodeId) : undefined
+      if (!host) return
+      pushUndoSnapshot(s)
+      host.infrastructureNodes.push({
+        id,
+        type: 'infrastructureNode',
+        name: 'New Infrastructure Node',
+        tags: ['Element', 'Infrastructure Node'],
+        properties: {},
+      })
+      refreshDeploymentViews(s.workspace, environment)
+      s.layoutVersion += 1
+      created = true
+    })
+    return created ? id : ''
+  },
+
+  addContainerInstance: (environment, hostNodeId, containerId) => {
+    const id = nanoid(8)
+    let created = false
+    set((s) => {
+      if (!s.workspace) return
+      const ws = s.workspace
+      const env = envByName(ws, environment)
+      const host = env ? nodeById(env, hostNodeId) : undefined
+      const containerExists = ws.model.softwareSystems.some(sys =>
+        sys.containers.some(c => c.id === containerId))
+      if (!host || !containerExists) return
+      pushUndoSnapshot(s)
+      host.containerInstances.push({
+        id,
+        type: 'containerInstance',
+        containerId,
+        tags: ['Container Instance'],
+        properties: {},
+      })
+      refreshDeploymentViews(ws, environment)
+      s.layoutVersion += 1
+      created = true
+    })
+    return created ? id : ''
+  },
+
+  addSoftwareSystemInstance: (environment, hostNodeId, softwareSystemId) => {
+    const id = nanoid(8)
+    let created = false
+    set((s) => {
+      if (!s.workspace) return
+      const ws = s.workspace
+      const env = envByName(ws, environment)
+      const host = env ? nodeById(env, hostNodeId) : undefined
+      if (!host || !ws.model.softwareSystems.some(sys => sys.id === softwareSystemId)) return
+      pushUndoSnapshot(s)
+      host.softwareSystemInstances.push({
+        id,
+        type: 'softwareSystemInstance',
+        softwareSystemId,
+        tags: ['Software System Instance'],
+        properties: {},
+      })
+      refreshDeploymentViews(ws, environment)
+      s.layoutVersion += 1
+      created = true
+    })
+    return created ? id : ''
+  },
+
+  renameDeploymentElement: (environment, id, name) => set((s) => {
+    if (!s.workspace) return
+    const env = envByName(s.workspace, environment)
+    if (!env) return
+    const trimmed = name.trim()
+    if (!trimmed) return
+    let target: { name: string } | undefined
+    walkDeploymentNodes(env, (node) => {
+      if (node.id === id) target = node
+      for (const infra of node.infrastructureNodes) {
+        if (infra.id === id) target = infra
+      }
+    })
+    if (!target || target.name === trimmed) return
+    pushUndoSnapshot(s)
+    target.name = trimmed
+  }),
+})

--- a/src/store/slices/dynamic-step-slice.ts
+++ b/src/store/slices/dynamic-step-slice.ts
@@ -73,9 +73,10 @@ export const createDynamicStepSlice: StateCreator<
       ws.model.relationships.push(created)
       rel = created
       // Non-dynamic views that show both endpoints pick up the new
-      // relationship, same as addRelationship. Dynamic views stay authored.
+      // relationship, same as addRelationship. Dynamic views stay authored;
+      // deployment views derive their edges from the topology.
       for (const v of allViewsOf(ws)) {
-        if (v.type === 'dynamic') continue
+        if (v.type === 'dynamic' || v.type === 'deployment') continue
         const ids = new Set(v.elements.map(e => e.id))
         if (ids.has(sourceId) && ids.has(destinationId) && !v.relationships.some(r => r.id === rel!.id)) {
           v.relationships.push({ id: rel.id })

--- a/src/store/slices/dynamic-step-slice.ts
+++ b/src/store/slices/dynamic-step-slice.ts
@@ -1,0 +1,140 @@
+import type { StateCreator } from 'zustand'
+import type { WorkspaceState } from '../workspace-types'
+import type { Relationship, View, Workspace } from '@/types/model'
+import { nanoid, pushUndoSnapshot } from '../internals'
+import { allViewsOf, elementExists, findViewHelper } from '../workspace-helpers'
+
+/** Sequential renumber + membership recompute after any step edit.
+ *
+ *  Orders regenerate 1..n, which flattens parallel-sequence numbering — the
+ *  editor is a linear list, so an edit is the user restating the sequence as
+ *  linear. Membership is a projection of the steps (steps are all that
+ *  serializes), so elements whose last step died drop out here. */
+function normalizeDynamicView(ws: Workspace, view: View): void {
+  view.relationships.forEach((step, i) => { step.order = String(i + 1) })
+  const endpoints = new Set<string>()
+  for (const step of view.relationships) {
+    const rel = ws.model.relationships.find(r => r.id === step.id)
+    const sourceId = step.sourceId ?? rel?.sourceId
+    const destId = step.destinationId ?? rel?.destinationId
+    if (sourceId) endpoints.add(sourceId)
+    if (destId) endpoints.add(destId)
+  }
+  view.elements = view.elements.filter(e => endpoints.has(e.id))
+}
+
+export type DynamicStepSlice = Pick<WorkspaceState,
+  | 'addDynamicStep' | 'updateDynamicStepDescription'
+  | 'moveDynamicStep' | 'deleteDynamicStep'
+>
+
+export const createDynamicStepSlice: StateCreator<
+  WorkspaceState,
+  [['zustand/immer', never]],
+  [],
+  DynamicStepSlice
+> = (set) => ({
+  addDynamicStep: (viewKey, sourceId, destinationId, description) => set((s) => {
+    if (!s.workspace) return
+    const ws = s.workspace
+    const view = findViewHelper(ws, viewKey)
+    if (!view || view.type !== 'dynamic') return
+    if (sourceId === destinationId) return
+    if (!elementExists(ws, sourceId) || !elementExists(ws, destinationId)) return
+
+    pushUndoSnapshot(s)
+
+    // Resolve the backing relationship the way the DSL parser does, minus
+    // the hierarchy-implied tiers (the picker offers concrete elements):
+    // exact forward, then exact reverse (a response step travelling back
+    // over an existing relationship), else create the relationship.
+    let rel = ws.model.relationships.find(
+      r => r.sourceId === sourceId && r.destinationId === destinationId,
+    )
+    let response = false
+    if (!rel) {
+      const reverse = ws.model.relationships.find(
+        r => r.sourceId === destinationId && r.destinationId === sourceId,
+      )
+      if (reverse) {
+        rel = reverse
+        response = true
+      }
+    }
+    if (!rel) {
+      const created: Relationship = {
+        id: nanoid(8),
+        sourceId,
+        destinationId,
+        description,
+        tags: ['Relationship'],
+        properties: {},
+      }
+      ws.model.relationships.push(created)
+      rel = created
+      // Non-dynamic views that show both endpoints pick up the new
+      // relationship, same as addRelationship. Dynamic views stay authored.
+      for (const v of allViewsOf(ws)) {
+        if (v.type === 'dynamic') continue
+        const ids = new Set(v.elements.map(e => e.id))
+        if (ids.has(sourceId) && ids.has(destinationId) && !v.relationships.some(r => r.id === rel!.id)) {
+          v.relationships.push({ id: rel.id })
+        }
+      }
+    }
+
+    view.relationships.push({
+      id: rel.id,
+      sourceId,
+      destinationId,
+      response: response ? true : undefined,
+      order: String(view.relationships.length + 1),
+      // A description matching the relationship's own is not an override.
+      description: description && description !== rel.description ? description : undefined,
+    })
+    for (const id of [sourceId, destinationId]) {
+      if (!view.elements.some(e => e.id === id)) view.elements.push({ id })
+    }
+    normalizeDynamicView(ws, view)
+    s.layoutVersion += 1
+  }),
+
+  updateDynamicStepDescription: (viewKey, stepIndex, description) => set((s) => {
+    if (!s.workspace) return
+    const view = findViewHelper(s.workspace, viewKey)
+    if (!view || view.type !== 'dynamic') return
+    const step = view.relationships[stepIndex]
+    if (!step) return
+    const rel = s.workspace.model.relationships.find(r => r.id === step.id)
+    const trimmed = description.trim()
+    // Clearing the override falls back to the relationship's description.
+    const next = trimmed && trimmed !== rel?.description ? trimmed : undefined
+    if (step.description === next) return
+    pushUndoSnapshot(s)
+    step.description = next
+  }),
+
+  moveDynamicStep: (viewKey, stepIndex, direction) => set((s) => {
+    if (!s.workspace) return
+    const view = findViewHelper(s.workspace, viewKey)
+    if (!view || view.type !== 'dynamic') return
+    const target = direction === 'up' ? stepIndex - 1 : stepIndex + 1
+    if (stepIndex < 0 || stepIndex >= view.relationships.length) return
+    if (target < 0 || target >= view.relationships.length) return
+    pushUndoSnapshot(s)
+    const steps = view.relationships
+    ;[steps[stepIndex], steps[target]] = [steps[target], steps[stepIndex]]
+    normalizeDynamicView(s.workspace, view)
+  }),
+
+  deleteDynamicStep: (viewKey, stepIndex) => set((s) => {
+    if (!s.workspace) return
+    const view = findViewHelper(s.workspace, viewKey)
+    if (!view || view.type !== 'dynamic') return
+    if (stepIndex < 0 || stepIndex >= view.relationships.length) return
+    pushUndoSnapshot(s)
+    view.relationships.splice(stepIndex, 1)
+    normalizeDynamicView(s.workspace, view)
+    s.layoutVersion += 1
+  }),
+})

--- a/src/store/slices/relationship-slice.ts
+++ b/src/store/slices/relationship-slice.ts
@@ -71,8 +71,10 @@ export const createRelationshipSlice: StateCreator<
       // Dynamic views are exempt: their relationship list is an ORDERED
       // interaction sequence — pushing an unnumbered entry would render a
       // phantom step and serialize it as one the user never authored.
+      // Deployment views are exempt too: their edge set is derived from the
+      // topology at render time, not stored per view.
       for (const view of allViewsOf(ws)) {
-        if (view.type === 'dynamic') continue
+        if (view.type === 'dynamic' || view.type === 'deployment') continue
         const viewElIds = new Set(view.elements.map(e => e.id))
         if (viewElIds.has(sourceId) && viewElIds.has(destinationId)) {
           if (!view.relationships.some(r => r.id === id)) {

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -1,7 +1,7 @@
 import { current, isDraft } from 'immer'
 import type {
   Workspace, View, ModelElement, Person, SoftwareSystem, Container, Component,
-  ViewType, ElementInView,
+  ViewType, ElementInView, DeploymentNode,
 } from '@/types/model'
 import type { CascadeImpact } from './workspace-types'
 import { expandDeploymentElements, walkDeploymentNodes } from '@/lib/deployment'
@@ -136,9 +136,24 @@ export function applyElementPatch(ws: Workspace, id: string, patch: ElementPatch
   return changed
 }
 
-/** True if an element with the given ID exists in the model tree. */
+/** True if an element with the given ID exists in the model tree. Deployment
+ *  elements count too — an explicit relationship may anchor on an
+ *  infrastructure node or instance (e.g. a load balancer routing to a
+ *  container instance), exactly as the DSL allows inside an environment. */
 export function elementExists(ws: Workspace, id: string): boolean {
-  return getElementIndex(ws).has(id)
+  if (getElementIndex(ws).has(id)) return true
+  for (const env of ws.model.deploymentEnvironments ?? []) {
+    let found = false
+    walkDeploymentNodes(env, (node) => {
+      if (found) return
+      if (node.id === id
+        || node.infrastructureNodes.some(i => i.id === id)
+        || node.containerInstances.some(i => i.id === id)
+        || node.softwareSystemInstances.some(i => i.id === id)) found = true
+    })
+    if (found) return true
+  }
+  return false
 }
 
 /** The view-type array keys — used wherever we need to iterate or locate views by type. */
@@ -617,6 +632,45 @@ export function cascadeDeleteElements(ws: Workspace, ids: Iterable<string>): Cas
     })
     return true
   })
+
+  // Deployment elements deleted directly (an instance or infrastructure node
+  // by id, or a deployment node — which takes its whole subtree with it).
+  const collectSubtree = (node: DeploymentNode, into: Set<string>): void => {
+    into.add(node.id)
+    for (const inst of node.containerInstances) into.add(inst.id)
+    for (const inst of node.softwareSystemInstances) into.add(inst.id)
+    for (const infra of node.infrastructureNodes) into.add(infra.id)
+    for (const child of node.children) collectSubtree(child, into)
+  }
+  const removedDeploymentIds = new Set<string>()
+  const pruneNodes = (nodes: DeploymentNode[]): DeploymentNode[] =>
+    nodes.filter((node) => {
+      if (idSet.has(node.id)) {
+        collectSubtree(node, removedDeploymentIds)
+        return false
+      }
+      node.children = pruneNodes(node.children)
+      node.infrastructureNodes = node.infrastructureNodes.filter((infra) => {
+        if (!idSet.has(infra.id)) return true
+        removedDeploymentIds.add(infra.id)
+        return false
+      })
+      node.containerInstances = node.containerInstances.filter((inst) => {
+        if (!idSet.has(inst.id)) return true
+        removedDeploymentIds.add(inst.id)
+        return false
+      })
+      node.softwareSystemInstances = node.softwareSystemInstances.filter((inst) => {
+        if (!idSet.has(inst.id)) return true
+        removedDeploymentIds.add(inst.id)
+        return false
+      })
+      return true
+    })
+  for (const env of ws.model.deploymentEnvironments ?? []) {
+    env.deploymentNodes = pruneNodes(env.deploymentNodes)
+  }
+  for (const id of removedDeploymentIds) allDeletedIds.add(id)
 
   // Deployment instances of deleted containers/systems die with them, and
   // the instances' own ids then cascade through relationships and view refs —

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -163,6 +163,15 @@ export interface WorkspaceState extends UndoState {
   moveDynamicStep: (viewKey: string, stepIndex: number, direction: 'up' | 'down') => void
   deleteDynamicStep: (viewKey: string, stepIndex: number) => void
 
+  // Deployment topology authoring. Views of the environment recompute their
+  // membership (same expansion `include *` parses to), keeping positions of
+  // surviving elements; all return the new element's id, or '' on no-op.
+  addDeploymentNode: (environment: string, parentNodeId: string | null) => string
+  addInfrastructureNode: (environment: string, hostNodeId: string) => string
+  addContainerInstance: (environment: string, hostNodeId: string, containerId: string) => string
+  addSoftwareSystemInstance: (environment: string, hostNodeId: string, softwareSystemId: string) => string
+  renameDeploymentElement: (environment: string, id: string, name: string) => void
+
   // View management
   addView: (type: ViewType, scopeId?: string, title?: string, options?: { environment?: string }) => string
   deleteView: (key: string) => void

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -155,6 +155,14 @@ export interface WorkspaceState extends UndoState {
   reconnectRelationship: (id: string, newSourceId: string, newTargetId: string) => void
   deleteRelationship: (id: string) => void
 
+  // Dynamic view steps. Edits renumber the sequence 1..n (an edit through
+  // the linear editor flattens any parallel-sequence numbering) and
+  // recompute the view's derived element membership.
+  addDynamicStep: (viewKey: string, sourceId: string, destinationId: string, description?: string) => void
+  updateDynamicStepDescription: (viewKey: string, stepIndex: number, description: string) => void
+  moveDynamicStep: (viewKey: string, stepIndex: number, direction: 'up' | 'down') => void
+  deleteDynamicStep: (viewKey: string, stepIndex: number) => void
+
   // View management
   addView: (type: ViewType, scopeId?: string, title?: string, options?: { environment?: string }) => string
   deleteView: (key: string) => void

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -12,6 +12,7 @@ import { createViewSlice } from './slices/view-slice'
 import { createTagStyleSlice } from './slices/tag-style-slice'
 import { createUndoSlice } from './slices/undo-slice'
 import { createLifecycleSlice } from './slices/lifecycle-slice'
+import { createDynamicStepSlice } from './slices/dynamic-step-slice'
 
 export type { WorkspaceState, UndoState } from './workspace-types'
 export { BUILTIN_TAGS } from './builtin-tags'
@@ -50,6 +51,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     ...createGroupSlice(...a),
     ...createRelationshipSlice(...a),
     ...createViewSlice(...a),
+    ...createDynamicStepSlice(...a),
     ...createTagStyleSlice(...a),
     ...createUndoSlice(...a),
   })),

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -13,6 +13,7 @@ import { createTagStyleSlice } from './slices/tag-style-slice'
 import { createUndoSlice } from './slices/undo-slice'
 import { createLifecycleSlice } from './slices/lifecycle-slice'
 import { createDynamicStepSlice } from './slices/dynamic-step-slice'
+import { createDeploymentSlice } from './slices/deployment-slice'
 
 export type { WorkspaceState, UndoState } from './workspace-types'
 export { BUILTIN_TAGS } from './builtin-tags'
@@ -52,6 +53,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     ...createRelationshipSlice(...a),
     ...createViewSlice(...a),
     ...createDynamicStepSlice(...a),
+    ...createDeploymentSlice(...a),
     ...createTagStyleSlice(...a),
     ...createUndoSlice(...a),
   })),


### PR DESCRIPTION
Part of the TEA-81 follow-up chain, stacked on #146. Linear: TEA-237.

## What ships

The add panel on a dynamic view is now a step editor:

- **Ordered step list** — number badge, `Source → Destination`, response indicator, description (falls back to the relationship's own); clicking a row selects the backing relationship on the canvas.
- **Add step** — source/destination pickers restricted to what the real Structurizr parser accepts for the view's scope (verified against CLI v2025.11.09: unscoped = people + systems; system-scoped adds containers; container-scoped adds the scoped container's components). Picking the reverse of an existing relationship authors a **response step**; a pair with no relationship **creates one** in the model and syncs it into non-dynamic views showing both endpoints (dynamic views stay authored).
- **Reorder / delete** — sequence renumbers 1..n, element membership recomputes from the surviving steps (membership is a projection of steps — orphan endpoints drop out). Editing through the linear editor flattens parallel-sequence numbering, by design.
- **Inline description override** — click a step's description to edit; setting it to the relationship's own description clears the override.
- All edits push undo snapshots and serialize losslessly (round-trip test included).

## Verification

- `npm run check` — 2346 unit tests (10 new store tests: forward/reverse/create resolution, renumbering, membership pruning, undo, serialize round-trip, scope rules), lint, typecheck, build.
- Full e2e — 173 passed, 1 pre-existing skip. New spec drives the editor through the real flyout: add a response step, watch the canvas badge appear, reorder, delete, inline-edit a description and see it on the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtCDHm2tr5v9bGcTxs2xct