### PR TITLE
feat(compare): diff the open workspace against another revision (TEA-82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Compare against another revision.** Pick any other `.dsl` file — an older
+  copy, a branch checkout, a teammate's export — and c4hero shows exactly what
+  the architecture gained, lost and changed: elements, relationships, view
+  membership and workspace metadata, each with its before/after value. Added
+  nodes ring green on the canvas and changed nodes ring amber while untouched
+  ones recede, so the change set reads at a glance; click any entry to jump
+  straight to it. The comparison stays live while you edit, and the compared
+  file is strictly read-only — it never becomes the save target. Open it from
+  the menu or the command palette ("Compare with another revision"). (TEA-82)
 - **Lock a whole view's layout.** One switch in the Auto-arrange menu freezes
   the active view: Auto-arrange and layout-direction changes become no-ops and
   nothing can be dragged — not even by accident. Element locks keep working

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -24,6 +24,23 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 - **Recent collections / files** are remembered in `localStorage` and re-openable from the welcome screen.
 - **Crash recovery**: the active workspace is mirrored to `localStorage`. If the tab crashes or you close it mid-edit, the next launch offers to restore.
 
+## Revision comparison
+
+- **Compare against another revision.** Point c4hero at any other `.dsl` file —
+  an older copy, a branch checkout, a teammate's export — and see exactly what
+  the architecture gained, lost and changed: elements, relationships, view
+  membership and workspace metadata, each with the before/after value.
+- **On the canvas, not just in a list.** Added nodes ring green, changed nodes
+  ring amber, untouched ones recede, and edges follow the same code. Click any
+  entry in the list to jump to it on the diagram.
+- **Live.** The comparison stays running while you edit, so the change set and
+  the canvas tint update as you work. A marker in the top-left names the
+  revision you're comparing against and clears it in one click.
+- **Read-only and safe.** The compared file is never written to, never becomes
+  the save target, and never lands in your recent files.
+- Matching is structural, not textual: renaming a DSL identifier or an element
+  reads as a change, not as a delete plus an add.
+
 ## Editing UX
 
 - **Inspector** (right panel) for element and relationship properties: name, description, technology, owner (with autocomplete from existing teams), URL, status, tags.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import ConfirmDeleteDialog from '@/components/shared/ConfirmDeleteDialog'
 import ZoomConfirmDialog from '@/components/shared/ZoomConfirmDialog'
 import Canvas from '@/components/canvas/Canvas'
 import CanvasHints from '@/components/canvas/CanvasHints'
+import CompareBar from '@/components/compare/CompareBar'
 import ErrorBoundary from '@/components/shared/ErrorBoundary'
 import NotFound from '@/components/shared/NotFound'
 import { loadFromLocalStorage } from '@/lib/fileIO'
@@ -27,6 +28,7 @@ import { isCanvasRoute } from '@/lib/routes'
 const SearchDialog = lazy(() => import('@/components/search/SearchDialog'))
 const WelcomeScreen = lazy(() => import('@/components/welcome/WelcomeScreen'))
 const AiPanel = lazy(() => import('@/components/ai/AiPanel'))
+const CompareDialog = lazy(() => import('@/components/compare/CompareDialog'))
 
 export default function App() {
   const workspace = useWorkspaceStore((s) => s.workspace)
@@ -37,6 +39,7 @@ export default function App() {
   const aiPanelOpen = useWorkspaceStore((s) => s.aiPanelOpen)
   const setAiPanelOpen = useWorkspaceStore((s) => s.setAiPanelOpen)
   const aiSettingsOpen = useWorkspaceStore((s) => s.aiSettingsOpen)
+  const comparisonPanelOpen = useWorkspaceStore((s) => s.comparisonPanelOpen)
   const setAiSettingsOpen = useWorkspaceStore((s) => s.setAiSettingsOpen)
   const loadWorkspace = useWorkspaceStore((s) => s.loadWorkspace)
   const navigate = useNavigate()
@@ -90,6 +93,7 @@ export default function App() {
         <FloatingBottomStrip />
         <FloatingZoomHud />
         <CanvasHints />
+        <CompareBar />
         <div id="c4hero-live" aria-live="polite" aria-atomic="true" className="sr-only" />
         <div className="commit-hash">v{__APP_VERSION__} · {__COMMIT_HASH__}</div>
       </div>
@@ -165,6 +169,14 @@ export default function App() {
       {/* Zoom-in confirm — shown when a user clicks zoom on an element with
           no existing child view. Offers fast create or "Customize…" for full control. */}
       <ZoomConfirmDialog />
+
+      {/* Revision comparison — the picker and the change list. Rendered outside
+          the canvas element so it survives a view switch mid-review. */}
+      {onCanvas && comparisonPanelOpen && (
+        <Suspense fallback={<LoadingDot />}>
+          <CompareDialog />
+        </Suspense>
+      )}
 
       {/* BYOK AI assistant — only on the canvas (a workspace open on a canvas
           route), never on the welcome/collection screens. */}

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -15,6 +15,7 @@ import {
   reconnectEdge,
 } from '@xyflow/react'
 import { applyAutoLayout } from '@/lib/canvasLayout'
+import { diffWorkspacesCached } from '@/lib/workspaceDiff'
 import { fitNodesToViewport, isContentFitNode } from '@/lib/fitViewport'
 import { saveViewport, loadViewport } from '@/lib/viewportStorage'
 import type { HighlightFilters } from '@/lib/highlight'
@@ -36,6 +37,7 @@ import RelationshipEdge from './edges/RelationshipEdge'
 import {
   buildNodes,
   buildEdges,
+  type DiffOverlay,
   buildGroupNodes,
   buildBoundaryNodes,
   buildDrillableSet,
@@ -186,6 +188,8 @@ export default function Canvas() {
   const techFilterMode = useWorkspaceStore((s) => s.techFilterMode)
   const teamFilterMode = useWorkspaceStore((s) => s.teamFilterMode)
   const layoutVersion = useWorkspaceStore((s) => s.layoutVersion)
+  const comparisonBase = useWorkspaceStore((s) => s.comparisonBase)
+  const comparisonOverlay = useWorkspaceStore((s) => s.comparisonOverlay)
   const canvasGuideOpen = useWorkspaceStore((s) => s.canvasGuideOpen)
   const setCanvasGuideOpen = useWorkspaceStore((s) => s.setCanvasGuideOpen)
 
@@ -199,6 +203,16 @@ export default function Canvas() {
     techsMode: techFilterMode,
     teamsMode: teamFilterMode,
   }), [activeTagFilter, activeStatusFilter, activeTechFilter, activeTeamFilter, tagFilterMode, statusFilterMode, techFilterMode, teamFilterMode])
+
+  // Comparison overlay: derived from the base revision and the live workspace,
+  // so every edit re-tints the canvas without any stale-diff bookkeeping. The
+  // diff itself is memoized on the two workspace identities, so the compare
+  // panel showing the same comparison costs nothing extra.
+  const diffOverlay = useMemo<DiffOverlay | null>(() => {
+    if (!comparisonBase || !comparisonOverlay || !workspace) return null
+    const diff = diffWorkspacesCached(comparisonBase, workspace)
+    return { elements: diff.elementStatus, relationships: diff.relationshipStatus }
+  }, [comparisonBase, comparisonOverlay, workspace])
 
   const minimapMode = useSettingsStore((s) => s.minimapMode)
   const snapToGrid = useSettingsStore((s) => s.snapToGrid)
@@ -335,7 +349,7 @@ export default function Canvas() {
 
     // 1. Build nodes with raw positions from view
     const drillableIds = buildDrillableSet(workspace)
-    const rawNodes = buildNodes(workspace, view, stableDrillInto, highlightFilters, viewCountMap, drillableIds, themeStyles)
+    const rawNodes = buildNodes(workspace, view, stableDrillInto, highlightFilters, viewCountMap, drillableIds, themeStyles, diffOverlay)
     const layoutNodes = carryForwardMeasurements(rawNodes, reactFlowInstance.getNodes())
 
     // 2. Build temporary edges (just source/target, no handles yet) for dagre
@@ -364,10 +378,10 @@ export default function Canvas() {
     const allNodes = [...overlayNodes, ...laidOut]
 
     // 5. Build final edges using post-layout positions for handle routing
-    const edges = buildEdges(workspace, view, allNodes, highlightFilters)
+    const edges = buildEdges(workspace, view, allNodes, highlightFilters, diffOverlay)
 
     return { initialNodes: allNodes, initialEdges: edges }
-  }, [workspace, view, stableDrillInto, highlightFilters, viewCountMap, themeStyles, reactFlowInstance])
+  }, [workspace, view, stableDrillInto, highlightFilters, viewCountMap, themeStyles, reactFlowInstance, diffOverlay])
 
   // Canonicalize the initial dagre layout: write computed positions back to
   // view.elements for any element that doesn't already have a saved x/y.

--- a/src/components/canvas/canvasBuilders.test.ts
+++ b/src/components/canvas/canvasBuilders.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { Node } from '@xyflow/react'
-import { buildEdges, buildNodes } from './canvasBuilders'
+import { buildEdges, buildNodes, type DiffOverlay } from './canvasBuilders'
 import { handleSide, handleSlot } from './handleSlots'
 import type { HighlightFilters } from '@/lib/highlight'
 import { THEMES } from '@/lib/themes'
@@ -182,5 +182,91 @@ describe('buildEdges handle routing', () => {
         expect(handleSlot(handle!)).not.toBeNull()
       }
     }
+  })
+})
+
+/** Two systems plus the relationship between them, so the overlay has one of
+ *  each thing it can tint. */
+function diffWorkspace(): Workspace {
+  return {
+    name: 'Diff test',
+    model: {
+      people: [],
+      softwareSystems: [
+        { id: 'a', type: 'softwareSystem', name: 'A', tags: ['Element', 'Software System'], properties: {}, containers: [] },
+        { id: 'b', type: 'softwareSystem', name: 'B', tags: ['Element', 'Software System'], properties: {}, containers: [] },
+      ],
+      relationships: [
+        { id: 'rel', sourceId: 'a', destinationId: 'b', tags: ['Relationship'], properties: {} },
+      ],
+      groups: [],
+    },
+    views: {
+      systemLandscapeViews: [
+        {
+          type: 'systemLandscape',
+          key: 'landscape',
+          elements: [{ id: 'a', x: 0, y: 0 }, { id: 'b', x: 400, y: 0 }],
+          relationships: [{ id: 'rel' }],
+        },
+      ],
+      systemContextViews: [],
+      containerViews: [],
+      componentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+function diffNodes(overlay: DiffOverlay | null) {
+  const ws = diffWorkspace()
+  return buildNodes(
+    ws, ws.views.systemLandscapeViews[0], () => {}, NO_FILTERS, new Map(), new Set(), THEMES.structurizr, overlay,
+  )
+}
+
+function diffEdges(overlay: DiffOverlay | null) {
+  const ws = diffWorkspace()
+  const nodes = diffNodes(overlay)
+  return buildEdges(ws, ws.views.systemLandscapeViews[0], nodes, NO_FILTERS, overlay)
+}
+
+describe('comparison overlay', () => {
+  const overlay: DiffOverlay = {
+    elements: new Map([['a', 'added' as const]]),
+    relationships: new Map([['rel', 'changed' as const]]),
+  }
+
+  it('leaves nodes and edges untouched when no comparison is running', () => {
+    expect(diffNodes(null).map((n) => n.className)).toEqual([undefined, undefined])
+    expect(diffEdges(null)[0].className).toBeUndefined()
+    expect(diffNodes(null)[0].data.diffStatus).toBeUndefined()
+  })
+
+  it('marks changed nodes and quiets the rest', () => {
+    const nodes = diffNodes(overlay)
+    expect(nodes[0].className).toBe('c4-node-diff-added')
+    expect(nodes[0].data.diffStatus).toBe('added')
+    expect(nodes[1].className).toBe('c4-node-diff-same')
+    expect(nodes[1].data.diffStatus).toBeUndefined()
+  })
+
+  it('marks changed edges and quiets the rest', () => {
+    expect(diffEdges(overlay)[0].className).toBe('c4-edge-diff-changed')
+    expect(diffEdges(overlay)[0].data!.diffStatus).toBe('changed')
+    const untouched = diffEdges({ elements: new Map(), relationships: new Map() })
+    expect(untouched[0].className).toBe('c4-edge-diff-same')
+  })
+
+  it('composes with the highlighter instead of replacing it', () => {
+    const ws = diffWorkspace()
+    ws.model.softwareSystems[0].tags.push('Critical')
+    const nodes = buildNodes(
+      ws, ws.views.systemLandscapeViews[0], () => {},
+      { tags: ['Critical'], statuses: [], techs: [], teams: [] },
+      new Map(), new Set(), THEMES.structurizr, overlay,
+    )
+    expect(nodes[0].className).toBe('c4-node-highlighted c4-node-diff-added')
+    expect(nodes[1].className).toBe('c4-node-faded c4-node-diff-same')
   })
 })

--- a/src/components/canvas/canvasBuilders.ts
+++ b/src/components/canvas/canvasBuilders.ts
@@ -10,6 +10,21 @@ import {
 import { CENTER_SLOT, handleId, pickSlots, type Side } from './handleSlots'
 import type { ModelElement, ElementStyle, RelationshipStyle, View, Workspace } from '@/types/model'
 
+/** Per-id diff status handed to the canvas while a revision comparison is
+ *  active. Only ids present in the *current* workspace can appear — elements
+ *  that a later revision removed have no node to tint, so the compare panel
+ *  lists them instead. */
+export interface DiffOverlay {
+  elements: Map<string, 'added' | 'changed'>
+  relationships: Map<string, 'added' | 'changed'>
+}
+
+/** Class marking a node/edge that the comparison left untouched, so changes
+ *  read against a quieter background. */
+function diffClass(prefix: 'c4-node' | 'c4-edge', status: 'added' | 'changed' | undefined): string {
+  return status ? `${prefix}-diff-${status}` : `${prefix}-diff-same`
+}
+
 /** Build a tag → style index from the styles array (O(S) once, then O(1) lookups) */
 function buildStyleIndex(styles: ElementStyle[]): Map<string, ElementStyle> {
   const map = new Map<string, ElementStyle>()
@@ -149,6 +164,7 @@ export function buildNodes(
   viewCountMap: Map<string, number>,
   drillableIds: Set<string>,
   themeStyles: ElementStyle[],
+  diff?: DiffOverlay | null,
 ): Node[] {
   const elementMap = buildElementMap(workspace)
   // Theme styles form the base layer. Truly custom workspace styles still
@@ -169,6 +185,13 @@ export function buildNodes(
     const style = getElementStyle(element, styleIndex)
     const highlighted = active && isHighlighted(element, filters)
     const pos = { x: viewEl.x ?? 0, y: viewEl.y ?? 0 }
+    const diffStatus = diff?.elements.get(element.id)
+
+    // Highlighter focus mode and the comparison overlay are independent
+    // treatments and can be on at the same time, so classes compose.
+    const classNames: string[] = []
+    if (active) classNames.push(highlighted ? 'c4-node-highlighted' : 'c4-node-faded')
+    if (diff) classNames.push(diffClass('c4-node', diffStatus))
 
     nodes.push({
       id: element.id,
@@ -183,6 +206,7 @@ export function buildNodes(
         highlighted,
         viewCount: viewCountMap.get(element.id) ?? 1,
         locked: viewEl.locked === true,
+        diffStatus,
       },
       // A locked node holds its place against Auto-arrange, so it should hold it
       // against a stray drag too. A locked VIEW freezes every node the same way.
@@ -190,7 +214,7 @@ export function buildNodes(
       // Highlighter focus mode: matched nodes get the highlighted ring; the rest
       // fade to ghost context. When no facets are active, every node renders
       // normally (no class either way).
-      className: active ? (highlighted ? 'c4-node-highlighted' : 'c4-node-faded') : undefined,
+      className: classNames.length > 0 ? classNames.join(' ') : undefined,
     })
   }
 
@@ -492,6 +516,7 @@ export function buildEdges(
   view: View,
   nodes: Node[],
   filters: HighlightFilters,
+  diff?: DiffOverlay | null,
 ): Edge[] {
   const relationshipMap = buildRelationshipMap(workspace)
   const relationshipStyles = workspace.views.configuration.styles.relationships
@@ -589,9 +614,11 @@ export function buildEdges(
     const highlighted = techHighlighted || (active && endpointsHighlighted)
     const faded = active && !highlighted
 
-    let className: string | undefined
-    if (highlighted) className = 'c4-edge-highlighted'
-    else if (faded) className = 'c4-edge-faded'
+    const classNames: string[] = []
+    if (highlighted) classNames.push('c4-edge-highlighted')
+    else if (faded) classNames.push('c4-edge-faded')
+    const diffStatus = diff?.relationships.get(e.rel.id)
+    if (diff) classNames.push(diffClass('c4-edge', diffStatus))
 
     edges.push({
       id: e.rel.id,
@@ -600,8 +627,8 @@ export function buildEdges(
       sourceHandle: handleId(e.sourceSide, srcSlot, 'source'),
       targetHandle: handleId(e.targetSide, tgtSlot, 'target'),
       type: 'relationship',
-      data: { relationship: e.rel, relationshipStyle: e.relStyle, highlighted },
-      className,
+      data: { relationship: e.rel, relationshipStyle: e.relStyle, highlighted, diffStatus },
+      className: classNames.length > 0 ? classNames.join(' ') : undefined,
     })
   }
 

--- a/src/components/canvas/nodes/BaseC4Node.tsx
+++ b/src/components/canvas/nodes/BaseC4Node.tsx
@@ -125,6 +125,17 @@ export default function BaseC4Node({
       aria-selected={selected}
     >
       <StatusDot status={element.status} />
+      {data.diffStatus && (
+        <span
+          className={`c4-node-diff-badge c4-node-diff-badge-${data.diffStatus}`}
+          role="img"
+          aria-label={data.diffStatus === 'added'
+            ? `${element.name} is new in this revision`
+            : `${element.name} changed in this revision`}
+        >
+          {data.diffStatus === 'added' ? 'New' : 'Changed'}
+        </span>
+      )}
       {elementViolations.length > 0 && (
         <span
           className="c4-node-violation"

--- a/src/components/canvas/nodes/types.ts
+++ b/src/components/canvas/nodes/types.ts
@@ -11,4 +11,8 @@ export interface C4NodeData {
   highlighted?: boolean
   /** True when the user has locked this node in place. */
   locked?: boolean
+  /** Set while a revision comparison is active: how this element differs from
+   *  the compared-against revision. Absent when it is unchanged, or when no
+   *  comparison is running. */
+  diffStatus?: 'added' | 'changed'
 }

--- a/src/components/compare/CompareBar.test.tsx
+++ b/src/components/compare/CompareBar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import CompareBar from './CompareBar'
+import { useWorkspaceStore } from '@/store/workspace'
+import { makeWorkspace } from '@/lib/ai/testFixture'
+
+function state() {
+  return useWorkspaceStore.getState()
+}
+
+describe('CompareBar', () => {
+  beforeEach(() => {
+    state().loadWorkspace(makeWorkspace())
+  })
+
+  it('stays out of the way when no comparison is running', () => {
+    const { container } = render(<CompareBar />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('stays hidden while the compare panel itself is open', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    const { container } = render(<CompareBar />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('names the revision and summarizes the diff once the panel closes', () => {
+    const base = makeWorkspace()
+    state().startComparison(base, 'v1.dsl')
+    state().setComparisonPanelOpen(false)
+    state().addPerson('Ops Engineer')
+
+    render(<CompareBar />)
+    expect(screen.getByText('vs v1.dsl')).toBeTruthy()
+    expect(screen.getByText('1 added')).toBeTruthy()
+  })
+
+  it('reopens the panel when the summary is clicked', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().setComparisonPanelOpen(false)
+    render(<CompareBar />)
+
+    fireEvent.click(screen.getByText('vs v1.dsl'))
+    expect(state().comparisonPanelOpen).toBe(true)
+  })
+
+  it('clears the comparison from the dismiss button', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().setComparisonPanelOpen(false)
+    render(<CompareBar />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop comparing revisions' }))
+    expect(state().comparisonBase).toBeNull()
+  })
+
+  it('reserves top chrome space so zoom-to-fit does not tuck the diagram behind it', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().setComparisonPanelOpen(false)
+    const { container } = render(<CompareBar />)
+    expect((container.firstChild as HTMLElement).getAttribute('data-canvas-fit-chrome')).toBe('top')
+  })
+})

--- a/src/components/compare/CompareBar.tsx
+++ b/src/components/compare/CompareBar.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react'
+import { GitCompare, X } from 'lucide-react'
+import { useWorkspaceStore } from '@/store/workspace'
+import { announce } from '@/lib/announce'
+import { diffWorkspacesCached, formatDiffSummary } from '@/lib/workspaceDiff'
+
+/** Persistent marker shown while a revision comparison is running and the
+ *  compare panel is closed. Without it, a tinted canvas would have no
+ *  explanation and no way out. Sits top-left, clear of the centered top pill. */
+export default function CompareBar() {
+  const workspace = useWorkspaceStore((s) => s.workspace)
+  const comparisonBase = useWorkspaceStore((s) => s.comparisonBase)
+  const comparisonLabel = useWorkspaceStore((s) => s.comparisonLabel)
+  const panelOpen = useWorkspaceStore((s) => s.comparisonPanelOpen)
+  const setComparisonPanelOpen = useWorkspaceStore((s) => s.setComparisonPanelOpen)
+  const clearComparison = useWorkspaceStore((s) => s.clearComparison)
+
+  const diff = useMemo(
+    () => (comparisonBase && workspace ? diffWorkspacesCached(comparisonBase, workspace) : null),
+    [comparisonBase, workspace],
+  )
+
+  if (!diff || panelOpen) return null
+
+  return (
+    <div
+      data-canvas-chrome="compare-bar"
+      data-canvas-fit-chrome="top"
+      className="glass-panel"
+      style={{
+        position: 'fixed',
+        top: 'max(14px, calc(env(safe-area-inset-top, 0px) + 8px))',
+        left: 14,
+        zIndex: 50,
+        height: 44,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '0 6px 0 10px',
+        maxWidth: 'min(340px, 40vw)',
+      }}
+    >
+      <GitCompare size={14} style={{ color: 'var(--color-text-secondary)', flexShrink: 0 }} aria-hidden="true" />
+      <button
+        type="button"
+        onClick={() => setComparisonPanelOpen(true)}
+        className="hover-subtle"
+        title={`Comparing against ${comparisonLabel ?? 'another revision'}`}
+        style={{
+          minWidth: 0,
+          textAlign: 'left',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '2px 4px',
+          borderRadius: 'var(--radius-sm)',
+        }}
+      >
+        <span
+          style={{
+            display: 'block',
+            fontSize: 'var(--text-xs)',
+            color: 'var(--color-text-primary)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          vs {comparisonLabel}
+        </span>
+        <span style={{ display: 'block', fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
+          {formatDiffSummary(diff)}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => { clearComparison(); announce('Comparison cleared') }}
+        aria-label="Stop comparing revisions"
+        title="Stop comparing"
+        className="hover-subtle"
+        style={{
+          flexShrink: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 26,
+          height: 26,
+          borderRadius: 'var(--radius-sm)',
+          border: '1px solid var(--color-border)',
+          background: 'var(--color-surface-2)',
+          color: 'var(--color-text-secondary)',
+          cursor: 'pointer',
+        }}
+      >
+        <X size={13} />
+      </button>
+    </div>
+  )
+}

--- a/src/components/compare/CompareDialog.test.tsx
+++ b/src/components/compare/CompareDialog.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import CompareDialog from './CompareDialog'
+import { useWorkspaceStore } from '@/store/workspace'
+import { openComparisonFile } from '@/lib/fileIO'
+import { parseDSL } from '@/lib/dsl'
+import type { Workspace } from '@/types/model'
+
+vi.mock('@/lib/fileIO', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/fileIO')>()),
+  openComparisonFile: vi.fn(),
+}))
+
+const openMock = vi.mocked(openComparisonFile)
+
+const V1 = `
+workspace "Shop" {
+  model {
+    cust = person "Customer" "Buys things"
+    shop = softwareSystem "Shop" "The store" {
+      web = container "Web App" "Storefront UI" "React"
+    }
+    cust -> web "Browses"
+  }
+  views {
+    container shop "Containers" { include * }
+  }
+}`
+
+function state() {
+  return useWorkspaceStore.getState()
+}
+
+/** The `V1` DSL above, as the in-memory model the store would hold. */
+function headWorkspace(): Workspace {
+  return {
+    name: 'Shop',
+    model: {
+      people: [{ id: 'cust', type: 'person', name: 'Customer', description: 'Buys things', tags: [], properties: {} }],
+      softwareSystems: [{
+        id: 'shop', type: 'softwareSystem', name: 'Shop', description: 'The store', tags: [], properties: {},
+        containers: [{
+          id: 'web', type: 'container', name: 'Web App', description: 'Storefront UI',
+          technology: 'React', tags: [], properties: {}, components: [],
+        }],
+      }],
+      relationships: [{ id: 'r1', sourceId: 'cust', destinationId: 'web', description: 'Browses', tags: [], properties: {} }],
+      groups: [],
+      deploymentEnvironments: [],
+    },
+    views: {
+      systemLandscapeViews: [],
+      systemContextViews: [],
+      containerViews: [{
+        type: 'container', key: 'Containers', title: 'Containers', softwareSystemId: 'shop',
+        elements: [{ id: 'web' }, { id: 'cust' }], relationships: [{ id: 'r1' }],
+      }],
+      componentViews: [],
+      dynamicViews: [],
+      deploymentViews: [],
+      configuration: { styles: { elements: [], relationships: [] } },
+    },
+  }
+}
+
+describe('CompareDialog', () => {
+  beforeEach(() => {
+    openMock.mockReset()
+    state().loadWorkspace(headWorkspace())
+  })
+
+  it('offers to pick a revision when nothing is being compared', () => {
+    render(<CompareDialog />)
+    expect(screen.getByRole('button', { name: /Choose a .dsl file/i })).toBeTruthy()
+  })
+
+  it('parses the picked revision and starts the comparison', async () => {
+    // Compare the parsed DSL against itself — the round-trip a user gets when
+    // they pick the file they are already editing.
+    state().loadWorkspace(parseDSL(V1).workspace)
+    openMock.mockResolvedValue({ content: V1, name: 'v1.dsl' })
+    render(<CompareDialog />)
+    fireEvent.click(screen.getByRole('button', { name: /Choose a .dsl file/i }))
+
+    await waitFor(() => expect(state().comparisonLabel).toBe('v1.dsl'))
+    expect(state().comparisonBase!.model.people[0].name).toBe('Customer')
+    await screen.findByText(/These two revisions describe the same model/i)
+  })
+
+  it('leaves the comparison alone when the picker is cancelled', async () => {
+    openMock.mockResolvedValue(null)
+    render(<CompareDialog />)
+    fireEvent.click(screen.getByRole('button', { name: /Choose a .dsl file/i }))
+    await waitFor(() => expect(openMock).toHaveBeenCalled())
+    expect(state().comparisonBase).toBeNull()
+  })
+
+  it('reports a file it cannot read instead of comparing against nothing', async () => {
+    openMock.mockResolvedValue({ content: 'this is not a workspace {{{', name: 'broken.dsl' })
+    render(<CompareDialog />)
+    fireEvent.click(screen.getByRole('button', { name: /Choose a .dsl file/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/broken\.dsl/)
+    expect(state().comparisonBase).toBeNull()
+  })
+
+  it('lists added, removed and changed items against the picked revision', async () => {
+    const base = headWorkspace()
+    // Head gains a container, drops the person, and re-techs the web app.
+    const head = headWorkspace()
+    head.model.people = []
+    head.model.relationships = []
+    head.model.softwareSystems[0].containers[0].technology = 'Svelte'
+    head.model.softwareSystems[0].containers.push({
+      id: 'api', type: 'container', name: 'API', tags: [], properties: {}, components: [],
+    })
+    head.views.containerViews[0].elements = [{ id: 'web' }, { id: 'api' }]
+    head.views.containerViews[0].relationships = []
+    state().loadWorkspace(head)
+    state().startComparison(base, 'v1.dsl')
+
+    render(<CompareDialog />)
+
+    const elements = screen.getByRole('region', { name: 'Elements' })
+    expect(within(elements).getByText('Shop / API')).toBeTruthy()
+    expect(within(elements).getByText('Customer')).toBeTruthy()
+    expect(within(elements).getByText('React')).toBeTruthy()
+    expect(within(elements).getByText('Svelte')).toBeTruthy()
+
+    const relationships = screen.getByRole('region', { name: 'Relationships' })
+    expect(within(relationships).getByText(/Customer/)).toBeTruthy()
+
+    expect(screen.getByRole('region', { name: 'Views' })).toBeTruthy()
+  })
+
+  it('jumps to an element that still exists and closes on the way', () => {
+    const base = headWorkspace()
+    base.model.softwareSystems[0].containers[0].technology = 'Vue'
+    state().startComparison(base, 'v1.dsl')
+    render(<CompareDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Show Web App on the canvas/i }))
+    expect(state().selectedElementIds).toEqual(['web'])
+    expect(state().comparisonPanelOpen).toBe(false)
+  })
+
+  it('does not offer a jump for an element the current revision no longer has', () => {
+    const base = headWorkspace()
+    base.model.softwareSystems[0].containers.push({
+      id: 'legacy', type: 'container', name: 'Legacy Batch', tags: [], properties: {}, components: [],
+    })
+    state().startComparison(base, 'v1.dsl')
+    render(<CompareDialog />)
+
+    expect(screen.getByText('Shop / Legacy Batch')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Show Legacy Batch on the canvas/i })).toBeNull()
+  })
+
+  it('toggles the canvas overlay from the footer', () => {
+    state().startComparison(headWorkspace(), 'v1.dsl')
+    render(<CompareDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Canvas highlight on/i }))
+    expect(state().comparisonOverlay).toBe(false)
+    fireEvent.click(screen.getByRole('button', { name: /Canvas highlight off/i }))
+    expect(state().comparisonOverlay).toBe(true)
+  })
+
+  it('stops comparing from the footer', () => {
+    state().startComparison(headWorkspace(), 'v1.dsl')
+    render(<CompareDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop comparing' }))
+    expect(state().comparisonBase).toBeNull()
+  })
+
+  it('closes on Escape without dropping the comparison', () => {
+    state().startComparison(headWorkspace(), 'v1.dsl')
+    render(<CompareDialog />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(state().comparisonPanelOpen).toBe(false)
+    expect(state().comparisonBase).not.toBeNull()
+  })
+
+  it('tracks edits made while the panel is open', async () => {
+    state().startComparison(headWorkspace(), 'v1.dsl')
+    const { rerender } = render(<CompareDialog />)
+    expect(screen.getByText(/These two revisions describe the same model/i)).toBeTruthy()
+
+    state().addPerson('Ops Engineer')
+    rerender(<CompareDialog />)
+
+    await waitFor(() => expect(screen.getByRole('region', { name: 'Elements' })).toBeTruthy())
+    expect(screen.getByText('Ops Engineer')).toBeTruthy()
+  })
+})

--- a/src/components/compare/CompareDialog.tsx
+++ b/src/components/compare/CompareDialog.tsx
@@ -1,0 +1,439 @@
+import { useMemo, useState } from 'react'
+import { ArrowRight, Eye, EyeOff, FileUp, GitCompare, X } from 'lucide-react'
+import DialogShell from '@/components/shared/DialogShell'
+import { useWorkspaceStore } from '@/store/workspace'
+import { openComparisonFile } from '@/lib/fileIO'
+import { parseDSL } from '@/lib/dsl'
+import { announce } from '@/lib/announce'
+import { createLogger } from '@/lib/logger'
+import {
+  diffWorkspacesCached,
+  formatDiffSummary,
+  formatElementPath,
+  type DiffKind,
+  type ElementDiffEntry,
+  type FieldChange,
+  type RelationshipDiffEntry,
+  type ViewDiffEntry,
+} from '@/lib/workspaceDiff'
+
+const log = createLogger('CompareDialog')
+
+const KIND_STYLE: Record<DiffKind, { symbol: string; color: string; label: string }> = {
+  added: { symbol: '+', color: 'var(--color-success)', label: 'Added' },
+  removed: { symbol: '-', color: 'var(--color-error)', label: 'Removed' },
+  changed: { symbol: '~', color: 'var(--color-warning)', label: 'Changed' },
+}
+
+const TYPE_LABEL: Record<ElementDiffEntry['type'], string> = {
+  person: 'Person',
+  softwareSystem: 'Software System',
+  container: 'Container',
+  component: 'Component',
+}
+
+/** Compare the open workspace against another revision of the same `.dsl`.
+ *
+ *  The picked revision is parsed once and kept as the comparison base; the diff
+ *  is derived from it and the live workspace on every render, so the list below
+ *  updates as the user edits. Closing this dialog leaves the comparison running
+ *  — `CompareBar` keeps it visible and offers a way out. */
+export default function CompareDialog() {
+  const workspace = useWorkspaceStore((s) => s.workspace)
+  const comparisonBase = useWorkspaceStore((s) => s.comparisonBase)
+  const comparisonLabel = useWorkspaceStore((s) => s.comparisonLabel)
+  const comparisonOverlay = useWorkspaceStore((s) => s.comparisonOverlay)
+  const startComparison = useWorkspaceStore((s) => s.startComparison)
+  const clearComparison = useWorkspaceStore((s) => s.clearComparison)
+  const setComparisonPanelOpen = useWorkspaceStore((s) => s.setComparisonPanelOpen)
+  const setComparisonOverlay = useWorkspaceStore((s) => s.setComparisonOverlay)
+  const focusViewForElements = useWorkspaceStore((s) => s.focusViewForElements)
+  const selectElements = useWorkspaceStore((s) => s.selectElements)
+
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const diff = useMemo(
+    () => (comparisonBase && workspace ? diffWorkspacesCached(comparisonBase, workspace) : null),
+    [comparisonBase, workspace],
+  )
+
+  const close = () => setComparisonPanelOpen(false)
+
+  async function pickRevision() {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const picked = await openComparisonFile()
+      if (!picked) return
+      const { workspace: parsed, errors } = parseDSL(picked.content)
+      // The DSL parser is deliberately lenient — it returns whatever it could
+      // make sense of. A file that yielded neither a `workspace` declaration nor
+      // a single element isn't a revision of anything, so say so instead of
+      // starting a comparison that reports the whole model as added.
+      const elementCount = parsed.model.people.length + parsed.model.softwareSystems.length
+      if (elementCount === 0 && !parsed.name) {
+        const detail = errors.length > 0 ? `: ${errors[0].message}` : ''
+        setError(`No Structurizr workspace found in ${picked.name}${detail}`)
+        return
+      }
+      startComparison(parsed, picked.name)
+      announce(`Comparing against ${picked.name}`)
+    } catch (err) {
+      log.warn('Failed to open comparison revision', err)
+      setError('Could not read that file.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function jumpTo(headId: string | undefined) {
+    if (!headId) return
+    focusViewForElements([headId])
+    selectElements([headId])
+    close()
+  }
+
+  return (
+    <DialogShell onClose={close} ariaLabel="Compare revisions" className="glass-panel" style={PANEL_STYLE}>
+      <header style={HEADER_STYLE}>
+        <GitCompare size={16} style={{ color: 'var(--color-text-secondary)', flexShrink: 0 }} />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: 'var(--color-text-primary)' }}>
+            Compare revisions
+          </div>
+          {diff && comparisonLabel && (
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
+              {workspace?.name ?? 'This workspace'} vs {comparisonLabel} &mdash; {formatDiffSummary(diff)}
+            </div>
+          )}
+        </div>
+        <button onClick={close} aria-label="Close compare" title="Close" style={ICON_BUTTON_STYLE}>
+          <X size={14} />
+        </button>
+      </header>
+
+      <div style={BODY_STYLE}>
+        {!diff && (
+          <div style={{ padding: '24px 18px', textAlign: 'center' }}>
+            <p style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)', margin: '0 0 6px' }}>
+              Pick another revision of this workspace &mdash; an older copy, a branch checkout, a
+              teammate&rsquo;s file &mdash; and see exactly what the architecture gained, lost and changed.
+            </p>
+            <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', margin: '0 0 16px' }}>
+              The file is read only. Nothing about your open workspace changes.
+            </p>
+            <button onClick={pickRevision} disabled={busy} style={PRIMARY_BUTTON_STYLE}>
+              <FileUp size={13} />
+              {busy ? 'Opening...' : 'Choose a .dsl file...'}
+            </button>
+            {error && (
+              <p role="alert" style={{ marginTop: 14, fontSize: 'var(--text-xs)', color: 'var(--color-error)' }}>
+                {error}
+              </p>
+            )}
+          </div>
+        )}
+
+        {diff?.identical && (
+          <p style={{ padding: '24px 18px', textAlign: 'center', fontSize: 'var(--text-sm)', color: 'var(--color-text-muted)' }}>
+            No architectural differences. These two revisions describe the same model and views.
+          </p>
+        )}
+
+        {diff && !diff.identical && (
+          <>
+            <Section title="Elements" count={diff.elements.length}>
+              {diff.elements.map((entry) => (
+                <ElementRow
+                  key={`${entry.kind}:${entry.headId ?? entry.baseId}`}
+                  entry={entry}
+                  onJump={() => jumpTo(entry.headId)}
+                />
+              ))}
+            </Section>
+            <Section title="Relationships" count={diff.relationships.length}>
+              {diff.relationships.map((entry) => (
+                <RelationshipRow key={`${entry.kind}:${entry.headId ?? entry.baseId}`} entry={entry} />
+              ))}
+            </Section>
+            <Section title="Views" count={diff.views.length}>
+              {diff.views.map((entry) => (
+                <ViewRow key={`${entry.kind}:${entry.key}`} entry={entry} />
+              ))}
+            </Section>
+            <Section title="Workspace" count={diff.workspaceChanges.length}>
+              {diff.workspaceChanges.map((change) => (
+                <div key={change.field} style={ROW_STYLE}>
+                  <KindChip kind="changed" />
+                  <div style={{ minWidth: 0 }}>
+                    <div style={ROW_TITLE_STYLE}>{change.field}</div>
+                    <FieldChangeList changes={[change]} />
+                  </div>
+                </div>
+              ))}
+            </Section>
+          </>
+        )}
+      </div>
+
+      {diff && (
+        <footer style={FOOTER_STYLE}>
+          <button
+            onClick={() => setComparisonOverlay(!comparisonOverlay)}
+            style={SECONDARY_BUTTON_STYLE}
+            aria-pressed={comparisonOverlay}
+          >
+            {comparisonOverlay ? <Eye size={13} /> : <EyeOff size={13} />}
+            {comparisonOverlay ? 'Canvas highlight on' : 'Canvas highlight off'}
+          </button>
+          <div style={{ flex: 1 }} />
+          <button onClick={pickRevision} disabled={busy} style={SECONDARY_BUTTON_STYLE}>
+            <FileUp size={13} />
+            Different file...
+          </button>
+          <button
+            onClick={() => { clearComparison(); announce('Comparison cleared') }}
+            style={SECONDARY_BUTTON_STYLE}
+          >
+            Stop comparing
+          </button>
+        </footer>
+      )}
+    </DialogShell>
+  )
+}
+
+// ─── Rows ────────────────────────────────────────────────────────────
+
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  if (count === 0) return null
+  return (
+    <section aria-label={title} style={{ borderBottom: '1px solid var(--color-border)' }}>
+      <h3 style={SECTION_TITLE_STYLE}>
+        {title}
+        <span style={{ color: 'var(--color-text-muted)', fontWeight: 500 }}> ({count})</span>
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+function KindChip({ kind }: { kind: DiffKind }) {
+  const { symbol, color, label } = KIND_STYLE[kind]
+  return (
+    <span
+      aria-label={label}
+      title={label}
+      style={{
+        flexShrink: 0,
+        width: 18,
+        height: 18,
+        borderRadius: 4,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 700,
+        fontSize: 12,
+        lineHeight: 1,
+        color,
+        background: `color-mix(in srgb, ${color} 16%, transparent)`,
+      }}
+    >
+      {symbol}
+    </span>
+  )
+}
+
+function FieldChangeList({ changes }: { changes: FieldChange[] }) {
+  if (changes.length === 0) return null
+  return (
+    <ul style={{ margin: '3px 0 0', padding: 0, listStyle: 'none' }}>
+      {changes.map((change) => (
+        <li key={change.field} style={CHANGE_LINE_STYLE}>
+          <span style={{ color: 'var(--color-text-muted)' }}>{change.field}</span>
+          <span style={{ color: 'var(--color-error-text)' }}>{change.before || '(empty)'}</span>
+          <ArrowRight size={10} aria-label="becomes" style={{ color: 'var(--color-text-muted)', flexShrink: 0 }} />
+          <span style={{ color: 'var(--color-success)' }}>{change.after || '(empty)'}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function ElementRow({ entry, onJump }: { entry: ElementDiffEntry; onJump: () => void }) {
+  const canJump = entry.headId !== undefined
+  const body = (
+    <>
+      <KindChip kind={entry.kind} />
+      <div style={{ minWidth: 0 }}>
+        <div style={ROW_TITLE_STYLE}>{formatElementPath(entry)}</div>
+        <div style={ROW_SUBTITLE_STYLE}>{TYPE_LABEL[entry.type]}</div>
+        <FieldChangeList changes={entry.changes} />
+      </div>
+    </>
+  )
+  if (!canJump) return <div style={ROW_STYLE}>{body}</div>
+  return (
+    <button
+      type="button"
+      onClick={onJump}
+      className="hover-subtle"
+      style={{ ...ROW_STYLE, width: '100%', textAlign: 'left', background: 'none', border: 'none', cursor: 'pointer' }}
+      // The row's own text is the path plus every changed field, which makes a
+      // noisy accessible name; label it with the action instead.
+      aria-label={`Show ${entry.name} on the canvas`}
+      title={`Show ${entry.name} on the canvas`}
+    >
+      {body}
+    </button>
+  )
+}
+
+function RelationshipRow({ entry }: { entry: RelationshipDiffEntry }) {
+  return (
+    <div style={ROW_STYLE}>
+      <KindChip kind={entry.kind} />
+      <div style={{ minWidth: 0 }}>
+        <div style={ROW_TITLE_STYLE}>
+          {entry.sourceName} &rarr; {entry.destinationName}
+        </div>
+        {entry.description && <div style={ROW_SUBTITLE_STYLE}>{entry.description}</div>}
+        <FieldChangeList changes={entry.changes} />
+      </div>
+    </div>
+  )
+}
+
+function ViewRow({ entry }: { entry: ViewDiffEntry }) {
+  return (
+    <div style={ROW_STYLE}>
+      <KindChip kind={entry.kind} />
+      <div style={{ minWidth: 0 }}>
+        <div style={ROW_TITLE_STYLE}>{entry.title}</div>
+        <div style={ROW_SUBTITLE_STYLE}>{entry.type}</div>
+        <FieldChangeList changes={entry.changes} />
+        {entry.addedElements.length > 0 && (
+          <div style={CHANGE_LINE_STYLE}>
+            <span style={{ color: 'var(--color-success)' }}>+ {entry.addedElements.join(', ')}</span>
+          </div>
+        )}
+        {entry.removedElements.length > 0 && (
+          <div style={CHANGE_LINE_STYLE}>
+            <span style={{ color: 'var(--color-error-text)' }}>- {entry.removedElements.join(', ')}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────
+
+const PANEL_STYLE: React.CSSProperties = {
+  width: 'min(720px, 94vw)',
+  maxHeight: '82vh',
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: 14,
+  overflow: 'hidden',
+}
+
+const HEADER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  padding: '12px 14px',
+  borderBottom: '1px solid var(--color-border)',
+}
+
+const BODY_STYLE: React.CSSProperties = {
+  overflowY: 'auto',
+  flex: 1,
+  minHeight: 0,
+}
+
+const FOOTER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '10px 14px',
+  borderTop: '1px solid var(--color-border)',
+  flexWrap: 'wrap',
+}
+
+const SECTION_TITLE_STYLE: React.CSSProperties = {
+  margin: 0,
+  padding: '10px 14px 4px',
+  fontSize: 'var(--text-xs)',
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: 'var(--color-text-secondary)',
+}
+
+const ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: 9,
+  padding: '7px 14px',
+}
+
+const ROW_TITLE_STYLE: React.CSSProperties = {
+  fontSize: 'var(--text-sm)',
+  color: 'var(--color-text-primary)',
+  overflowWrap: 'anywhere',
+}
+
+const ROW_SUBTITLE_STYLE: React.CSSProperties = {
+  fontSize: 'var(--text-xs)',
+  color: 'var(--color-text-muted)',
+}
+
+const CHANGE_LINE_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: 'var(--text-xs)',
+  overflowWrap: 'anywhere',
+}
+
+const BUTTON_BASE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '6px 11px',
+  borderRadius: 'var(--radius-sm)',
+  fontSize: 'var(--text-xs)',
+  fontWeight: 500,
+  cursor: 'pointer',
+}
+
+const PRIMARY_BUTTON_STYLE: React.CSSProperties = {
+  ...BUTTON_BASE,
+  border: '1px solid var(--color-accent)',
+  background: 'color-mix(in srgb, var(--color-accent) 16%, transparent)',
+  color: 'var(--color-text-primary)',
+}
+
+const SECONDARY_BUTTON_STYLE: React.CSSProperties = {
+  ...BUTTON_BASE,
+  border: '1px solid var(--color-border)',
+  background: 'var(--color-surface-2)',
+  color: 'var(--color-text-secondary)',
+}
+
+const ICON_BUTTON_STYLE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 26,
+  height: 26,
+  borderRadius: 'var(--radius-sm)',
+  border: '1px solid var(--color-border)',
+  background: 'var(--color-surface-2)',
+  color: 'var(--color-text-secondary)',
+  cursor: 'pointer',
+  flexShrink: 0,
+}

--- a/src/components/layout/FloatingTopPill.tsx
+++ b/src/components/layout/FloatingTopPill.tsx
@@ -20,6 +20,7 @@ import {
   FolderSymlink,
   LayoutGrid,
   Sparkles,
+  GitCompare,
 } from 'lucide-react'
 import { useSettingsStore } from '@/store/settings'
 
@@ -414,6 +415,12 @@ export default function FloatingTopPill() {
             <MenuItemRow icon={FolderSymlink} label="Workspaces…" onClick={() => { setHamburgerOpen(false); openWsPicker() }} />
             <div style={{ borderTop: '1px solid var(--color-border)', margin: '4px 0' }} />
             <MenuItemRow icon={Sparkles} label="AI assistant…" onClick={() => { setHamburgerOpen(false); useWorkspaceStore.getState().setAiPanelOpen(true) }} />
+            <div style={{ borderTop: '1px solid var(--color-border)', margin: '4px 0' }} />
+            <MenuItemRow
+              icon={GitCompare}
+              label="Compare revisions…"
+              onClick={() => { setHamburgerOpen(false); useWorkspaceStore.getState().setComparisonPanelOpen(true); setExportDialogOpen(false); setWsPickerOpen(false) }}
+            />
             <div style={{ borderTop: '1px solid var(--color-border)', margin: '4px 0' }} />
             <MenuItemRow icon={Download} label="Export…" onClick={() => { setHamburgerOpen(false); setExportDialogOpen(true); setWsPickerOpen(false); useWorkspaceStore.getState().setCommandPaletteOpen(false) }} />
             <div style={{ borderTop: '1px solid var(--color-border)', margin: '4px 0' }} />

--- a/src/index.css
+++ b/src/index.css
@@ -2010,6 +2010,63 @@ body {
   opacity: 0.35;
 }
 
+/* ─── Revision comparison overlay ────────────────────────────────────
+   Active only while the user is comparing the open workspace against another
+   revision. Added and changed nodes get a colored ring plus a corner badge;
+   untouched nodes recede so the change set reads at a glance. Composes with
+   the highlighter classes above — a node can be both faded and "added". */
+.c4-node-diff-added > .c4-node {
+  box-shadow:
+    0 0 0 2px var(--color-success),
+    0 0 18px color-mix(in srgb, var(--color-success) 45%, transparent);
+}
+.c4-node-diff-changed > .c4-node {
+  box-shadow:
+    0 0 0 2px var(--color-warning),
+    0 0 18px color-mix(in srgb, var(--color-warning) 45%, transparent);
+}
+.react-flow__node.c4-node-diff-same {
+  opacity: 0.45;
+  filter: saturate(0.75);
+}
+.c4-edge-diff-added path.react-flow__edge-path {
+  stroke: var(--color-success) !important;
+  stroke-width: 2.4 !important;
+}
+.c4-edge-diff-changed path.react-flow__edge-path {
+  stroke: var(--color-warning) !important;
+  stroke-width: 2.4 !important;
+}
+.c4-edge-diff-same path.react-flow__edge-path {
+  opacity: 0.3 !important;
+}
+.c4-edge-diff-same text {
+  opacity: 0.45;
+}
+
+.c4-node-diff-badge {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  z-index: 4;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0b1207;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35), 0 0 0 2px var(--canvas-bg, var(--color-bg-primary));
+}
+.c4-node-diff-badge-added { background: var(--color-success); }
+.c4-node-diff-badge-changed { background: var(--color-warning); }
+
+@media (prefers-reduced-motion: no-preference) {
+  .react-flow__node.c4-node-diff-same {
+    transition: opacity 0.18s ease, filter 0.18s ease;
+  }
+}
+
 .c4-node-violation {
   position: absolute;
   top: -8px;

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -4,7 +4,7 @@ import {
   MousePointer, LayoutDashboard, Maximize2, ZoomIn, ZoomOut,
   LayoutGrid, Search, Save, Settings, Monitor,
   Presentation, FolderOpen, Image, FileCode, Copy, Plus,
-  Highlighter, MousePointerClick, RotateCcw, CircleHelp, Sparkles,
+  Highlighter, MousePointerClick, RotateCcw, CircleHelp, Sparkles, GitCompare,
 } from 'lucide-react'
 import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews, isFocalScopeElement } from '@/store/workspace'
 import { computeCascadeImpact } from '@/store/workspace-helpers'
@@ -362,6 +362,25 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
       icon: FolderOpen,
       keywords: ['close', 'home', 'welcome'],
       execute: () => store().closeWorkspace(),
+    },
+
+    {
+      id: 'compare-revisions',
+      label: 'Compare with another revision...',
+      category: 'view',
+      icon: GitCompare,
+      keywords: ['compare', 'diff', 'revision', 'changes', 'git', 'review'],
+      when: () => !!store().workspace,
+      execute: () => { store().setComparisonPanelOpen(true) },
+    },
+    {
+      id: 'stop-comparing',
+      label: 'Stop comparing revisions',
+      category: 'view',
+      icon: GitCompare,
+      keywords: ['compare', 'diff', 'clear', 'stop'],
+      when: () => store().comparisonBase !== null,
+      execute: () => { store().clearComparison(); announce('Comparison cleared') },
     },
 
     // ─── Export ──────────────────────────────────────────

--- a/src/lib/fileIO.test.ts
+++ b/src/lib/fileIO.test.ts
@@ -524,3 +524,71 @@ describe('isWorkspaceShape edge cases', () => {
     expect(isWorkspaceShape(bad)).toBe(false)
   })
 })
+
+// ─── Comparison file picker ──────────────────────────────────────────
+
+describe('openComparisonFile', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  function stubPicker(content: string, name: string) {
+    const file = new File([content], name, { type: 'text/plain' })
+    const handle = { getFile: vi.fn().mockResolvedValue(file) }
+    const showOpenFilePicker = vi.fn().mockResolvedValue([handle])
+    vi.stubGlobal('showOpenFilePicker', showOpenFilePicker)
+    return showOpenFilePicker
+  }
+
+  it('reads the picked revision', async () => {
+    const { mock } = makeMockLocalStorage()
+    vi.stubGlobal('localStorage', mock)
+    stubPicker('workspace "v1" {}', 'v1.dsl')
+
+    const { openComparisonFile } = await import('./fileIO')
+    expect(await openComparisonFile()).toEqual({ content: 'workspace "v1" {}', name: 'v1.dsl' })
+  })
+
+  it('never repoints where Save writes', async () => {
+    const { mock } = makeMockLocalStorage()
+    vi.stubGlobal('localStorage', mock)
+    stubPicker('workspace "v1" {}', 'v1.dsl')
+
+    const { openComparisonFile, getCurrentFileHandle } = await import('./fileIO')
+    await openComparisonFile()
+    // openDSLFile would have adopted the handle here; comparing must not.
+    expect(getCurrentFileHandle()).toBeNull()
+  })
+
+  it('does not pollute the recent-files list with a compared revision', async () => {
+    const { mock } = makeMockLocalStorage()
+    vi.stubGlobal('localStorage', mock)
+    stubPicker('workspace "v1" {}', 'v1.dsl')
+
+    const { openComparisonFile, getRecentFiles } = await import('./fileIO')
+    await openComparisonFile()
+    expect(getRecentFiles()).toEqual([])
+  })
+
+  it('returns null when the picker is dismissed', async () => {
+    const { mock } = makeMockLocalStorage()
+    vi.stubGlobal('localStorage', mock)
+    vi.stubGlobal('showOpenFilePicker', vi.fn().mockRejectedValue(new DOMException('aborted')))
+
+    const { openComparisonFile } = await import('./fileIO')
+    expect(await openComparisonFile()).toBeNull()
+  })
+
+  it('limits the picker to DSL and text files', async () => {
+    const { mock } = makeMockLocalStorage()
+    vi.stubGlobal('localStorage', mock)
+    const picker = stubPicker('workspace "v1" {}', 'v1.dsl')
+
+    const { openComparisonFile } = await import('./fileIO')
+    await openComparisonFile()
+    expect(picker).toHaveBeenCalledWith(expect.objectContaining({
+      types: [expect.objectContaining({ accept: { 'text/plain': ['.dsl', '.txt'] } })],
+    }))
+  })
+})

--- a/src/lib/fileIO.ts
+++ b/src/lib/fileIO.ts
@@ -225,6 +225,50 @@ export async function openDSLFile(): Promise<{ content: string; name: string; si
   })
 }
 
+/** Read a `.dsl` file for read-only comparison.
+ *
+ *  Deliberately does NOT touch `currentFileHandle`, the sidecar handle, or the
+ *  recent-files list: picking a revision to compare against must never repoint
+ *  where Save writes, and an old revision is not a file the user "opened". */
+export async function openComparisonFile(): Promise<{ content: string; name: string } | null> {
+  if (hasFileSystemAccess()) {
+    try {
+      const [handle] = await window.showOpenFilePicker({
+        types: [
+          {
+            description: 'Structurizr DSL or text',
+            accept: { 'text/plain': ['.dsl', '.txt'] },
+          },
+        ],
+        excludeAcceptAllOption: false,
+      })
+      const file = await handle.getFile()
+      const content = await readTextFileWithLimit(file, 'DSL file')
+      return { content, name: file.name }
+    } catch {
+      // User cancelled the file picker — not an error
+      return null
+    }
+  }
+
+  return new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.dsl,.txt'
+    input.onchange = async () => {
+      const file = input.files?.[0]
+      if (!file) { resolve(null); return }
+      try {
+        resolve({ content: await readTextFileWithLimit(file, 'DSL file'), name: file.name })
+      } catch (err) {
+        log.warn('Failed to open comparison file', err)
+        resolve(null)
+      }
+    }
+    input.click()
+  })
+}
+
 /** Save content to the current file handle or prompt for new file */
 export async function saveDSLFile(content: string, suggestedName?: string): Promise<boolean> {
   const safeSuggestedName = safeSuggestedDslName(suggestedName)

--- a/src/lib/workspaceDiff.test.ts
+++ b/src/lib/workspaceDiff.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from 'vitest'
+import {
+  diffWorkspaces,
+  formatDiffSummary,
+  formatElementPath,
+  matchByIdentity,
+  type ElementDiffEntry,
+} from './workspaceDiff'
+import { makeWorkspace } from './ai/testFixture'
+import { parseDSL } from './dsl'
+import type { Container, Component, Person, Workspace } from '@/types/model'
+
+/** Deep clone helper — keeps each test's mutation isolated from the shared fixture. */
+function clone(ws: Workspace): Workspace {
+  return JSON.parse(JSON.stringify(ws)) as Workspace
+}
+
+function entryFor(entries: ElementDiffEntry[], name: string): ElementDiffEntry | undefined {
+  return entries.find((entry) => entry.name === name)
+}
+
+function changeFor(entry: ElementDiffEntry | undefined, field: string) {
+  return entry?.changes.find((change) => change.field === field)
+}
+
+const person = (id: string, name: string): Person => ({
+  id, type: 'person', name, tags: [], properties: {},
+})
+
+describe('matchByIdentity', () => {
+  it('pairs on id + name before anything else', () => {
+    const result = matchByIdentity(
+      [person('a', 'Alice'), person('b', 'Bob')],
+      [person('b', 'Bob'), person('a', 'Alice')],
+    )
+    expect(result.pairs).toHaveLength(2)
+    expect(result.addedOnly).toEqual([])
+    expect(result.removedOnly).toEqual([])
+  })
+
+  it('pairs on name when the DSL identifier was renamed', () => {
+    const result = matchByIdentity([person('oldId', 'Alice')], [person('newId', 'Alice')])
+    expect(result.pairs).toEqual([{ base: person('oldId', 'Alice'), head: person('newId', 'Alice') }])
+  })
+
+  it('pairs on an authored id when the element was renamed', () => {
+    const result = matchByIdentity([person('alice', 'Alice')], [person('alice', 'Alice Smith')])
+    expect(result.pairs).toHaveLength(1)
+    expect(result.pairs[0].head.name).toBe('Alice Smith')
+  })
+
+  it('never pairs two unrelated elements that share a parser-generated id', () => {
+    // `p1` is what the DSL parser hands an anonymous declaration. The counter
+    // restarts per parse, so the same id in two files means nothing.
+    const result = matchByIdentity([person('p1', 'Alice')], [person('p1', 'Zach')])
+    expect(result.pairs).toEqual([])
+    expect(result.addedOnly.map((p) => p.name)).toEqual(['Zach'])
+    expect(result.removedOnly.map((p) => p.name)).toEqual(['Alice'])
+  })
+
+  it('matches names case- and whitespace-insensitively', () => {
+    const result = matchByIdentity([person('a', ' Alice ')], [person('b', 'alice')])
+    expect(result.pairs).toHaveLength(1)
+  })
+
+  it('pairs same-named siblings in source order, deterministically', () => {
+    const base = [person('a1', 'API'), person('a2', 'API')]
+    const head = [person('b1', 'API'), person('b2', 'API')]
+    const result = matchByIdentity(base, head)
+    expect(result.pairs.map((p) => [p.base.id, p.head.id])).toEqual([['a1', 'b1'], ['a2', 'b2']])
+  })
+})
+
+describe('diffWorkspaces — no change', () => {
+  it('reports two identical workspaces as identical', () => {
+    const diff = diffWorkspaces(makeWorkspace(), makeWorkspace())
+    expect(diff.identical).toBe(true)
+    expect(diff.summary).toEqual({ added: 0, removed: 0, changed: 0, total: 0 })
+    expect(diff.elements).toEqual([])
+    expect(diff.relationships).toEqual([])
+    expect(diff.views).toEqual([])
+    expect(diff.workspaceChanges).toEqual([])
+    expect(formatDiffSummary(diff)).toBe('No architectural differences')
+  })
+
+  it('ignores tag order and property order', () => {
+    const base = clone(makeWorkspace())
+    const head = clone(makeWorkspace())
+    base.model.people[0].tags = ['Element', 'Person']
+    head.model.people[0].tags = ['Person', 'Element']
+    base.model.people[0].properties = { a: '1', b: '2' }
+    head.model.people[0].properties = { b: '2', a: '1' }
+    expect(diffWorkspaces(base, head).identical).toBe(true)
+  })
+})
+
+describe('diffWorkspaces — elements', () => {
+  it('reports an added person', () => {
+    const head = clone(makeWorkspace())
+    head.model.people.push(person('ops', 'Ops Engineer'))
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.elements).toEqual([
+      { kind: 'added', headId: 'ops', type: 'person', name: 'Ops Engineer', parentPath: [], changes: [] },
+    ])
+    expect(diff.elementStatus.get('ops')).toBe('added')
+    expect(diff.summary.added).toBe(1)
+  })
+
+  it('reports a removed container along with its components', () => {
+    const base = clone(makeWorkspace())
+    const head = clone(makeWorkspace())
+    head.model.softwareSystems[0].containers = head.model.softwareSystems[0].containers.filter(
+      (c) => c.id !== 'web',
+    )
+    const diff = diffWorkspaces(base, head)
+    const removed = diff.elements.filter((entry) => entry.kind === 'removed')
+    expect(removed.map((entry) => entry.name)).toEqual(['Web App', 'Cart'])
+    expect(removed[1].parentPath).toEqual(['Shop', 'Web App'])
+    // Nothing removed can be tinted on a canvas that no longer contains it.
+    expect(diff.elementStatus.size).toBe(0)
+  })
+
+  it('reports an added component nested under its container path', () => {
+    const head = clone(makeWorkspace())
+    const webApp = head.model.softwareSystems[0].containers[0]
+    webApp.components.push({ id: 'checkout', type: 'component', name: 'Checkout', tags: [], properties: {} } as Component)
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    const added = entryFor(diff.elements, 'Checkout')
+    expect(added?.kind).toBe('added')
+    expect(added?.parentPath).toEqual(['Shop', 'Web App'])
+    expect(formatElementPath(added!)).toBe('Shop / Web App / Checkout')
+  })
+
+  it('reports every scalar field change on a matched element', () => {
+    const head = clone(makeWorkspace())
+    const db = head.model.softwareSystems[0].containers[1]
+    db.description = 'Stores orders'
+    db.technology = 'PostgreSQL'
+    db.owner = 'Platform'
+    db.url = 'https://example.test/db'
+    db.status = 'Deprecated'
+    db.tags = ['Database']
+    db.properties = { tier: 'gold' }
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    const changed = entryFor(diff.elements, 'Database')
+    expect(changed?.kind).toBe('changed')
+    expect(changed?.changes.map((c) => c.field).sort()).toEqual(
+      ['description', 'owner', 'properties', 'status', 'tags', 'technology', 'url'],
+    )
+    expect(changeFor(changed, 'technology')).toEqual({ field: 'technology', before: '', after: 'PostgreSQL' })
+    expect(diff.elementStatus.get('db')).toBe('changed')
+  })
+
+  it('reports a rename as a change, not a remove + add', () => {
+    const head = clone(makeWorkspace())
+    head.model.people[0].name = 'Shopper'
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.elements).toHaveLength(1)
+    expect(diff.elements[0]).toMatchObject({
+      kind: 'changed',
+      headId: 'cust',
+      baseId: 'cust',
+      changes: [{ field: 'name', before: 'Customer', after: 'Shopper' }],
+    })
+  })
+
+  it('reports a location change on a software system', () => {
+    const head = clone(makeWorkspace())
+    head.model.softwareSystems[0].location = 'External'
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(changeFor(entryFor(diff.elements, 'Shop'), 'location')).toEqual({
+      field: 'location', before: '', after: 'External',
+    })
+  })
+
+  it('treats a container moved to another system as removed + added', () => {
+    const head = clone(makeWorkspace())
+    const [moved] = head.model.softwareSystems[0].containers.splice(1, 1)
+    head.model.softwareSystems.push({
+      id: 'analytics', type: 'softwareSystem', name: 'Analytics', tags: [], properties: {},
+      containers: [moved as Container],
+    })
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    const database = diff.elements.filter((entry) => entry.name === 'Database')
+    expect(database.map((entry) => entry.kind).sort()).toEqual(['added', 'removed'])
+  })
+})
+
+describe('diffWorkspaces — relationships', () => {
+  it('reports an added relationship with resolved endpoint names', () => {
+    const head = clone(makeWorkspace())
+    head.model.relationships.push({
+      id: 'r3', sourceId: 'admin', destinationId: 'web', description: 'Configures', tags: [], properties: {},
+    })
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.relationships).toEqual([
+      {
+        kind: 'added', headId: 'r3', sourceName: 'Admin', destinationName: 'Web App',
+        description: 'Configures', changes: [],
+      },
+    ])
+    expect(diff.relationshipStatus.get('r3')).toBe('added')
+  })
+
+  it('reports a removed relationship using the base revision names', () => {
+    const head = clone(makeWorkspace())
+    head.model.relationships = head.model.relationships.filter((rel) => rel.id !== 'r1')
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.relationships).toEqual([
+      {
+        kind: 'removed', baseId: 'r1', sourceName: 'Customer', destinationName: 'Web App',
+        description: 'Browses', changes: [],
+      },
+    ])
+  })
+
+  it('reports a re-described relationship as changed', () => {
+    const head = clone(makeWorkspace())
+    head.model.relationships[0].description = 'Shops on'
+    head.model.relationships[0].technology = 'HTTPS'
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.relationships).toHaveLength(1)
+    expect(diff.relationships[0]).toMatchObject({ kind: 'changed', headId: 'r1', baseId: 'r1' })
+    expect(diff.relationships[0].changes.map((c) => c.field)).toEqual(['description', 'technology'])
+  })
+
+  it('keeps parallel relationships apart by description', () => {
+    const base = clone(makeWorkspace())
+    const head = clone(makeWorkspace())
+    for (const ws of [base, head]) {
+      ws.model.relationships.push({
+        id: 'r9', sourceId: 'cust', destinationId: 'web', description: 'Uploads to', tags: [], properties: {},
+      })
+    }
+    head.model.relationships[0].technology = 'HTTPS'
+    const diff = diffWorkspaces(base, head)
+    expect(diff.relationships).toHaveLength(1)
+    expect(diff.relationships[0]).toMatchObject({ kind: 'changed', headId: 'r1' })
+  })
+
+  it('reports relationships orphaned by a removed element as removed', () => {
+    const head = clone(makeWorkspace())
+    head.model.softwareSystems[0].containers = head.model.softwareSystems[0].containers.filter(
+      (c) => c.id !== 'db',
+    )
+    head.model.relationships = head.model.relationships.filter((rel) => rel.destinationId !== 'db')
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.relationships).toEqual([
+      {
+        kind: 'removed', baseId: 'r2', sourceName: 'Web App', destinationName: 'Database',
+        description: '', changes: [],
+      },
+    ])
+  })
+
+  it('follows a renamed endpoint instead of reporting a rewire', () => {
+    const head = clone(makeWorkspace())
+    head.model.people[0].name = 'Shopper'
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.relationships).toEqual([])
+  })
+})
+
+describe('diffWorkspaces — views', () => {
+  function withView(ws: Workspace, key: string, elementIds: string[]): Workspace {
+    ws.views.containerViews.push({
+      type: 'container',
+      key,
+      title: 'Containers',
+      softwareSystemId: 'shop',
+      elements: elementIds.map((id) => ({ id })),
+      relationships: [],
+    })
+    return ws
+  }
+
+  it('reports an added view with its members', () => {
+    const diff = diffWorkspaces(makeWorkspace(), withView(clone(makeWorkspace()), 'containers', ['web', 'db']))
+    expect(diff.views).toEqual([
+      {
+        kind: 'added', key: 'containers', title: 'Containers', type: 'container',
+        addedElements: ['Web App', 'Database'], removedElements: [], changes: [],
+      },
+    ])
+  })
+
+  it('reports a removed view', () => {
+    const diff = diffWorkspaces(withView(clone(makeWorkspace()), 'containers', ['web']), makeWorkspace())
+    expect(diff.views).toEqual([
+      {
+        kind: 'removed', key: 'containers', title: 'Containers', type: 'container',
+        addedElements: [], removedElements: [], changes: [],
+      },
+    ])
+  })
+
+  it('reports membership changes on a matched view', () => {
+    const base = withView(clone(makeWorkspace()), 'containers', ['web'])
+    const head = withView(clone(makeWorkspace()), 'containers', ['db'])
+    const diff = diffWorkspaces(base, head)
+    expect(diff.views).toEqual([
+      {
+        kind: 'changed', key: 'containers', title: 'Containers', type: 'container',
+        addedElements: ['Database'], removedElements: ['Web App'], changes: [],
+      },
+    ])
+  })
+
+  it('reports a retitled view', () => {
+    const base = withView(clone(makeWorkspace()), 'containers', ['web'])
+    const head = withView(clone(makeWorkspace()), 'containers', ['web'])
+    head.views.containerViews[0].title = 'Shop containers'
+    const diff = diffWorkspaces(base, head)
+    expect(diff.views[0].changes).toEqual([
+      { field: 'title', before: 'Containers', after: 'Shop containers' },
+    ])
+  })
+
+  it('does not treat a renamed DSL identifier as a view membership change', () => {
+    const base = withView(clone(makeWorkspace()), 'containers', ['web'])
+    const head = clone(makeWorkspace())
+    head.model.softwareSystems[0].containers[0].id = 'webApp'
+    withView(head, 'containers', ['webApp'])
+    const diff = diffWorkspaces(base, head)
+    expect(diff.views).toEqual([])
+  })
+})
+
+describe('diffWorkspaces — workspace fields', () => {
+  it('reports name, description and scope changes', () => {
+    const head = clone(makeWorkspace())
+    head.name = 'Shop v2'
+    head.description = 'A better store'
+    head.scope = 'landscape'
+    const diff = diffWorkspaces(makeWorkspace(), head)
+    expect(diff.workspaceChanges).toEqual([
+      { field: 'name', before: 'Shop', after: 'Shop v2' },
+      { field: 'description', before: 'An e-commerce platform', after: 'A better store' },
+      { field: 'scope', before: '', after: 'landscape' },
+    ])
+    expect(diff.identical).toBe(false)
+    expect(formatDiffSummary(diff)).toBe('3 workspace field changed')
+  })
+})
+
+describe('diffWorkspaces — determinism', () => {
+  it('produces identical output for repeated runs over the same inputs', () => {
+    const base = makeWorkspace()
+    const head = clone(makeWorkspace())
+    head.model.people.push(person('ops', 'Ops'))
+    head.model.softwareSystems[0].containers[1].technology = 'PostgreSQL'
+    head.model.relationships.push({
+      id: 'r3', sourceId: 'ops', destinationId: 'db', description: 'Backs up', tags: [], properties: {},
+    })
+
+    const first = diffWorkspaces(base, head)
+    const second = diffWorkspaces(base, head)
+    expect(JSON.stringify(second.elements)).toBe(JSON.stringify(first.elements))
+    expect(JSON.stringify(second.relationships)).toBe(JSON.stringify(first.relationships))
+    expect(JSON.stringify(second.views)).toBe(JSON.stringify(first.views))
+    expect(second.summary).toEqual(first.summary)
+  })
+
+  it('is not symmetric — swapping the revisions swaps added and removed', () => {
+    const head = clone(makeWorkspace())
+    head.model.people.push(person('ops', 'Ops'))
+    const forward = diffWorkspaces(makeWorkspace(), head)
+    const backward = diffWorkspaces(head, makeWorkspace())
+    expect(forward.summary.added).toBe(1)
+    expect(backward.summary.removed).toBe(1)
+  })
+})
+
+describe('diffWorkspaces — real DSL revisions', () => {
+  const V1 = `
+workspace "Bank" {
+  model {
+    customer = person "Customer" "Banks online"
+    banking = softwareSystem "Internet Banking" {
+      web = container "Web App" "Serves pages" "Java"
+      db = container "Database" "Stores data" "Oracle"
+    }
+    customer -> web "Uses" "HTTPS"
+    web -> db "Reads from"
+  }
+  views {
+    container banking "Containers" { include * }
+  }
+}`
+
+  const V2 = `
+workspace "Bank" {
+  model {
+    customer = person "Customer" "Banks online"
+    banking = softwareSystem "Internet Banking" {
+      web = container "Web App" "Serves pages" "Kotlin"
+      db = container "Database" "Stores data" "Oracle"
+      api = container "API" "Mobile backend" "Kotlin"
+    }
+    customer -> web "Uses" "HTTPS"
+    web -> db "Reads from"
+    api -> db "Reads from"
+  }
+  views {
+    container banking "Containers" { include * }
+  }
+}`
+
+  it('diffs two parsed revisions the way an engineer would read the patch', () => {
+    const base = parseDSL(V1).workspace
+    const head = parseDSL(V2).workspace
+
+    const diff = diffWorkspaces(base, head)
+    expect(entryFor(diff.elements, 'API')?.kind).toBe('added')
+    expect(changeFor(entryFor(diff.elements, 'Web App'), 'technology')).toEqual({
+      field: 'technology', before: 'Java', after: 'Kotlin',
+    })
+    expect(diff.relationships).toEqual([
+      expect.objectContaining({ kind: 'added', sourceName: 'API', destinationName: 'Database' }),
+    ])
+    // The container view gained API too, so the view shows up as changed
+    // alongside the re-teched Web App.
+    expect(diff.views).toEqual([
+      expect.objectContaining({ kind: 'changed', addedElements: ['API'], removedElements: [] }),
+    ])
+    expect(diff.summary).toMatchObject({ added: 2, removed: 0, changed: 2 })
+    expect(formatDiffSummary(diff)).toBe('2 added, 2 changed')
+  })
+
+  it('finds no differences between a revision and itself', () => {
+    expect(diffWorkspaces(parseDSL(V1).workspace, parseDSL(V1).workspace).identical).toBe(true)
+  })
+
+  it('survives the DSL parser reusing generated ids across two parses', () => {
+    // Anonymous groups get `p1`, `p2`, … from a counter that keeps climbing
+    // for the lifetime of the module, so both parses see different ids for
+    // structurally identical content. The diff must still come out empty.
+    const dsl = `
+workspace "Anon" {
+  model {
+    group "Core" {
+      a = softwareSystem "A"
+      b = softwareSystem "B"
+    }
+  }
+}`
+    expect(diffWorkspaces(parseDSL(dsl).workspace, parseDSL(dsl).workspace).identical).toBe(true)
+  })
+})

--- a/src/lib/workspaceDiff.ts
+++ b/src/lib/workspaceDiff.ts
@@ -1,0 +1,634 @@
+import type {
+  Container,
+  Component,
+  ModelElement,
+  Person,
+  Relationship,
+  SoftwareSystem,
+  View,
+  ViewType,
+  Workspace,
+} from '@/types/model'
+
+/**
+ * Structural diff between two revisions of the same workspace.
+ *
+ * Pure and deterministic: the same two workspaces always produce byte-identical
+ * output, in a stable traversal order (people, systems, containers, components,
+ * then relationships, then views). No DOM, no store, no clock, no randomness —
+ * so the same engine can serve the in-app compare view and a future CI narrator
+ * (TEA-78).
+ *
+ * ## Why identity is not just `id`
+ *
+ * Element ids come from the DSL: an authored identifier (`apiApp = container …`)
+ * is used verbatim, but a declaration without one gets a *parse-local* counter
+ * id (`p1`, `p2`, …) that is not stable between two parses. Matching on id alone
+ * would therefore pair unrelated anonymous elements and report a rename storm.
+ * Matching runs in three rounds instead, strongest evidence first:
+ *
+ *   1. same id **and** same name — unambiguous, the common case;
+ *   2. same name within the same parent — the DSL identifier was renamed;
+ *   3. same *authored* id — the element was renamed (generated `pN` ids are
+ *      excluded here, because by this round the name evidence is exhausted and
+ *      `p3` in one file means nothing to `p3` in the other).
+ *
+ * Whatever is left over is genuinely added or removed. Matching is scoped to a
+ * parent: a container that moved between systems reads as removed + added,
+ * which is what actually happened to the model.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type DiffKind = 'added' | 'removed' | 'changed'
+
+/** One field that differs between the two revisions. */
+export interface FieldChange {
+  field: string
+  before: string
+  after: string
+}
+
+export interface ElementDiffEntry {
+  kind: DiffKind
+  /** Id in the head (current) workspace — absent for removed elements. */
+  headId?: string
+  /** Id in the base (compared-against) workspace — absent for added elements. */
+  baseId?: string
+  type: ModelElement['type']
+  /** Head name, or the base name for a removed element. */
+  name: string
+  /** Ancestor names, outermost first: `["Internet Banking System"]`. */
+  parentPath: string[]
+  changes: FieldChange[]
+}
+
+export interface RelationshipDiffEntry {
+  kind: DiffKind
+  headId?: string
+  baseId?: string
+  sourceName: string
+  destinationName: string
+  description: string
+  changes: FieldChange[]
+}
+
+export interface ViewDiffEntry {
+  kind: DiffKind
+  key: string
+  title: string
+  type: ViewType
+  /** Names of elements that appear on this view only in the head revision. */
+  addedElements: string[]
+  /** Names of elements that appear on this view only in the base revision. */
+  removedElements: string[]
+  changes: FieldChange[]
+}
+
+export interface DiffSummary {
+  added: number
+  removed: number
+  changed: number
+  /** Every entry across elements, relationships, views and workspace fields. */
+  total: number
+}
+
+export interface WorkspaceDiff {
+  elements: ElementDiffEntry[]
+  relationships: RelationshipDiffEntry[]
+  views: ViewDiffEntry[]
+  /** Workspace-level fields (name, description, scope). */
+  workspaceChanges: FieldChange[]
+  summary: DiffSummary
+  /** Head element id -> status, for canvas tinting. Removed elements are absent
+   *  from the head workspace and so cannot appear here; they are in `elements`. */
+  elementStatus: Map<string, 'added' | 'changed'>
+  /** Head relationship id -> status, for canvas tinting. */
+  relationshipStatus: Map<string, 'added' | 'changed'>
+  /** True when the two revisions describe the same architecture. */
+  identical: boolean
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Ids the DSL parser generates for declarations with no author identifier.
+ *  They restart per parse, so they carry no cross-revision meaning. */
+function isGeneratedId(id: string): boolean {
+  return /^p\d+$/.test(id)
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+function text(value: string | undefined): string {
+  return value?.trim() ?? ''
+}
+
+function tagText(tags: string[]): string {
+  return [...tags].sort().join(', ')
+}
+
+function propertiesText(properties: Record<string, string>): string {
+  return Object.keys(properties)
+    .sort()
+    .map((key) => `${key}=${properties[key]}`)
+    .join(', ')
+}
+
+function pushChange(
+  changes: FieldChange[],
+  field: string,
+  before: string,
+  after: string,
+): void {
+  if (before !== after) changes.push({ field, before, after })
+}
+
+// ─── Matching ────────────────────────────────────────────────────────
+
+interface MatchResult<T> {
+  pairs: Array<{ base: T; head: T }>
+  addedOnly: T[]
+  removedOnly: T[]
+}
+
+interface Identified {
+  id: string
+  name: string
+}
+
+/**
+ * Pair items from two revisions of the same sibling list. See the module
+ * comment for why this runs in three rounds. Deterministic: candidates are
+ * always consumed in source order.
+ */
+export function matchByIdentity<T extends Identified>(base: T[], head: T[]): MatchResult<T> {
+  const pairs: Array<{ base: T; head: T }> = []
+  const usedHead = new Set<number>()
+  const matchedBase = new Set<number>()
+
+  const claim = (baseIndex: number, headIndex: number, baseItem: T, headItem: T) => {
+    matchedBase.add(baseIndex)
+    usedHead.add(headIndex)
+    pairs.push({ base: baseItem, head: headItem })
+  }
+
+  const rounds: Array<(b: T, h: T) => boolean> = [
+    (b, h) => b.id === h.id && normalizeName(b.name) === normalizeName(h.name),
+    (b, h) => normalizeName(b.name) === normalizeName(h.name),
+    (b, h) => b.id === h.id && !isGeneratedId(b.id),
+  ]
+
+  for (const isMatch of rounds) {
+    for (let i = 0; i < base.length; i++) {
+      if (matchedBase.has(i)) continue
+      for (let j = 0; j < head.length; j++) {
+        if (usedHead.has(j)) continue
+        if (!isMatch(base[i], head[j])) continue
+        claim(i, j, base[i], head[j])
+        break
+      }
+    }
+  }
+
+  return {
+    pairs,
+    addedOnly: head.filter((_, index) => !usedHead.has(index)),
+    removedOnly: base.filter((_, index) => !matchedBase.has(index)),
+  }
+}
+
+// ─── Element diffing ─────────────────────────────────────────────────
+
+function baseElementChanges(before: ModelElement, after: ModelElement): FieldChange[] {
+  const changes: FieldChange[] = []
+  pushChange(changes, 'name', before.name, after.name)
+  pushChange(changes, 'description', text(before.description), text(after.description))
+  pushChange(changes, 'owner', text(before.owner), text(after.owner))
+  pushChange(changes, 'url', text(before.url), text(after.url))
+  pushChange(changes, 'status', text(before.status), text(after.status))
+  pushChange(changes, 'tags', tagText(before.tags), tagText(after.tags))
+  pushChange(changes, 'properties', propertiesText(before.properties), propertiesText(after.properties))
+  if ('technology' in before || 'technology' in after) {
+    const beforeTech = 'technology' in before ? text(before.technology) : ''
+    const afterTech = 'technology' in after ? text(after.technology) : ''
+    pushChange(changes, 'technology', beforeTech, afterTech)
+  }
+  if ('location' in before || 'location' in after) {
+    const beforeLocation = 'location' in before ? text(before.location) : ''
+    const afterLocation = 'location' in after ? text(after.location) : ''
+    pushChange(changes, 'location', beforeLocation, afterLocation)
+  }
+  return changes
+}
+
+/** Accumulates element entries and the base -> head id mapping in one pass. */
+class ElementDiffCollector {
+  readonly entries: ElementDiffEntry[] = []
+  /** base element id -> head element id, for every matched pair. */
+  readonly baseToHead = new Map<string, string>()
+  readonly headNames = new Map<string, string>()
+  readonly baseNames = new Map<string, string>()
+
+  added(element: ModelElement, parentPath: string[]): void {
+    this.entries.push({
+      kind: 'added',
+      headId: element.id,
+      type: element.type,
+      name: element.name,
+      parentPath,
+      changes: [],
+    })
+  }
+
+  removed(element: ModelElement, parentPath: string[]): void {
+    this.entries.push({
+      kind: 'removed',
+      baseId: element.id,
+      type: element.type,
+      name: element.name,
+      parentPath,
+      changes: [],
+    })
+  }
+
+  matched(before: ModelElement, after: ModelElement, parentPath: string[]): void {
+    this.baseToHead.set(before.id, after.id)
+    const changes = baseElementChanges(before, after)
+    if (changes.length === 0) return
+    this.entries.push({
+      kind: 'changed',
+      headId: after.id,
+      baseId: before.id,
+      type: after.type,
+      name: after.name,
+      parentPath,
+      changes,
+    })
+  }
+}
+
+function addSubtree(
+  collector: ElementDiffCollector,
+  element: ModelElement,
+  parentPath: string[],
+): void {
+  collector.added(element, parentPath)
+  const childPath = [...parentPath, element.name]
+  if (element.type === 'softwareSystem') {
+    for (const container of element.containers) addSubtree(collector, container, childPath)
+  } else if (element.type === 'container') {
+    for (const component of element.components) addSubtree(collector, component, childPath)
+  }
+}
+
+function removeSubtree(
+  collector: ElementDiffCollector,
+  element: ModelElement,
+  parentPath: string[],
+): void {
+  collector.removed(element, parentPath)
+  const childPath = [...parentPath, element.name]
+  if (element.type === 'softwareSystem') {
+    for (const container of element.containers) removeSubtree(collector, container, childPath)
+  } else if (element.type === 'container') {
+    for (const component of element.components) removeSubtree(collector, component, childPath)
+  }
+}
+
+function diffComponents(
+  collector: ElementDiffCollector,
+  before: Container,
+  after: Container,
+  parentPath: string[],
+): void {
+  const path = [...parentPath, after.name]
+  const { pairs, addedOnly, removedOnly } = matchByIdentity<Component>(before.components, after.components)
+  for (const pair of pairs) collector.matched(pair.base, pair.head, path)
+  for (const component of addedOnly) addSubtree(collector, component, path)
+  for (const component of removedOnly) removeSubtree(collector, component, path)
+}
+
+function diffContainers(
+  collector: ElementDiffCollector,
+  before: SoftwareSystem,
+  after: SoftwareSystem,
+  parentPath: string[],
+): void {
+  const path = [...parentPath, after.name]
+  const { pairs, addedOnly, removedOnly } = matchByIdentity<Container>(before.containers, after.containers)
+  for (const pair of pairs) {
+    collector.matched(pair.base, pair.head, path)
+    diffComponents(collector, pair.base, pair.head, path)
+  }
+  for (const container of addedOnly) addSubtree(collector, container, path)
+  for (const container of removedOnly) removeSubtree(collector, container, path)
+}
+
+function diffElements(base: Workspace, head: Workspace): ElementDiffCollector {
+  const collector = new ElementDiffCollector()
+
+  const people = matchByIdentity<Person>(base.model.people, head.model.people)
+  for (const pair of people.pairs) collector.matched(pair.base, pair.head, [])
+  for (const person of people.addedOnly) addSubtree(collector, person, [])
+  for (const person of people.removedOnly) removeSubtree(collector, person, [])
+
+  const systems = matchByIdentity<SoftwareSystem>(base.model.softwareSystems, head.model.softwareSystems)
+  for (const pair of systems.pairs) {
+    collector.matched(pair.base, pair.head, [])
+    diffContainers(collector, pair.base, pair.head, [])
+  }
+  for (const system of systems.addedOnly) addSubtree(collector, system, [])
+  for (const system of systems.removedOnly) removeSubtree(collector, system, [])
+
+  return collector
+}
+
+// ─── Relationship diffing ────────────────────────────────────────────
+
+function relationshipChanges(before: Relationship, after: Relationship): FieldChange[] {
+  const changes: FieldChange[] = []
+  pushChange(changes, 'description', text(before.description), text(after.description))
+  pushChange(changes, 'technology', text(before.technology), text(after.technology))
+  pushChange(changes, 'interactionStyle', text(before.interactionStyle), text(after.interactionStyle))
+  pushChange(changes, 'lineStyle', text(before.lineStyle), text(after.lineStyle))
+  pushChange(changes, 'url', text(before.url), text(after.url))
+  pushChange(changes, 'tags', tagText(before.tags), tagText(after.tags))
+  pushChange(changes, 'properties', propertiesText(before.properties), propertiesText(after.properties))
+  return changes
+}
+
+/** Index every element of a workspace by id, including nested ones. */
+function indexElements(workspace: Workspace): Map<string, ModelElement> {
+  const index = new Map<string, ModelElement>()
+  for (const person of workspace.model.people) index.set(person.id, person)
+  for (const system of workspace.model.softwareSystems) {
+    index.set(system.id, system)
+    for (const container of system.containers) {
+      index.set(container.id, container)
+      for (const component of container.components) index.set(component.id, component)
+    }
+  }
+  return index
+}
+
+function diffRelationships(
+  base: Workspace,
+  head: Workspace,
+  baseToHead: Map<string, string>,
+  baseIndex: Map<string, ModelElement>,
+  headIndex: Map<string, ModelElement>,
+): RelationshipDiffEntry[] {
+  const entries: RelationshipDiffEntry[] = []
+  const nameOf = (index: Map<string, ModelElement>, id: string) => index.get(id)?.name ?? id
+
+  // Head relationships bucketed by endpoint pair. Parallel edges between the
+  // same two elements stay in one bucket and are then told apart by
+  // description, so re-describing one of them reads as a change, not a
+  // remove + add.
+  const headByEndpoints = new Map<string, Relationship[]>()
+  for (const rel of head.model.relationships) {
+    const key = `${rel.sourceId}->${rel.destinationId}`
+    const bucket = headByEndpoints.get(key)
+    if (bucket) bucket.push(rel)
+    else headByEndpoints.set(key, [rel])
+  }
+  const claimedHead = new Set<string>()
+
+  for (const rel of base.model.relationships) {
+    const headSource = baseToHead.get(rel.sourceId)
+    const headDestination = baseToHead.get(rel.destinationId)
+    const candidates = headSource && headDestination
+      ? (headByEndpoints.get(`${headSource}->${headDestination}`) ?? []).filter((c) => !claimedHead.has(c.id))
+      : []
+
+    const match =
+      candidates.find((c) => normalizeName(text(c.description)) === normalizeName(text(rel.description))) ??
+      candidates[0]
+
+    if (!match) {
+      entries.push({
+        kind: 'removed',
+        baseId: rel.id,
+        sourceName: nameOf(baseIndex, rel.sourceId),
+        destinationName: nameOf(baseIndex, rel.destinationId),
+        description: text(rel.description),
+        changes: [],
+      })
+      continue
+    }
+
+    claimedHead.add(match.id)
+    const changes = relationshipChanges(rel, match)
+    if (changes.length === 0) continue
+    entries.push({
+      kind: 'changed',
+      headId: match.id,
+      baseId: rel.id,
+      sourceName: nameOf(headIndex, match.sourceId),
+      destinationName: nameOf(headIndex, match.destinationId),
+      description: text(match.description),
+      changes,
+    })
+  }
+
+  for (const rel of head.model.relationships) {
+    if (claimedHead.has(rel.id)) continue
+    entries.push({
+      kind: 'added',
+      headId: rel.id,
+      sourceName: nameOf(headIndex, rel.sourceId),
+      destinationName: nameOf(headIndex, rel.destinationId),
+      description: text(rel.description),
+      changes: [],
+    })
+  }
+
+  return entries
+}
+
+// ─── View diffing ────────────────────────────────────────────────────
+
+/** Every view in the workspace, in a stable order. Includes dynamic and
+ *  deployment views (which the canvas doesn't draw yet but the model carries),
+ *  and tolerates workspaces written before those arrays existed. */
+function allViewsIn(workspace: Workspace): View[] {
+  const views = workspace.views
+  return [
+    ...views.systemLandscapeViews,
+    ...views.systemContextViews,
+    ...views.containerViews,
+    ...views.componentViews,
+    ...(views.dynamicViews ?? []),
+    ...(views.deploymentViews ?? []),
+  ]
+}
+
+function viewTitle(view: View): string {
+  return text(view.title) || view.key
+}
+
+function diffViews(
+  base: Workspace,
+  head: Workspace,
+  baseToHead: Map<string, string>,
+  baseIndex: Map<string, ModelElement>,
+  headIndex: Map<string, ModelElement>,
+): ViewDiffEntry[] {
+  const entries: ViewDiffEntry[] = []
+  const baseViews = allViewsIn(base)
+  const headViews = allViewsIn(head)
+  const headByKey = new Map(headViews.map((view) => [view.key, view]))
+  const seenHeadKeys = new Set<string>()
+
+  for (const before of baseViews) {
+    const after = headByKey.get(before.key)
+    if (!after) {
+      entries.push({
+        kind: 'removed',
+        key: before.key,
+        title: viewTitle(before),
+        type: before.type,
+        addedElements: [],
+        removedElements: [],
+        changes: [],
+      })
+      continue
+    }
+    seenHeadKeys.add(after.key)
+
+    const changes: FieldChange[] = []
+    pushChange(changes, 'title', text(before.title), text(after.title))
+    pushChange(changes, 'description', text(before.description), text(after.description))
+
+    // Membership is compared in head id space so a renamed DSL identifier
+    // doesn't masquerade as "removed from the view, then added back".
+    const beforeMembers = new Set(
+      before.elements.map((element) => baseToHead.get(element.id) ?? `base:${element.id}`),
+    )
+    const afterMembers = new Set(after.elements.map((element) => element.id))
+
+    const addedElements = after.elements
+      .filter((element) => !beforeMembers.has(element.id))
+      .map((element) => headIndex.get(element.id)?.name ?? element.id)
+    const removedElements = before.elements
+      .filter((element) => {
+        const headId = baseToHead.get(element.id)
+        return !headId || !afterMembers.has(headId)
+      })
+      .map((element) => baseIndex.get(element.id)?.name ?? element.id)
+
+    if (changes.length === 0 && addedElements.length === 0 && removedElements.length === 0) continue
+    entries.push({
+      kind: 'changed',
+      key: after.key,
+      title: viewTitle(after),
+      type: after.type,
+      addedElements,
+      removedElements,
+      changes,
+    })
+  }
+
+  for (const after of headViews) {
+    if (seenHeadKeys.has(after.key)) continue
+    entries.push({
+      kind: 'added',
+      key: after.key,
+      title: viewTitle(after),
+      type: after.type,
+      addedElements: after.elements.map((element) => headIndex.get(element.id)?.name ?? element.id),
+      removedElements: [],
+      changes: [],
+    })
+  }
+
+  return entries
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────
+
+/**
+ * Diff two revisions of a workspace: `base` is the older/compared-against
+ * revision, `head` is the one currently open.
+ */
+export function diffWorkspaces(base: Workspace, head: Workspace): WorkspaceDiff {
+  const collector = diffElements(base, head)
+  const baseIndex = indexElements(base)
+  const headIndex = indexElements(head)
+
+  const relationships = diffRelationships(base, head, collector.baseToHead, baseIndex, headIndex)
+  const views = diffViews(base, head, collector.baseToHead, baseIndex, headIndex)
+
+  const workspaceChanges: FieldChange[] = []
+  pushChange(workspaceChanges, 'name', text(base.name), text(head.name))
+  pushChange(workspaceChanges, 'description', text(base.description), text(head.description))
+  pushChange(workspaceChanges, 'scope', text(base.scope), text(head.scope))
+
+  const elementStatus = new Map<string, 'added' | 'changed'>()
+  for (const entry of collector.entries) {
+    if (entry.kind === 'removed' || !entry.headId) continue
+    elementStatus.set(entry.headId, entry.kind)
+  }
+  const relationshipStatus = new Map<string, 'added' | 'changed'>()
+  for (const entry of relationships) {
+    if (entry.kind === 'removed' || !entry.headId) continue
+    relationshipStatus.set(entry.headId, entry.kind)
+  }
+
+  const all = [...collector.entries, ...relationships, ...views]
+  const summary: DiffSummary = {
+    added: all.filter((entry) => entry.kind === 'added').length,
+    removed: all.filter((entry) => entry.kind === 'removed').length,
+    changed: all.filter((entry) => entry.kind === 'changed').length,
+    total: all.length + workspaceChanges.length,
+  }
+
+  return {
+    elements: collector.entries,
+    relationships,
+    views,
+    workspaceChanges,
+    summary,
+    elementStatus,
+    relationshipStatus,
+    identical: summary.total === 0,
+  }
+}
+
+// Two-level WeakMap: base -> head -> diff. Both keys are workspace objects, and
+// the store replaces the workspace object on every edit, so a stale entry is
+// unreachable the moment either side changes and the pair is re-diffed. Lets the
+// canvas overlay and the compare panel share one computation per edit.
+const diffCache = new WeakMap<Workspace, WeakMap<Workspace, WorkspaceDiff>>()
+
+/** `diffWorkspaces`, memoized on the two workspace object identities. */
+export function diffWorkspacesCached(base: Workspace, head: Workspace): WorkspaceDiff {
+  let byHead = diffCache.get(base)
+  if (!byHead) {
+    byHead = new WeakMap<Workspace, WorkspaceDiff>()
+    diffCache.set(base, byHead)
+  }
+  const cached = byHead.get(head)
+  if (cached) return cached
+  const diff = diffWorkspaces(base, head)
+  byHead.set(head, diff)
+  return diff
+}
+
+/** One-line summary for the compare header and screen-reader announcements. */
+export function formatDiffSummary(diff: WorkspaceDiff): string {
+  if (diff.identical) return 'No architectural differences'
+  const parts: string[] = []
+  if (diff.summary.added > 0) parts.push(`${diff.summary.added} added`)
+  if (diff.summary.removed > 0) parts.push(`${diff.summary.removed} removed`)
+  if (diff.summary.changed > 0) parts.push(`${diff.summary.changed} changed`)
+  if (parts.length === 0) return `${diff.workspaceChanges.length} workspace field changed`
+  return parts.join(', ')
+}
+
+/** Display path for an element entry: `System / Container / Component`. */
+export function formatElementPath(entry: ElementDiffEntry): string {
+  return [...entry.parentPath, entry.name].join(' / ')
+}

--- a/src/store/slices/compare-slice.test.ts
+++ b/src/store/slices/compare-slice.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from '../workspace'
+import { makeWorkspace } from '@/lib/ai/testFixture'
+
+function state() {
+  return useWorkspaceStore.getState()
+}
+
+describe('compare slice', () => {
+  beforeEach(() => {
+    state().loadWorkspace(makeWorkspace())
+  })
+
+  it('starts with no comparison and the overlay armed', () => {
+    expect(state().comparisonBase).toBeNull()
+    expect(state().comparisonLabel).toBeNull()
+    expect(state().comparisonPanelOpen).toBe(false)
+    expect(state().comparisonOverlay).toBe(true)
+  })
+
+  it('startComparison stores the base revision and opens the panel', () => {
+    const base = makeWorkspace()
+    state().startComparison(base, 'v1.dsl')
+    expect(state().comparisonBase).toBe(base)
+    expect(state().comparisonLabel).toBe('v1.dsl')
+    expect(state().comparisonPanelOpen).toBe(true)
+    expect(state().comparisonOverlay).toBe(true)
+  })
+
+  it('keeps the base revision as a plain object, not an immer draft or frozen copy', () => {
+    // The base is a read-only snapshot parsed from another file — deep-freezing
+    // it would be wasted work, and drafting it would tie it to the store.
+    const base = makeWorkspace()
+    state().startComparison(base, 'v1.dsl')
+    expect(Object.isFrozen(state().comparisonBase)).toBe(false)
+    expect(state().comparisonBase).toBe(base)
+  })
+
+  it('startComparison closes the command palette so the two do not stack', () => {
+    state().setCommandPaletteOpen(true)
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    expect(state().commandPaletteOpen).toBe(false)
+  })
+
+  it('clearComparison drops the base, the label and the panel', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().clearComparison()
+    expect(state().comparisonBase).toBeNull()
+    expect(state().comparisonLabel).toBeNull()
+    expect(state().comparisonPanelOpen).toBe(false)
+    expect(state().comparisonOverlay).toBe(true)
+  })
+
+  it('toggles the canvas overlay without dropping the comparison', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().setComparisonOverlay(false)
+    expect(state().comparisonOverlay).toBe(false)
+    expect(state().comparisonBase).not.toBeNull()
+  })
+
+  it('reopens the panel for an already-running comparison', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().setComparisonPanelOpen(false)
+    expect(state().comparisonPanelOpen).toBe(false)
+    state().setComparisonPanelOpen(true)
+    expect(state().comparisonPanelOpen).toBe(true)
+    expect(state().comparisonLabel).toBe('v1.dsl')
+  })
+
+  it('drops the comparison when another workspace is loaded', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().loadWorkspace(makeWorkspace())
+    expect(state().comparisonBase).toBeNull()
+    expect(state().comparisonPanelOpen).toBe(false)
+  })
+
+  it('drops the comparison when the workspace is closed', () => {
+    state().startComparison(makeWorkspace(), 'v1.dsl')
+    state().closeWorkspace()
+    expect(state().comparisonBase).toBeNull()
+    expect(state().comparisonLabel).toBeNull()
+    expect(state().comparisonPanelOpen).toBe(false)
+  })
+
+  it('survives edits to the open workspace — the base is never mutated', () => {
+    const base = makeWorkspace()
+    state().startComparison(base, 'v1.dsl')
+    state().addPerson('Ops Engineer')
+    expect(state().comparisonBase!.model.people).toHaveLength(base.model.people.length)
+    expect(state().workspace!.model.people.length).toBe(base.model.people.length + 1)
+  })
+})

--- a/src/store/slices/compare-slice.ts
+++ b/src/store/slices/compare-slice.ts
@@ -1,0 +1,49 @@
+import type { StateCreator } from 'zustand'
+import type { WorkspaceState } from '../workspace-types'
+
+/** Revision comparison: the base (compared-against) workspace plus the two
+ *  surfaces that render its diff — the change panel and the canvas overlay.
+ *
+ *  Only the *base* revision is stored. The diff itself is derived from
+ *  (base, current workspace) at render time via `diffWorkspacesCached`, so it
+ *  stays live: every edit the user makes updates the change list and the canvas
+ *  tint immediately, with no stale-diff state to invalidate.
+ *
+ *  The base workspace is read-only. It is assigned through the object form of
+ *  `set` rather than an immer recipe so it is never deep-frozen or drafted —
+ *  it is a plain parsed snapshot, not part of the editable model. */
+export type CompareSlice = Pick<WorkspaceState,
+  | 'comparisonBase' | 'comparisonLabel' | 'comparisonPanelOpen' | 'comparisonOverlay'
+  | 'startComparison' | 'clearComparison'
+  | 'setComparisonPanelOpen' | 'setComparisonOverlay'
+>
+
+export const createCompareSlice: StateCreator<
+  WorkspaceState,
+  [['zustand/immer', never]],
+  [],
+  CompareSlice
+> = (set) => ({
+  comparisonBase: null,
+  comparisonLabel: null,
+  comparisonPanelOpen: false,
+  comparisonOverlay: true,
+
+  startComparison: (base, label) => set({
+    comparisonBase: base,
+    comparisonLabel: label,
+    comparisonOverlay: true,
+    comparisonPanelOpen: true,
+    commandPaletteOpen: false,
+  }),
+
+  clearComparison: () => set({
+    comparisonBase: null,
+    comparisonLabel: null,
+    comparisonPanelOpen: false,
+    comparisonOverlay: true,
+  }),
+
+  setComparisonPanelOpen: (open) => set({ comparisonPanelOpen: open, commandPaletteOpen: false }),
+  setComparisonOverlay: (on) => set({ comparisonOverlay: on }),
+})

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -61,6 +61,11 @@ export const createLifecycleSlice: StateCreator<
       activeTechFilter: [],
       activeTeamFilter: [],
       lastClearedHighlightFilters: null,
+      // A comparison is scoped to one workspace — carrying it across a load
+      // would diff the new model against an unrelated revision.
+      comparisonBase: null,
+      comparisonLabel: null,
+      comparisonPanelOpen: false,
       scopeViolations: validateScope(workspace),
     })
   },
@@ -84,6 +89,9 @@ export const createLifecycleSlice: StateCreator<
       undoStack: [],
       redoStack: [],
       lastClearedHighlightFilters: null,
+      comparisonBase: null,
+      comparisonLabel: null,
+      comparisonPanelOpen: false,
       scopeViolations: [],
     }),
 

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -261,4 +261,19 @@ export interface WorkspaceState extends UndoState {
   createViewDialogOpen: boolean
   setCreateViewDialogOpen: (open: boolean) => void
   setPresentationMode: (on: boolean) => void
+
+  // Revision comparison
+  /** The revision being compared against, parsed read-only. Null when no
+   *  comparison is active. The diff is derived from this plus the live
+   *  workspace, so it tracks edits without extra state. */
+  comparisonBase: Workspace | null
+  /** Where the base revision came from, e.g. `bigbank.dsl`. */
+  comparisonLabel: string | null
+  comparisonPanelOpen: boolean
+  /** Whether the canvas tints added/changed nodes while a comparison is active. */
+  comparisonOverlay: boolean
+  startComparison: (base: Workspace, label: string) => void
+  clearComparison: () => void
+  setComparisonPanelOpen: (open: boolean) => void
+  setComparisonOverlay: (on: boolean) => void
 }

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 import type { WorkspaceState } from './workspace-types'
+import { createCompareSlice } from './slices/compare-slice'
 import { createFilterSlice } from './slices/filter-slice'
 import { createUiSlice } from './slices/ui-slice'
 import { createSelectionSlice } from './slices/selection-slice'
@@ -41,6 +42,7 @@ export {
  */
 export const useWorkspaceStore = create<WorkspaceState>()(
   immer((...a) => ({
+    ...createCompareSlice(...a),
     ...createFilterSlice(...a),
     ...createUiSlice(...a),
     ...createSelectionSlice(...a),


### PR DESCRIPTION
Closes [TEA-82](https://linear.app/kevnord/issue/TEA-82/visual-git-diff-render-architecture-changes-between-two-revisions).

Point c4hero at any other `.dsl` file — an older copy, a branch checkout, a teammate's export — and see exactly what the architecture gained, lost and changed.

## What you get

- **A change list.** Elements, relationships, view membership and workspace metadata, each entry showing the before/after value of every field that moved. Click an element to jump to it on the canvas.
- **The same diff on the canvas.** Added nodes ring green, changed nodes ring amber, untouched ones recede; edges follow the same code. Composes with the highlighter rather than fighting it, and can be toggled off.
- **A live comparison.** The diff is derived from the base revision plus the live workspace, so it updates as you edit — there is no stale-diff state to invalidate. A marker in the top-left names the revision and clears it in one click.
- **Read-only by construction.** `openComparisonFile()` deliberately does not adopt the file handle, write a sidecar, or touch recent files, so picking a revision can never repoint where Save writes.

Reachable from the app menu and the command palette ("Compare with another revision").

## Implementation

`src/lib/workspaceDiff.ts` is a pure, deterministic engine with no DOM, store or clock — the shared model-diff library TEA-82 asks for, and the one TEA-78 can reuse.

The interesting part is identity. Element ids come from the DSL: an authored identifier is used verbatim, but a declaration without one gets a *parse-local* counter id (`p1`, `p2`, …) that is not stable between two parses. Matching on id alone would pair unrelated anonymous elements and report a rename storm, so matching runs in three rounds, strongest evidence first: same id **and** name; same name within the same parent (the identifier was renamed); same *authored* id (the element was renamed). Whatever is left is genuinely added or removed.

## Testing

`npm run check` passes (lint, typecheck, 2381 unit tests, build).

New coverage: 32 tests over the diff engine (including two revisions of a real parsed DSL, and the generated-id hazard above), 10 over the store slice, 17 over the two components, 5 over `openComparisonFile` (with an explicit test that it never repoints the save handle), and 4 over the canvas overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL4NttSfZK6jahZonarDWV