### PR TITLE
feat(app): what's-new release notes pill + dialog (TEA-248)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,11 @@ browser check.
 3. Run the relevant checks locally.
 4. Write a clear commit message.
 5. Open a pull request with context, screenshots, or repro steps when helpful.
+6. If the change is a user-visible feature worth announcing in-app, update the
+   what's-new entry in `src/lib/whatsNew.ts` in the same pull request: set a new
+   `id` (date-slug), the release date, and short user-facing `items`. Skip this
+   for fixes and chores — an unchanged entry shows nobody anything, and forks
+   that never author entries never show the what's-new pill at all.
 
 Good commit examples:
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useAutoSave } from '@/hooks/useAutoSave'
 import { useRouteSync, useRefreshRedirect } from '@/hooks/useRouteSync'
 import FloatingTopPill from '@/components/layout/FloatingTopPill'
+import WhatsNewPill from '@/components/whatsnew/WhatsNewPill'
 import FloatingToolRail from '@/components/layout/FloatingToolRail'
 import FloatingViewsPanel from '@/components/layout/FloatingViewsPanel'
 import FloatingInspector from '@/components/layout/FloatingInspector'
@@ -165,6 +166,11 @@ export default function App() {
       {/* Zoom-in confirm — shown when a user clicks zoom on an element with
           no existing child view. Offers fast create or "Customize…" for full control. */}
       <ZoomConfirmDialog />
+
+      {/* What's-new pill — outside routes so it greets the user wherever they
+          land (welcome or canvas); presentation mode returns earlier and never
+          shows it. Renders nothing unless an unseen release exists. */}
+      <WhatsNewPill />
 
       {/* BYOK AI assistant — only on the canvas (a workspace open on a canvas
           route), never on the welcome/collection screens. */}

--- a/src/components/whatsnew/WhatsNewPill.test.tsx
+++ b/src/components/whatsnew/WhatsNewPill.test.tsx
@@ -3,6 +3,7 @@ import WhatsNewPill from './WhatsNewPill'
 import type { WhatsNewRelease } from '@/lib/whatsNew'
 
 vi.mock('lucide-react', () => ({
+  ExternalLink: () => null,
   Megaphone: () => null,
   X: () => null,
 }))
@@ -62,6 +63,25 @@ describe('WhatsNewPill', () => {
     fireEvent.click(screen.getByRole('button', { name: /dismiss what's new/i }))
     expect(screen.queryByRole('button', { name: /what's new in c4hero/i })).toBeNull()
     expect(localStorage.getItem(KEY)).toBe(release.id)
+  })
+
+  it('shows a release-notes link when the entry provides one, external-safe', () => {
+    localStorage.setItem(KEY, 'older-release')
+    const linked = { ...release, link: { label: 'Full release notes', url: 'https://example.com/notes' } }
+    render(<WhatsNewPill release={linked} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /what's new in c4hero/i }))
+    const link = screen.getByRole('link', { name: /full release notes/i }) as HTMLAnchorElement
+    expect(link.href).toBe('https://example.com/notes')
+    expect(link.target).toBe('_blank')
+    expect(link.rel).toBe('noopener noreferrer')
+  })
+
+  it('shows no link when the entry has none', () => {
+    localStorage.setItem(KEY, 'older-release')
+    render(<WhatsNewPill release={release} />)
+    fireEvent.click(screen.getByRole('button', { name: /what's new in c4hero/i }))
+    expect(screen.queryByRole('link')).toBeNull()
   })
 
   it('closing the dialog without dismissing keeps the pill armed', () => {

--- a/src/components/whatsnew/WhatsNewPill.test.tsx
+++ b/src/components/whatsnew/WhatsNewPill.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import WhatsNewPill from './WhatsNewPill'
+import type { WhatsNewRelease } from '@/lib/whatsNew'
+
+vi.mock('lucide-react', () => ({
+  Sparkles: () => null,
+  X: () => null,
+}))
+
+const KEY = 'c4hero.whatsNewDismissed'
+
+const release: WhatsNewRelease = {
+  id: '2026-09-01-test',
+  date: 'September 1, 2026',
+  items: [
+    { title: 'Deployment views', body: 'Model environments and instances.' },
+    { title: 'Dynamic views', body: 'Ordered interaction steps.' },
+  ],
+}
+
+beforeEach(() => localStorage.clear())
+
+describe('WhatsNewPill', () => {
+  it('renders nothing when there is no release', () => {
+    render(<WhatsNewPill release={null} />)
+    expect(screen.queryByRole('button', { name: /what's new/i })).toBeNull()
+  })
+
+  it('renders nothing on first-ever launch, and seeds the stored id', () => {
+    render(<WhatsNewPill release={release} />)
+    expect(screen.queryByRole('button', { name: /what's new/i })).toBeNull()
+    expect(localStorage.getItem(KEY)).toBe(release.id)
+  })
+
+  it('shows the pill for an undismissed release and opens the details dialog', () => {
+    localStorage.setItem(KEY, 'older-release')
+    render(<WhatsNewPill release={release} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /what's new in c4hero/i }))
+    const dialog = screen.getByRole('dialog', { name: /what's new/i })
+    expect(dialog.textContent).toContain('Deployment views')
+    expect(dialog.textContent).toContain('Dynamic views')
+    expect(dialog.textContent).toContain('September 1, 2026')
+  })
+
+  it('"Got it" dismisses: dialog and pill disappear, id is stored', () => {
+    localStorage.setItem(KEY, 'older-release')
+    render(<WhatsNewPill release={release} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /what's new in c4hero/i }))
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }))
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.queryByRole('button', { name: /what's new in c4hero/i })).toBeNull()
+    expect(localStorage.getItem(KEY)).toBe(release.id)
+  })
+
+  it('the pill ✕ dismisses without opening the dialog', () => {
+    localStorage.setItem(KEY, 'older-release')
+    render(<WhatsNewPill release={release} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss what's new/i }))
+    expect(screen.queryByRole('button', { name: /what's new in c4hero/i })).toBeNull()
+    expect(localStorage.getItem(KEY)).toBe(release.id)
+  })
+
+  it('closing the dialog without dismissing keeps the pill armed', () => {
+    localStorage.setItem(KEY, 'older-release')
+    render(<WhatsNewPill release={release} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /what's new in c4hero/i }))
+    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }))
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.getByRole('button', { name: /what's new in c4hero/i })).toBeTruthy()
+    expect(localStorage.getItem(KEY)).toBe('older-release')
+  })
+})

--- a/src/components/whatsnew/WhatsNewPill.test.tsx
+++ b/src/components/whatsnew/WhatsNewPill.test.tsx
@@ -3,7 +3,7 @@ import WhatsNewPill from './WhatsNewPill'
 import type { WhatsNewRelease } from '@/lib/whatsNew'
 
 vi.mock('lucide-react', () => ({
-  Sparkles: () => null,
+  Megaphone: () => null,
   X: () => null,
 }))
 

--- a/src/components/whatsnew/WhatsNewPill.tsx
+++ b/src/components/whatsnew/WhatsNewPill.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Megaphone, X } from 'lucide-react'
+import { ExternalLink, Megaphone, X } from 'lucide-react'
 import DialogShell from '@/components/shared/DialogShell'
 import { WHATS_NEW, unseenRelease, dismissRelease, type WhatsNewRelease } from '@/lib/whatsNew'
 
@@ -89,7 +89,18 @@ export default function WhatsNewPill({ release = WHATS_NEW }: { release?: WhatsN
             ))}
           </ul>
 
-          <div className="mt-4 flex justify-end">
+          <div className="mt-4 flex items-center justify-between">
+            {unseen.link ? (
+              <a
+                href={unseen.link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[12px]"
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--color-accent)' }}
+              >
+                {unseen.link.label} <ExternalLink size={11} />
+              </a>
+            ) : <span />}
             <button onClick={dismiss} className="btn-surface">
               Got it
             </button>

--- a/src/components/whatsnew/WhatsNewPill.tsx
+++ b/src/components/whatsnew/WhatsNewPill.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Sparkles, X } from 'lucide-react'
+import { Megaphone, X } from 'lucide-react'
 import DialogShell from '@/components/shared/DialogShell'
 import { WHATS_NEW, unseenRelease, dismissRelease, type WhatsNewRelease } from '@/lib/whatsNew'
 
@@ -51,7 +51,7 @@ export default function WhatsNewPill({ release = WHATS_NEW }: { release?: WhatsN
             cursor: 'pointer',
           }}
         >
-          <Sparkles size={13} style={{ color: 'var(--color-accent)' }} />
+          <Megaphone size={13} style={{ color: 'var(--color-accent)' }} />
           What's new
         </button>
         <button
@@ -72,7 +72,7 @@ export default function WhatsNewPill({ release = WHATS_NEW }: { release?: WhatsN
         >
           <div className="flex items-center justify-between mb-1">
             <h2 className="text-sm font-semibold" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <Sparkles size={14} style={{ color: 'var(--color-accent)' }} /> What's new
+              <Megaphone size={14} style={{ color: 'var(--color-accent)' }} /> What's new
             </h2>
             <button onClick={() => setOpen(false)} className="btn-icon !min-h-7 !min-w-7 !p-1" aria-label="Close dialog">
               <X size={14} />
@@ -90,11 +90,7 @@ export default function WhatsNewPill({ release = WHATS_NEW }: { release?: WhatsN
           </ul>
 
           <div className="mt-4 flex justify-end">
-            <button
-              onClick={dismiss}
-              className="rounded-lg border px-3 py-1.5 text-sm"
-              style={{ background: 'var(--color-surface-2)', borderColor: 'var(--color-border)', color: 'var(--color-text-primary)' }}
-            >
+            <button onClick={dismiss} className="btn-surface">
               Got it
             </button>
           </div>

--- a/src/components/whatsnew/WhatsNewPill.tsx
+++ b/src/components/whatsnew/WhatsNewPill.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { Sparkles, X } from 'lucide-react'
+import DialogShell from '@/components/shared/DialogShell'
+import { WHATS_NEW, unseenRelease, dismissRelease, type WhatsNewRelease } from '@/lib/whatsNew'
+
+/** Subtle what's-new affordance: a small pill that appears when a release the
+ *  user hasn't dismissed is available. Clicking it opens the details dialog;
+ *  dismissing (pill ✕ or the dialog's Got it) hides it until a new release id
+ *  ships. Renders nothing at all when there's nothing unseen.
+ *
+ *  `release` is injectable for tests; production mounts read WHATS_NEW. */
+export default function WhatsNewPill({ release = WHATS_NEW }: { release?: WhatsNewRelease | null }) {
+  const [unseen, setUnseen] = useState(() => unseenRelease(release))
+  const [open, setOpen] = useState(false)
+
+  if (!unseen) return null
+
+  const dismiss = () => {
+    dismissRelease(unseen)
+    setOpen(false)
+    setUnseen(null)
+  }
+
+  return (
+    <>
+      <div
+        className="glass-flyout"
+        style={{
+          position: 'fixed',
+          top: 'max(14px, env(safe-area-inset-top, 0px))',
+          right: 14,
+          zIndex: 40,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '4px 6px 4px 10px',
+        }}
+      >
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="What's new in c4hero"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            fontSize: 12,
+            color: 'var(--color-text-primary)',
+            cursor: 'pointer',
+          }}
+        >
+          <Sparkles size={13} style={{ color: 'var(--color-accent)' }} />
+          What's new
+        </button>
+        <button
+          onClick={dismiss}
+          aria-label="Dismiss what's new"
+          className="btn-icon !min-h-6 !min-w-6 !p-1"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      {open && (
+        <DialogShell
+          onClose={() => setOpen(false)}
+          ariaLabel="What's new in c4hero"
+          className="w-full max-w-md rounded-xl border p-5 shadow-2xl"
+          style={{ background: 'var(--color-surface-1)', borderColor: 'var(--color-border)' }}
+        >
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-sm font-semibold" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Sparkles size={14} style={{ color: 'var(--color-accent)' }} /> What's new
+            </h2>
+            <button onClick={() => setOpen(false)} className="btn-icon !min-h-7 !min-w-7 !p-1" aria-label="Close dialog">
+              <X size={14} />
+            </button>
+          </div>
+          <div className="mb-3 text-[11px]" style={{ color: 'var(--color-text-muted)' }}>{unseen.date}</div>
+
+          <ul style={{ display: 'flex', flexDirection: 'column', gap: 12, margin: 0, padding: 0, listStyle: 'none' }}>
+            {unseen.items.map((item) => (
+              <li key={item.title}>
+                <div className="text-[13px] font-medium" style={{ color: 'var(--color-text-primary)' }}>{item.title}</div>
+                <div className="text-[12px]" style={{ color: 'var(--color-text-muted)', marginTop: 2 }}>{item.body}</div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-4 flex justify-end">
+            <button
+              onClick={dismiss}
+              className="rounded-lg border px-3 py-1.5 text-sm"
+              style={{ background: 'var(--color-surface-2)', borderColor: 'var(--color-border)', color: 'var(--color-text-primary)' }}
+            >
+              Got it
+            </button>
+          </div>
+        </DialogShell>
+      )}
+    </>
+  )
+}

--- a/src/lib/whatsNew.test.ts
+++ b/src/lib/whatsNew.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { unseenRelease, dismissRelease, type WhatsNewRelease } from './whatsNew'
+
+const KEY = 'c4hero.whatsNewDismissed'
+
+const release: WhatsNewRelease = {
+  id: '2026-09-01-test',
+  date: 'September 1, 2026',
+  items: [{ title: 'Thing', body: 'Does stuff.' }],
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.restoreAllMocks())
+
+describe('unseenRelease', () => {
+  it('returns null when there is no release (feature dormant)', () => {
+    expect(unseenRelease(null)).toBeNull()
+  })
+
+  it('returns null for a release with no items', () => {
+    expect(unseenRelease({ ...release, items: [] })).toBeNull()
+  })
+
+  it('seeds first-ever launch silently: nothing shown, id stored', () => {
+    expect(unseenRelease(release)).toBeNull()
+    expect(localStorage.getItem(KEY)).toBe(release.id)
+  })
+
+  it('returns the release when a DIFFERENT id was dismissed', () => {
+    localStorage.setItem(KEY, 'some-older-release')
+    expect(unseenRelease(release)).toBe(release)
+    // Peeking must not mark it seen — only dismissal does.
+    expect(localStorage.getItem(KEY)).toBe('some-older-release')
+  })
+
+  it('returns null when the SAME id was already dismissed', () => {
+    localStorage.setItem(KEY, release.id)
+    expect(unseenRelease(release)).toBeNull()
+  })
+
+  it('fails closed when localStorage throws', () => {
+    localStorage.setItem(KEY, 'some-older-release')
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('denied') })
+    expect(unseenRelease(release)).toBeNull()
+  })
+})
+
+describe('dismissRelease', () => {
+  it('stores the id so the release never shows again', () => {
+    localStorage.setItem(KEY, 'some-older-release')
+    expect(unseenRelease(release)).toBe(release)
+    dismissRelease(release)
+    expect(unseenRelease(release)).toBeNull()
+  })
+
+  it('swallows storage errors', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('denied') })
+    expect(() => dismissRelease(release)).not.toThrow()
+  })
+})

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -1,0 +1,57 @@
+// What's-new release notes: a curated, build-time announcement of user-visible
+// changes. The pill/dialog UI (components/whatsnew) shows WHATS_NEW when its id
+// differs from the one the user last dismissed.
+//
+// Authoring convention: bump this as part of the PR that ships a user-visible
+// feature — new `id` (date-slug), fresh `items`, user-facing language. Leave it
+// alone for fixes/chores nobody needs an announcement for. `null` keeps the
+// whole feature dormant, which is also the "off switch" for forks that don't
+// want release notes: no config, no code changes, just no content.
+
+export interface WhatsNewItem {
+  title: string
+  body: string
+}
+
+export interface WhatsNewRelease {
+  /** Stable identifier for this announcement, e.g. "2026-09-02-deployment-views".
+   *  A changed id re-arms the pill for everyone; an unchanged id never re-nags. */
+  id: string
+  /** Human-readable release date, shown in the dialog. */
+  date: string
+  items: WhatsNewItem[]
+}
+
+export const WHATS_NEW: WhatsNewRelease | null = null
+
+const STORAGE_KEY = 'c4hero.whatsNewDismissed'
+
+/** The release the user hasn't seen yet, or null when there's nothing to show.
+ *
+ *  First-ever launch (no stored value) seeds the current id WITHOUT showing:
+ *  to a brand-new user everything is new, so an announcement is noise. When
+ *  localStorage is unavailable (private mode, embeds) this fails closed —
+ *  better to never show than to nag on every launch. */
+export function unseenRelease(release: WhatsNewRelease | null = WHATS_NEW): WhatsNewRelease | null {
+  if (!release || release.items.length === 0) return null
+  try {
+    const dismissed = localStorage.getItem(STORAGE_KEY)
+    if (dismissed === null) {
+      localStorage.setItem(STORAGE_KEY, release.id)
+      return null
+    }
+    return dismissed === release.id ? null : release
+  } catch {
+    return null
+  }
+}
+
+/** Mark a release as seen so it never shows again (until a new id ships). */
+export function dismissRelease(release: WhatsNewRelease): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, release.id)
+  } catch {
+    // No storage — the pill still hides for this session; next launch fails
+    // closed in unseenRelease, so the user is never nagged repeatedly.
+  }
+}

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -20,6 +20,9 @@ export interface WhatsNewRelease {
   /** Human-readable release date, shown in the dialog. */
   date: string
   items: WhatsNewItem[]
+  /** Optional "full release notes" link shown in the dialog footer — point it
+   *  at the changelog section or announcement post for this release. */
+  link?: { label: string; url: string }
 }
 
 export const WHATS_NEW: WhatsNewRelease | null = null


### PR DESCRIPTION
## Summary
- Adds a curated, build-time what's-new system: `src/lib/whatsNew.ts` holds a single release entry (`{ id, date, items }`). `null` (the shipped state) keeps the feature fully dormant — that's also the natural off switch for open-source forks/self-hosters: no config flag, just no content.
- When the entry's `id` differs from the last-dismissed id in `localStorage`, a subtle top-right **What's new** pill appears (welcome + canvas, never presentation mode). Clicking opens a details dialog; dismissing (pill ✕ or **Got it**) stores the id so it never reappears until a new id ships.
- Politeness guards: first-ever launch seeds the current id silently (everything is new to a new user), and localStorage failures fail closed — never nag.
- Documents the authoring convention in CONTRIBUTING.md: bump the entry in the same PR that ships a user-visible feature.

Ships with no active entry — the deployment/dynamic views release (#138) will author the first one.

## Test plan
- 8 unit tests for the seen/unseen/dismiss logic (first-launch seeding, re-arm on new id, storage failure fail-closed)
- 6 component tests for the pill/dialog (hidden states, open, both dismiss paths, close-without-dismiss keeps it armed)
- `npm run check` green: lint, typecheck, 2327 tests, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYbYWAfHS9XGxUycg1kVsH