### PR TITLE
feat(whatsnew): gate the pill behind opt-in VITE_WHATS_NEW build flag (TEA-248)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@
 # VITE_SENTRY_DSN=https://public-key@o000000.ingest.us.sentry.io/000000
 # VITE_SENTRY_ENVIRONMENT=production
 
+# Optional: show the in-app "What's new" release-notes pill when an unseen
+# release entry exists in src/lib/whatsNew.ts. Leave unset for local/self-hosted
+# builds — the pill is disabled by default and shows nothing without this flag.
+# VITE_WHATS_NEW=1
+
 # Optional: extra hostnames the Vite dev server will accept (comma-separated),
 # e.g. when developing through a tunnel or reverse-proxy domain. Leave unset
 # for normal localhost development.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ Optional variables are documented in `.env.example`:
   proxy that terminates TLS
 - `VITE_LOG_ENDPOINT`, to send warn/error logs to an HTTPS endpoint; remember to
   add that origin to the deployment CSP `connect-src`
+- `VITE_WHATS_NEW`, to enable the in-app "What's new" release-notes pill
+  (disabled by default; self-hosted builds show nothing without it)
 
 Keep local overrides out of git.
 
@@ -131,8 +133,9 @@ browser check.
 6. If the change is a user-visible feature worth announcing in-app, update the
    what's-new entry in `src/lib/whatsNew.ts` in the same pull request: set a new
    `id` (date-slug), the release date, and short user-facing `items`. Skip this
-   for fixes and chores — an unchanged entry shows nobody anything, and forks
-   that never author entries never show the what's-new pill at all.
+   for fixes and chores — an unchanged entry shows nobody anything. The pill
+   only appears on builds that opt in with `VITE_WHATS_NEW=1` (the hosted app
+   does; local and self-hosted builds are off by default).
 
 Good commit examples:
 

--- a/src/components/whatsnew/WhatsNewPill.test.tsx
+++ b/src/components/whatsnew/WhatsNewPill.test.tsx
@@ -19,9 +19,20 @@ const release: WhatsNewRelease = {
   ],
 }
 
-beforeEach(() => localStorage.clear())
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubEnv('VITE_WHATS_NEW', '1')
+})
+afterEach(() => vi.unstubAllEnvs())
 
 describe('WhatsNewPill', () => {
+  it('renders nothing when the build-time flag is off, even with an undismissed release', () => {
+    vi.unstubAllEnvs()
+    localStorage.setItem(KEY, 'older-release')
+    render(<WhatsNewPill release={release} />)
+    expect(screen.queryByRole('button', { name: /what's new/i })).toBeNull()
+  })
+
   it('renders nothing when there is no release', () => {
     render(<WhatsNewPill release={null} />)
     expect(screen.queryByRole('button', { name: /what's new/i })).toBeNull()

--- a/src/lib/whatsNew.test.ts
+++ b/src/lib/whatsNew.test.ts
@@ -9,8 +9,39 @@ const release: WhatsNewRelease = {
   items: [{ title: 'Thing', body: 'Does stuff.' }],
 }
 
-beforeEach(() => localStorage.clear())
-afterEach(() => vi.restoreAllMocks())
+beforeEach(() => {
+  localStorage.clear()
+  // Most cases test the enabled behavior; the opt-in default gets its own suite.
+  vi.stubEnv('VITE_WHATS_NEW', '1')
+})
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('build-time opt-in (VITE_WHATS_NEW)', () => {
+  it('is disabled by default: no pill, and storage is never touched', () => {
+    vi.unstubAllEnvs()
+    localStorage.setItem(KEY, 'some-older-release')
+    expect(unseenRelease(release)).toBeNull()
+    // No first-launch seeding either — flipping the flag on later starts clean.
+    localStorage.clear()
+    expect(unseenRelease(release)).toBeNull()
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('accepts "true" as well as "1"', () => {
+    vi.stubEnv('VITE_WHATS_NEW', 'true')
+    localStorage.setItem(KEY, 'some-older-release')
+    expect(unseenRelease(release)).toBe(release)
+  })
+
+  it('any other value stays disabled', () => {
+    vi.stubEnv('VITE_WHATS_NEW', 'on')
+    localStorage.setItem(KEY, 'some-older-release')
+    expect(unseenRelease(release)).toBeNull()
+  })
+})
 
 describe('unseenRelease', () => {
   it('returns null when there is no release (feature dormant)', () => {

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -27,6 +27,15 @@ export interface WhatsNewRelease {
 
 export const WHATS_NEW: WhatsNewRelease | null = null
 
+/** Build-time opt-in: the what's-new pill only ever shows on builds with
+ *  VITE_WHATS_NEW=1 (or true). Default is OFF — self-hosted and fork builds
+ *  show nothing even when release entries exist in the source; the hosted app
+ *  turns it on via its deploy environment. */
+export function whatsNewEnabled(): boolean {
+  const v = import.meta.env.VITE_WHATS_NEW
+  return v === '1' || v === 'true'
+}
+
 const STORAGE_KEY = 'c4hero.whatsNewDismissed'
 
 /** The release the user hasn't seen yet, or null when there's nothing to show.
@@ -36,6 +45,9 @@ const STORAGE_KEY = 'c4hero.whatsNewDismissed'
  *  localStorage is unavailable (private mode, embeds) this fails closed —
  *  better to never show than to nag on every launch. */
 export function unseenRelease(release: WhatsNewRelease | null = WHATS_NEW): WhatsNewRelease | null {
+  // Disabled builds bail before touching storage — no seeding, no reads, so
+  // enabling the flag later still gets the clean first-launch behavior.
+  if (!whatsNewEnabled()) return null
   if (!release || release.items.length === 0) return null
   try {
     const dismissed = localStorage.getItem(STORAGE_KEY)


### PR DESCRIPTION
Follow-up to #158, making the what's-new pill truly opt-in for the open-source project:

- **Disabled by default**: even when a release entry exists in `src/lib/whatsNew.ts`, forks and self-hosted builds show nothing unless the build sets `VITE_WHATS_NEW=1` (or `true`). Without this, the first authored entry would have appeared on every build from source.
- The hosted app (app.c4hero.com) opts in via its Vercel environment.
- Disabled builds never touch localStorage — flipping the flag on later still gets the clean first-launch seeding behavior.
- Documented in `.env.example` and CONTRIBUTING (env vars section + PR checklist), following the same opt-in pattern as analytics/Sentry.

Test plan: 4 new tests (default-off with storage untouched, `true` accepted, other values rejected, component renders nothing when off); `npm run check` green (2333 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYbYWAfHS9XGxUycg1kVsH