### PR TITLE
chore(release): prepare 0.4.0 (dynamic & deployment views)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-30
+
 ### Added
 
 - **Dynamic and deployment views — c4hero now covers the complete C4 view
@@ -186,6 +188,7 @@ Initial public release. c4hero is a local-first browser-based visual editor for 
 - Canvas interactions no longer trigger browser-back navigation on Backspace in non-text contexts.
 - Boundary-node E2E selectors now match the per-scope ID format.
 
+[0.4.0]: https://github.com/c4hero/c4hero/releases/tag/v0.4.0
 [0.3.0]: https://github.com/c4hero/c4hero/releases/tag/v0.3.0
 [0.2.2]: https://github.com/c4hero/c4hero/releases/tag/v0.2.2
 [0.2.1]: https://github.com/c4hero/c4hero/releases/tag/v0.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c4hero",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c4hero",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dagrejs/dagre": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c4hero",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Local-first visual architecture modelling for the C4 model. Edit visually, save as Structurizr DSL — your architecture lives in your repo.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump 0.3.0 → 0.4.0 and CHANGELOG cut for the release: dynamic + deployment views (TEA-81), visual topology/step authoring, scoped-view clarity, view/node layout locks (TEA-161/227), and the what's-new pill (TEA-248). Tag + GitHub release to follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYbYWAfHS9XGxUycg1kVsH