### PR TITLE
fix(whatsnew): show the first announcement to returning users (TEA-248)

### DIFF
--- a/src/lib/whatsNew.test.ts
+++ b/src/lib/whatsNew.test.ts
@@ -52,7 +52,27 @@ describe('unseenRelease', () => {
     expect(unseenRelease({ ...release, items: [] })).toBeNull()
   })
 
-  it('seeds first-ever launch silently: nothing shown, id stored', () => {
+  it('seeds a truly new user silently: nothing shown, id stored', () => {
+    expect(unseenRelease(release)).toBeNull()
+    expect(localStorage.getItem(KEY)).toBe(release.id)
+  })
+
+  it('shows the release to a returning user (app state exists, no dismissed id)', () => {
+    // Any c4hero* key proves the browser used the app before the feature
+    // shipped — the FIRST announcement must reach these users.
+    localStorage.setItem('c4hero_recent_files', '[]')
+    expect(unseenRelease(release)).toBe(release)
+    // Not seeded either — only an actual dismissal stores the id.
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('viewport keys also count as prior app state', () => {
+    localStorage.setItem('c4hero.viewport.Workspace.context', '{}')
+    expect(unseenRelease(release)).toBe(release)
+  })
+
+  it('non-app storage keys do NOT count as prior app state', () => {
+    localStorage.setItem('some-other-site-key', 'x')
     expect(unseenRelease(release)).toBeNull()
     expect(localStorage.getItem(KEY)).toBe(release.id)
   })

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -26,7 +26,9 @@ export interface WhatsNewRelease {
 }
 
 export const WHATS_NEW: WhatsNewRelease | null = {
-  id: '2026-08-deployment-dynamic-views',
+  // The "-r2" re-arms this announcement for users who visited during the
+  // window where the first-launch rule silently seeded them (see below).
+  id: '2026-08-deployment-dynamic-views-r2',
   date: 'August 2026',
   items: [
     {
@@ -56,12 +58,27 @@ export function whatsNewEnabled(): boolean {
 
 const STORAGE_KEY = 'c4hero.whatsNewDismissed'
 
+/** Every app storage key starts with "c4hero" (c4hero_crash_recovery,
+ *  c4hero_recent_files, c4hero.viewport.*, …), so any such key that isn't ours
+ *  proves the browser used the app before this feature existed. Without this
+ *  check, existing users are indistinguishable from brand-new ones and the
+ *  FIRST announcement after the feature ships would reach nobody. */
+function hasPriorAppState(): boolean {
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key && key !== STORAGE_KEY && key.startsWith('c4hero')) return true
+  }
+  return false
+}
+
 /** The release the user hasn't seen yet, or null when there's nothing to show.
  *
- *  First-ever launch (no stored value) seeds the current id WITHOUT showing:
- *  to a brand-new user everything is new, so an announcement is noise. When
- *  localStorage is unavailable (private mode, embeds) this fails closed —
- *  better to never show than to nag on every launch. */
+ *  No stored value + no other app state = a brand-new user: seed the current
+ *  id WITHOUT showing (everything is new to them, an announcement is noise).
+ *  No stored value + existing app state = a returning user from before the
+ *  feature shipped: show the release. When localStorage is unavailable
+ *  (private mode, embeds) this fails closed — better to never show than to
+ *  nag on every launch. */
 export function unseenRelease(release: WhatsNewRelease | null = WHATS_NEW): WhatsNewRelease | null {
   // Disabled builds bail before touching storage — no seeding, no reads, so
   // enabling the flag later still gets the clean first-launch behavior.
@@ -70,6 +87,7 @@ export function unseenRelease(release: WhatsNewRelease | null = WHATS_NEW): What
   try {
     const dismissed = localStorage.getItem(STORAGE_KEY)
     if (dismissed === null) {
+      if (hasPriorAppState()) return release
       localStorage.setItem(STORAGE_KEY, release.id)
       return null
     }


### PR DESCRIPTION
On production, the v0.4.0 what's-new entry reached zero users: nobody had the dismissed-id key before the feature shipped, so every existing user was indistinguishable from a brand-new one and got silently seeded.

- `unseenRelease` now treats any other `c4hero*` localStorage key (crash recovery, recent files/folders, viewports) as proof of prior use — those browsers see the pill; truly-new browsers still seed silently.
- The entry id gets an `-r2` suffix so users seeded during the gap (visited prod since the v0.4.0 deploy) are re-armed.
- 3 new tests (returning user via `c4hero_recent_files`, via viewport key, and non-app keys not counting); full check green (2409 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYbYWAfHS9XGxUycg1kVsH