### PR TITLE
chore(release): prepare 0.5.0 (code pane, impact analysis, HTML export)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-05
+
 ### Added
 
 - **Edit the DSL next to the canvas, live in both directions.** A dockable
@@ -34,6 +36,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a chat attachment or from a years-old build artifact, with or without c4hero.
   Exports are deterministic, so they diff cleanly in review. Find it in the
   Export dialog or the command palette ("Export as interactive HTML"). (TEA-88)
+- **Readable, editable element IDs.** Elements used to carry random eight-letter
+  ids, which then became the identifiers in exported DSL. New elements now
+  derive a `camelCase` id from their name and keep re-deriving it as you rename,
+  so the DSL keeps tracking what things are called. Edit the id yourself in the
+  inspector and it pins — renames stop touching it — with a sync button to go
+  back to deriving. Identifiers that came from imported DSL are pinned from the
+  start, because whoever wrote `paymentService = container ...` chose that name.
+  Changing an id cascades through every relationship, view, group and deployment
+  instance that references it, as a single undo step. Existing workspaces need
+  no migration. (TEA-242)
+
+### Fixed
+
+- **The what's-new pill now reaches returning users.** The 0.4.0 announcement
+  went out to nobody: no existing user had a dismissed-id stored yet, so every
+  one of them looked like a brand-new visitor and was silently seeded instead of
+  shown the release. Prior use is now detected from any other `c4hero*` browser
+  storage key, and genuinely new visitors are still seeded in silence.
+  (TEA-248)
 
 ## [0.4.0] - 2026-08-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c4hero",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Local-first visual architecture modelling for the C4 model. Edit visually, save as Structurizr DSL — your architecture lives in your repo.",
   "license": "Apache-2.0",

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -2,11 +2,13 @@
 // changes. The pill/dialog UI (components/whatsnew) shows WHATS_NEW when its id
 // differs from the one the user last dismissed.
 //
-// Authoring convention: bump this as part of the PR that ships a user-visible
-// feature — new `id` (date-slug), fresh `items`, user-facing language. Leave it
-// alone for fixes/chores nobody needs an announcement for. `null` keeps the
-// whole feature dormant, which is also the "off switch" for forks that don't
-// want release notes: no config, no code changes, just no content.
+// Authoring convention: bump this once per release, in the release PR — new
+// `id` (date-slug), fresh `items`, user-facing language — curated across
+// everything that shipped rather than accreted one bullet per feature PR.
+// Per-PR changelog entries in CHANGELOG.md are what feed it. Leave it alone for
+// fixes/chores nobody needs an announcement for. `null` keeps the whole feature
+// dormant, which is also the "off switch" for forks that don't want release
+// notes: no config, no code changes, just no content.
 
 export interface WhatsNewItem {
   title: string
@@ -26,25 +28,27 @@ export interface WhatsNewRelease {
 }
 
 export const WHATS_NEW: WhatsNewRelease | null = {
-  // The "-r2" re-arms this announcement for users who visited during the
-  // window where the first-launch rule silently seeded them (see below).
-  id: '2026-08-deployment-dynamic-views-r2',
-  date: 'August 2026',
+  id: '2026-09-code-pane-impact-export',
+  date: 'September 2026',
   items: [
     {
-      title: 'Deployment views',
-      body: 'Model deployment environments — nodes, infrastructure, and container/system instances — and see them rendered as nested boundaries on the canvas, with relationships drawn automatically between instances.',
+      title: 'Live DSL code pane',
+      body: 'Open the workspace as Structurizr DSL beside the canvas and edit either one — changes flow both ways. Your layout survives the round trip, and a document that does not parse simply never applies.',
     },
     {
-      title: 'Dynamic views',
-      body: 'Author ordered interaction steps over your model and see them numbered on the diagram, including repeated steps and responses.',
+      title: 'See what breaks before you delete',
+      body: 'Ask what happens if an element is removed and get the exact blast radius: what goes with it, which relationships lose an end, what depended on it, and which views disappear. Counted from your model, not estimated.',
     },
     {
-      title: 'Clearer scoped views',
-      body: 'The deployment topology editor now shows the view’s scope, flags elements the scope hides, and links straight to the unscoped view.',
+      title: 'Export one interactive HTML file',
+      body: 'Every view, rendered and wrapped in a small read-only viewer with tabs, zoom, drill-through and search. No dependencies and no network calls, so it opens from disk or a wiki years later.',
+    },
+    {
+      title: 'Readable element IDs',
+      body: 'Elements now take a readable id derived from their name instead of a random string, and you can edit it. Exported DSL reads like something a person wrote.',
     },
   ],
-  link: { label: 'Full release notes', url: 'https://github.com/c4hero/c4hero/blob/main/CHANGELOG.md' },
+  link: { label: 'Full release notes', url: 'https://c4hero.com/changelog' },
 }
 
 /** Build-time opt-in: the what's-new pill only ever shows on builds with


### PR DESCRIPTION
Cuts `[Unreleased]` into `## [0.5.0] - 2026-09-05` and bumps `package.json` to 0.5.0.

## What's in 0.5.0

| Feature | Ticket | Shipped in |
|---|---|---|
| Live two-way DSL code pane | TEA-252 | #162 |
| Removal impact — what breaks before you delete | TEA-72 | #157 |
| Self-contained interactive HTML export | TEA-88 | #156 |
| Readable, editable element IDs | TEA-242 | #154 |
| Fix: what's-new pill reaches returning users | TEA-248 | #161 |

## Two entries written from scratch

TEA-242 and TEA-248 both merged with **no CHANGELOG entry at all** — the audit step caught them. They're written up here rather than left out of the release.

## What's new

`src/lib/whatsNew.ts` gets a new `id` (`2026-09-code-pane-impact-export`), so the pill re-arms for everyone, and four curated items. The footer link now points at `c4hero.com/changelog` instead of the raw `CHANGELOG.md` on GitHub — the site renders the same content properly.

Its authoring comment changes too. It used to say to bump the file in the PR that ships a feature; that conflicts with curating a release. It now says once per release, in the release PR, fed by the per-PR CHANGELOG entries.

Reminder: the pill only renders where `VITE_WHATS_NEW=1`, which is set in the hosted Vercel environment.

## Companion PR

The landing site's `public/CHANGELOG.md` is a separate hand-written rewrite in its own voice — c4hero-landing#73.

## Testing

`npm run check` passes: lint, typecheck, 2557 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs
