### PR TITLE
feat(files): watch mode — reload the workspace when the .dsl changes on disk (TEA-323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Watch mode: the canvas follows the file on disk.** Disk sync used to be
+  one-way — c4hero wrote, nothing read back — so editing the `.dsl` in another
+  editor or switching git branches left a stale diagram that the next autosave
+  would silently overwrite. Now the open workspace (and its sidecar) is watched
+  and reloaded within a couple of seconds of changing, keeping your active
+  view, viewport and selection. Check out the PR branch and the diagram is just
+  there. Unsaved local edits are never discarded: a conflict bar offers
+  *Reload (discard my changes)* or *Keep mine*. Text that doesn't parse, or
+  parses to an empty model, is reported and left unapplied; a deleted file
+  leaves your work on the canvas with a hint to save. Only visible tabs poll,
+  c4hero's own saves never count as changes, and the collection list refreshes
+  when the tab regains focus. Toggle it with the *Watch Mode* command;
+  default on wherever a file or folder is linked. (TEA-323)
+
 ## [0.5.0] - 2026-09-05
 
 ### Added

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -25,6 +25,7 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 - **Single-file mode** (all browsers): open a `.dsl` file directly. Saves either go back to the source handle (where supported) or trigger a download.
 - **Recent collections / files** are remembered in `localStorage` and re-openable from the welcome screen.
 - **Crash recovery**: the active workspace is mirrored to `localStorage`. If the tab crashes or you close it mid-edit, the next launch offers to restore.
+- **Watch mode**: the open `.dsl` (and its sidecar) is polled while the tab is visible and reloaded when it changes outside c4hero — an external editor, a `git checkout`. Active view, viewport, and selection are kept. If you have unsaved local edits, a conflict bar offers *Reload* or *Keep mine* instead of picking for you; unparseable text is reported and not applied; a deleted file leaves your model in place. c4hero's own saves are recognised and never trigger a reload. Toggle via the *Watch Mode* command (default on when a file or folder is linked).
 
 ## Editing UX
 

--- a/e2e/file-io/watch-mode.spec.ts
+++ b/e2e/file-io/watch-mode.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '../fixtures/workspace'
+
+// Real File System Access handles can't be driven from Playwright, so these
+// tests use the dev-only `window.__testFileSource` stand-in: an in-memory
+// "file" the disk watcher polls exactly like a handle.
+
+const BASE = `workspace "Watch" {
+  model {
+    u = person "User"
+    sys = softwareSystem "Sys"
+    u -> sys "Uses"
+  }
+  views {
+    systemLandscape "Land" { include * }
+    systemContext sys "Ctx" { include * }
+  }
+}`
+
+const WITH_PAYMENTS = BASE.replace(
+  'sys = softwareSystem "Sys"',
+  'sys = softwareSystem "Sys"\n    pay = softwareSystem "Payments"',
+)
+
+type FileSourceApi = {
+  install: (filename: string, content: string, sidecarJson?: string) => void
+  set: (content: string, sidecarJson?: string) => void
+  remove: () => void
+  clear: () => void
+}
+
+function fileSource(page: import('@playwright/test').Page) {
+  const call = <K extends keyof FileSourceApi>(method: K, ...args: Parameters<FileSourceApi[K]>) =>
+    page.evaluate(
+      ({ method, args }) => {
+        const api = (window as unknown as { __testFileSource: FileSourceApi }).__testFileSource
+        ;(api[method] as (...a: unknown[]) => void)(...args)
+      },
+      { method, args },
+    )
+  return {
+    install: (filename: string, content: string) => call('install', filename, content),
+    set: (content: string) => call('set', content),
+    remove: () => call('remove'),
+    clear: () => call('clear'),
+  }
+}
+
+test.describe('Watch mode', () => {
+  test.afterEach(async ({ page }) => {
+    await fileSource(page).clear().catch(() => {})
+  })
+
+  test('reloads the canvas when the file changes on disk and keeps the active view', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(BASE)
+    await workspace.setView('Ctx')
+    await fileSource(page).install('watch.dsl', BASE)
+
+    // The model picks up the new element within a poll interval. (It isn't
+    // related to Sys, so the system-context view we're on doesn't show it —
+    // which is exactly why the active view must survive the swap.)
+    await fileSource(page).set(WITH_PAYMENTS)
+    await expect.poll(async () => {
+      const ws = await workspace.getWorkspace()
+      return ws?.model.softwareSystems.map((s) => s.name) ?? []
+    }, { timeout: 6000 }).toContain('Payments')
+
+    // The user's place is preserved and the workspace is clean.
+    const state = await page.evaluate(() => {
+      const s = (window as unknown as { __testStore: () => { activeViewKey: string; undoStack: unknown[]; diskConflict: unknown } }).__testStore()
+      return { activeViewKey: s.activeViewKey, undo: s.undoStack.length, conflict: s.diskConflict }
+    })
+    expect(state.activeViewKey).toBe('Ctx')
+    expect(state.undo).toBe(0)
+    expect(state.conflict).toBeNull()
+    await expect(page.locator('[data-disk-conflict-bar]')).toBeHidden()
+
+    // On the landscape view the new system is on the canvas.
+    await workspace.setView('Land')
+    await expect(await workspace.getNodeByName('Payments')).toBeVisible()
+  })
+
+  test('never discards unsaved local edits silently: conflict bar with both directions', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(BASE)
+    await fileSource(page).install('watch.dsl', BASE)
+
+    // Make a local edit (no handles are linked, so nothing autosaves it to "disk").
+    await page.evaluate(() => {
+      (window as unknown as { __testStore: () => { updateWorkspaceMeta: (p: { name: string }) => void } })
+        .__testStore().updateWorkspaceMeta({ name: 'Renamed locally' })
+    })
+
+    await fileSource(page).set(WITH_PAYMENTS)
+    const bar = page.locator('[data-disk-conflict-bar]')
+    await expect(bar).toBeVisible({ timeout: 6000 })
+    await expect(bar).toHaveAttribute('data-reason', 'dirty')
+    await expect(bar).toContainText('watch.dsl changed on disk')
+    // Not applied yet.
+    await expect(await workspace.getNodeByName('Payments')).toHaveCount(0)
+
+    // Keep mine: the bar goes away and stays away for this on-disk state.
+    await bar.getByRole('button', { name: 'Keep mine' }).click()
+    await expect(bar).toBeHidden()
+    await page.waitForTimeout(2500)
+    await expect(bar).toBeHidden()
+    await expect(await workspace.getNodeByName('Payments')).toHaveCount(0)
+
+    // A further external edit prompts again; this time reload and discard.
+    const WITH_BILLING = WITH_PAYMENTS.replace('"Payments"', '"Billing"')
+    await fileSource(page).set(WITH_BILLING)
+    await expect(bar).toBeVisible({ timeout: 6000 })
+    await bar.getByRole('button', { name: /Reload/ }).click()
+    await expect(await workspace.getNodeByName('Billing')).toBeVisible({ timeout: 6000 })
+    await expect(bar).toBeHidden()
+    const name = await page.evaluate(() =>
+      (window as unknown as { __testGetWorkspace: () => { name?: string } }).__testGetWorkspace().name)
+    expect(name).toBe('Watch')
+  })
+
+  test('broken text on disk is reported, not applied', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(BASE)
+    await fileSource(page).install('watch.dsl', BASE)
+
+    await fileSource(page).set('workspace "Broken" { model { u = person }')
+    const bar = page.locator('[data-disk-conflict-bar]')
+    await expect(bar).toBeVisible({ timeout: 6000 })
+    await expect(bar).toHaveAttribute('data-reason', 'unparseable')
+    await expect(await workspace.getNodeByName('User')).toBeVisible()
+  })
+
+  test('a deleted file gives a friendly state, not an empty canvas', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(BASE)
+    await fileSource(page).install('watch.dsl', BASE)
+
+    await fileSource(page).remove()
+    const bar = page.locator('[data-disk-conflict-bar]')
+    await expect(bar).toBeVisible({ timeout: 6000 })
+    await expect(bar).toHaveAttribute('data-reason', 'missing')
+    await expect(bar).toContainText('no longer on disk')
+    await expect(await workspace.getNodeByName('User')).toBeVisible()
+  })
+
+  test('with watch mode off nothing is watched', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.parseAndLoad(BASE)
+    await fileSource(page).install('watch.dsl', BASE)
+    await page.evaluate(() => {
+      (window as unknown as { __testStore: () => { setWatchDisk: (on: boolean) => void } }).__testStore().setWatchDisk(false)
+    })
+
+    await fileSource(page).set(WITH_PAYMENTS)
+    await page.waitForTimeout(3000)
+    await expect(await workspace.getNodeByName('Payments')).toHaveCount(0)
+    await expect(page.locator('[data-disk-conflict-bar]')).toBeHidden()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ReactFlowProvider } from '@xyflow/react'
 import { useWorkspaceStore } from '@/store/workspace'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useAutoSave } from '@/hooks/useAutoSave'
+import { useDiskWatch } from '@/hooks/useDiskWatch'
 import { useRouteSync, useRefreshRedirect } from '@/hooks/useRouteSync'
 import FloatingTopPill from '@/components/layout/FloatingTopPill'
 import WhatsNewPill from '@/components/whatsnew/WhatsNewPill'
@@ -12,6 +13,7 @@ import FloatingToolRail from '@/components/layout/FloatingToolRail'
 import FloatingViewsPanel from '@/components/layout/FloatingViewsPanel'
 import FloatingInspector from '@/components/layout/FloatingInspector'
 import FloatingBottomStrip from '@/components/layout/FloatingBottomStrip'
+import DiskConflictBar from '@/components/layout/DiskConflictBar'
 import BottomHighlighterBar from '@/components/layout/highlighter/BottomHighlighterBar'
 import FloatingZoomHud from '@/components/layout/FloatingZoomHud'
 import MultiSelectBar from '@/components/layout/MultiSelectBar'
@@ -49,6 +51,7 @@ export default function App() {
 
   useKeyboardShortcuts()
   useAutoSave()
+  useDiskWatch()
   useRouteSync()
   useRefreshRedirect()
 
@@ -87,6 +90,7 @@ export default function App() {
           </ErrorBoundary>
         </main>
         <nav aria-label="Workspace navigation"><FloatingTopPill /></nav>
+        <DiskConflictBar />
         <MultiSelectBar />
         <nav aria-label="Tools"><FloatingToolRail /></nav>
         <FloatingViewsPanel />

--- a/src/components/code-pane/CodePane.tsx
+++ b/src/components/code-pane/CodePane.tsx
@@ -308,6 +308,8 @@ export default function CodePane() {
         // the user has learned the pane is editable, stop teaching it.
         const prev = statusRef.current
         statusRef.current = s
+        // Disk watch must not hot-swap the model under unapplied/broken text.
+        useWorkspaceStore.getState().setCodePaneDirty(s.pendingApply || s.errors.length > 0)
         if (prev.pendingApply && !s.pendingApply && s.errors.length === 0) {
           setEverApplied(true)
           writeString(EDITED_STORAGE_KEY, '1')
@@ -361,6 +363,7 @@ export default function CodePane() {
     return () => {
       unsubscribe()
       engine.dispose()
+      useWorkspaceStore.getState().setCodePaneDirty(false)
       view.destroy()
       viewRef.current = null
     }

--- a/src/components/layout/DiskConflictBar.tsx
+++ b/src/components/layout/DiskConflictBar.tsx
@@ -1,0 +1,123 @@
+import { FileWarning, RefreshCw, X } from 'lucide-react'
+import { useWorkspaceStore } from '@/store/workspace'
+import { applyDiskSnapshot } from '@/hooks/useDiskWatch'
+import { suppressSnapshot } from '@/lib/saveCoordinator'
+import { announce } from '@/lib/announce'
+
+/**
+ * Slim bar under the top pill for disk-watch situations that need a human:
+ * the file changed while there are unsaved local edits, the new text can't
+ * be applied, or the file vanished. Never auto-resolves either way.
+ */
+export default function DiskConflictBar() {
+  const conflict = useWorkspaceStore((s) => s.diskConflict)
+  const missing = useWorkspaceStore((s) => s.diskFileMissing)
+  const activeFilename = useWorkspaceStore((s) => s.activeWorkspaceFilename)
+  const workspaceName = useWorkspaceStore((s) => s.workspace?.name)
+
+  if (!conflict && !missing) return null
+
+  const filename = conflict?.filename ?? activeFilename ?? `${workspaceName ?? 'workspace'}.dsl`
+
+  const reload = () => {
+    if (!conflict) return
+    if (applyDiskSnapshot(conflict.filename, conflict.snapshot, conflict.hashes)) {
+      useWorkspaceStore.getState().setDiskConflict(null)
+    }
+  }
+  const keepMine = () => {
+    if (!conflict) return
+    // Stop re-prompting about this exact on-disk state; the next save overwrites it.
+    suppressSnapshot(conflict.hashes)
+    useWorkspaceStore.getState().setDiskConflict(null)
+    announce('Kept your version — the next save overwrites the file')
+  }
+  const dismiss = () => {
+    const s = useWorkspaceStore.getState()
+    if (conflict) { suppressSnapshot(conflict.hashes); s.setDiskConflict(null) }
+    if (missing) s.setDiskFileMissing(false)
+  }
+
+  let message: string
+  if (conflict?.reason === 'dirty') {
+    message = `${filename} changed on disk — you have unsaved changes here.`
+  } else if (conflict) {
+    message = `${filename} changed on disk but ${conflict.detail ?? 'cannot be applied'} — canvas kept as it was.`
+  } else {
+    message = `${filename} is no longer on disk. Your work is still here — Save writes it back.`
+  }
+
+  return (
+    <div
+      role="alert"
+      data-disk-conflict-bar
+      data-reason={conflict?.reason ?? 'missing'}
+      style={{
+        position: 'fixed',
+        top: 64,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 40,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        maxWidth: 'min(720px, calc(100vw - 32px))',
+        padding: '6px 10px 6px 12px',
+        borderRadius: 10,
+        border: '1px solid var(--color-warning)',
+        background: 'var(--color-bg-panel)',
+        color: 'var(--color-text-primary)',
+        boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+        fontSize: 'var(--text-xs)',
+      }}
+    >
+      <FileWarning size={14} color="var(--color-warning)" aria-hidden="true" style={{ flexShrink: 0 }} />
+      <span style={{ flex: 1, minWidth: 0 }}>{message}</span>
+
+      {conflict?.reason === 'dirty' && (
+        <>
+          <button type="button" onClick={reload} className="hover-subtle" style={BTN_PRIMARY}>
+            <RefreshCw size={12} aria-hidden="true" /> Reload (discard my changes)
+          </button>
+          <button type="button" onClick={keepMine} className="hover-subtle" style={BTN}>
+            Keep mine
+          </button>
+        </>
+      )}
+      {conflict?.reason === 'unparseable' && (
+        <button type="button" onClick={reload} className="hover-subtle" style={BTN} title="Try applying the file as it is now">
+          <RefreshCw size={12} aria-hidden="true" /> Retry
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={dismiss}
+        className="hover-subtle"
+        aria-label="Dismiss"
+        title="Dismiss"
+        style={{ ...BTN, padding: 4 }}
+      >
+        <X size={12} aria-hidden="true" />
+      </button>
+    </div>
+  )
+}
+
+const BTN: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 5,
+  padding: '4px 8px',
+  borderRadius: 6,
+  border: '1px solid var(--color-border)',
+  background: 'transparent',
+  color: 'var(--color-text-primary)',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  fontSize: 'var(--text-xs)',
+}
+
+const BTN_PRIMARY: React.CSSProperties = {
+  ...BTN,
+  border: '1px solid var(--color-warning)',
+}

--- a/src/components/layout/SaveIndicator.tsx
+++ b/src/components/layout/SaveIndicator.tsx
@@ -23,6 +23,7 @@ export default function SaveIndicator() {
   const currentUndoLength = useWorkspaceStore((s) => s.undoStack.length)
   const isDirty = currentUndoLength > 0
   const lastSavedUndoLength = useWorkspaceStore((s) => s.lastSavedUndoLength)
+  const watchDisk = useWorkspaceStore((s) => s.watchDisk)
 
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [savedUndoLength, setSavedUndoLength] = useState(lastSavedUndoLength)
@@ -80,6 +81,8 @@ export default function SaveIndicator() {
     : isFileDirty ? 'Unsaved changes \u2014 click to save'
     : 'All changes saved'
   const isUnlinked = canLinkFiles && !hasFileHandle && saveStatus === 'idle'
+  const watching = watchDisk && hasFileHandle
+  const tooltipWithWatch = watching && saveStatus === 'idle' ? `${tooltip} · watching for changes on disk` : tooltip
 
   const dotBg = isUnlinked ? 'var(--color-warning)' : dotColor
   const dotShadow = isUnlinked ? '0 0 6px var(--color-warning)' : dotGlow
@@ -99,8 +102,9 @@ export default function SaveIndicator() {
         borderRight: '1px solid var(--color-border)',
         flexShrink: 0,
       }}
-      title={tooltip}
+      title={tooltipWithWatch}
       aria-label={tooltip}
+      data-watching-disk={watching ? 'true' : undefined}
     >
       {!canLinkFiles ? (
         // No File System Access API — clicking saves by triggering a browser

--- a/src/components/welcome/WelcomeScreen.tsx
+++ b/src/components/welcome/WelcomeScreen.tsx
@@ -111,13 +111,22 @@ export default function WelcomeScreen({ initialView }: { initialView?: 'startup'
   const jsonInputRef = useRef<HTMLInputElement>(null)
   const dslInputRef = useRef<HTMLInputElement>(null)
 
-  // Load workspace list when entering collection view
+  // Load workspace list when entering collection view, and refresh it when the
+  // tab comes back into focus — files added or removed outside c4hero (another
+  // editor, a `git checkout`) should show up without a reload (TEA-323).
   useEffect(() => {
-    if (view === 'collection') {
+    if (view !== 'collection') return
+    const refresh = () => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
       const dir = getCurrentDirHandle()
-      if (dir) {
-        listCurrentDSLFiles().then(setFolderWorkspaces)
-      }
+      if (dir) listCurrentDSLFiles().then(setFolderWorkspaces)
+    }
+    refresh()
+    document.addEventListener('visibilitychange', refresh)
+    window.addEventListener('focus', refresh)
+    return () => {
+      document.removeEventListener('visibilitychange', refresh)
+      window.removeEventListener('focus', refresh)
     }
   }, [view])
 

--- a/src/hooks/useDiskWatch.test.ts
+++ b/src/hooks/useDiskWatch.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from '@/store/workspace'
+import { parseDSL } from '@/lib/dsl'
+import { hashSnapshot } from '@/lib/fileWatch'
+import { applyDiskSnapshot } from './useDiskWatch'
+
+const DSL = `workspace "W" {
+  model {
+    u = person "User"
+    sys = softwareSystem "Sys"
+    u -> sys "Uses"
+  }
+  views {
+    systemLandscape "Land" { include * }
+  }
+}`
+
+function store() { return useWorkspaceStore.getState() }
+
+describe('applyDiskSnapshot', () => {
+  beforeEach(() => {
+    const { workspace } = parseDSL(DSL)
+    store().loadWorkspace(workspace)
+  })
+
+  it('reloads clean DSL and reports success', () => {
+    const snapshot = { content: DSL.replace('"User"', '"Customer"') }
+    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(true)
+    expect(store().workspace!.model.people[0].name).toBe('Customer')
+    expect(store().diskConflict).toBeNull()
+  })
+
+  it('applies the sidecar from disk alongside the DSL', () => {
+    const sidecar = JSON.stringify({
+      version: 1,
+      views: { Land: { elements: { u: { x: 123, y: 456 } } } },
+    })
+    const snapshot = { content: DSL, sidecarJson: sidecar }
+    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(true)
+    const land = store().workspace!.views.systemLandscapeViews[0]
+    const placed = land.elements.find((e) => e.id === 'u')
+    expect(placed?.x).toBe(123)
+    expect(placed?.y).toBe(456)
+  })
+
+  it('raises an unparseable conflict instead of applying broken text', () => {
+    const before = store().workspace
+    const snapshot = { content: 'workspace "Broken" { model { u = person }' }
+    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(false)
+    expect(store().workspace).toBe(before)
+    expect(store().diskConflict?.reason).toBe('unparseable')
+    expect(store().diskConflict?.detail).toMatch(/parse error/)
+  })
+
+  it('refuses to empty a populated model silently', () => {
+    const before = store().workspace
+    const snapshot = { content: 'workspace "Empty" { model { } views { } }' }
+    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(false)
+    expect(store().workspace).toBe(before)
+    expect(store().diskConflict?.detail).toMatch(/empty model/)
+  })
+})

--- a/src/hooks/useDiskWatch.ts
+++ b/src/hooks/useDiskWatch.ts
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react'
+import { useWorkspaceStore } from '@/store/workspace'
+import { getCurrentFileHandle, readCurrentFile } from '@/lib/fileIO'
+import { getCurrentDirHandle, readDSLFileForWatch } from '@/lib/folderIO'
+import { createFileWatcher, type SnapshotHashes, type WatchedSnapshot } from '@/lib/fileWatch'
+import { isSelfWrite, resetSaveCoordinator } from '@/lib/saveCoordinator'
+import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
+import { announce } from '@/lib/announce'
+import { createLogger } from '@/lib/logger'
+import { getTestFileSource, subscribeTestFileSource } from '@/lib/testFileSource'
+
+const log = createLogger('useDiskWatch')
+
+export const DISK_WATCH_INTERVAL_MS = 2000
+
+/** Is there anything on disk to watch for the current workspace? */
+export function isDiskWatchable(activeFilename: string | null): boolean {
+  if (getTestFileSource()) return true
+  if (getCurrentFileHandle()) return true
+  return !!(getCurrentDirHandle() && activeFilename)
+}
+
+function currentFilename(activeFilename: string | null, workspaceName: string | undefined): string {
+  return getTestFileSource()?.filename
+    ?? activeFilename
+    ?? `${workspaceName ?? 'workspace'}.dsl`
+}
+
+/** The workspace store's dirty signal, plus the code pane's own buffer. */
+function hasUnsavedLocalEdits(): boolean {
+  const s = useWorkspaceStore.getState()
+  return s.undoStack.length !== s.lastSavedUndoLength || s.codePaneDirty
+}
+
+/** Parse what's on disk and swap it in. Returns false (and raises a conflict)
+ *  when the text can't be applied safely. */
+export function applyDiskSnapshot(filename: string, snapshot: WatchedSnapshot, hashes: SnapshotHashes): boolean {
+  const store = useWorkspaceStore.getState()
+  const current = store.workspace
+  const { workspace, errors } = parseWorkspaceDocument({
+    content: snapshot.content,
+    fallbackName: filename.replace(/\.dsl$/, ''),
+    sidecarJson: snapshot.sidecarJson,
+  })
+  if (errors.length > 0) {
+    store.setDiskConflict({
+      filename, snapshot, hashes, reason: 'unparseable',
+      detail: `${errors.length} parse ${errors.length === 1 ? 'error' : 'errors'}`,
+    })
+    return false
+  }
+  // Same guard as the code pane: a file that parses to nothing (mid-write,
+  // truncated, or genuinely emptied) must not silently wipe a populated canvas.
+  const parsedEmpty = workspace.model.people.length === 0
+    && workspace.model.softwareSystems.length === 0
+    && workspace.model.deploymentEnvironments.length === 0
+  const currentNonEmpty = !!current && (
+    current.model.people.length > 0
+    || current.model.softwareSystems.length > 0
+    || current.model.deploymentEnvironments.length > 0
+  )
+  if (parsedEmpty && currentNonEmpty) {
+    store.setDiskConflict({ filename, snapshot, hashes, reason: 'unparseable', detail: 'parses to an empty model' })
+    return false
+  }
+  store.reloadWorkspaceFromDisk(workspace)
+  announce(`${filename} changed on disk — reloaded`)
+  return true
+}
+
+/**
+ * Watch the open workspace's file(s) and reload on external change.
+ * Mounted once beside useAutoSave. Does nothing without a handle or a test
+ * source, and nothing at all when the user has watch mode off.
+ */
+export function useDiskWatch() {
+  const watchDisk = useWorkspaceStore((s) => s.watchDisk)
+  const workspaceName = useWorkspaceStore((s) => s.workspace?.name)
+  const hasWorkspace = useWorkspaceStore((s) => !!s.workspace)
+  const activeFilename = useWorkspaceStore((s) => s.activeWorkspaceFilename)
+  const testSource = useSyncExternalStore(subscribeTestFileSource, getTestFileSource, getTestFileSource)
+  const watcherRef = useRef<ReturnType<typeof createFileWatcher> | null>(null)
+
+  useEffect(() => {
+    if (!watchDisk || !hasWorkspace || !isDiskWatchable(activeFilename)) return
+
+    const filename = currentFilename(activeFilename, workspaceName)
+    const read = (): Promise<WatchedSnapshot | null> => {
+      const test = getTestFileSource()
+      if (test) return test.read()
+      if (getCurrentFileHandle()) return readCurrentFile()
+      if (getCurrentDirHandle() && activeFilename) return readDSLFileForWatch(activeFilename)
+      return Promise.resolve(null)
+    }
+
+    // A fresh watch target means the remembered self-writes belong to the
+    // previous file. Start clean so an old hash can't mask a real edit here.
+    resetSaveCoordinator()
+
+    const watcher = createFileWatcher({
+      read,
+      intervalMs: DISK_WATCH_INTERVAL_MS,
+      isVisible: () => typeof document === 'undefined' || document.visibilityState === 'visible',
+      subscribeWake: (cb) => {
+        document.addEventListener('visibilitychange', cb)
+        window.addEventListener('focus', cb)
+        return () => {
+          document.removeEventListener('visibilitychange', cb)
+          window.removeEventListener('focus', cb)
+        }
+      },
+      isSelfWrite,
+      onMissing: () => {
+        useWorkspaceStore.getState().setDiskFileMissing(true)
+        announce(`${filename} is no longer on disk`)
+      },
+      onChange: (snapshot, hashes) => {
+        const store = useWorkspaceStore.getState()
+        if (store.diskFileMissing) store.setDiskFileMissing(false)
+        if (hasUnsavedLocalEdits()) {
+          store.setDiskConflict({ filename, snapshot, hashes, reason: 'dirty' })
+          announce(`${filename} changed on disk — you have unsaved changes`)
+          return
+        }
+        applyDiskSnapshot(filename, snapshot, hashes)
+      },
+    })
+    watcherRef.current = watcher
+    watcher.start().catch((err) => log.warn('Disk watch failed to start', err))
+
+    return () => {
+      watcher.dispose()
+      if (watcherRef.current === watcher) watcherRef.current = null
+      const s = useWorkspaceStore.getState()
+      if (s.diskConflict) s.setDiskConflict(null)
+      if (s.diskFileMissing) s.setDiskFileMissing(false)
+    }
+    // Re-key on the watched file's identity, not on the workspace ref — a
+    // reload swaps the ref but not the file.
+  }, [watchDisk, hasWorkspace, workspaceName, activeFilename, testSource])
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -4,7 +4,7 @@ import {
   MousePointer, LayoutDashboard, Maximize2, ZoomIn, ZoomOut,
   LayoutGrid, Search, Save, Settings, Monitor,
   Presentation, FolderOpen, Image, FileCode, Copy, Plus,
-  Highlighter, MousePointerClick, RotateCcw, CircleHelp, Sparkles, Radar,
+  Highlighter, MousePointerClick, RotateCcw, CircleHelp, Sparkles, Radar, Eye, EyeOff,
 } from 'lucide-react'
 import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews, isFocalScopeElement } from '@/store/workspace'
 import { computeCascadeImpact } from '@/store/workspace-helpers'
@@ -289,6 +289,19 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
       keywords: ['dsl', 'code', 'editor', 'structurizr', 'text', 'source'],
       when: () => !!store().workspace,
       execute: () => store().toggleCodePanel(),
+    },
+    {
+      id: 'toggle-watch-mode',
+      label: 'Watch Mode',
+      category: 'view',
+      icon: store().watchDisk ? Eye : EyeOff,
+      keywords: ['watch', 'disk', 'reload', 'file', 'sync', 'external', 'git'],
+      when: () => !!store().workspace,
+      execute: () => {
+        const s = store()
+        s.toggleWatchDisk()
+        announce(store().watchDisk ? 'Watch mode on — reloads when the file changes on disk' : 'Watch mode off')
+      },
     },
     {
       id: 'new-view',

--- a/src/lib/fileIO.ts
+++ b/src/lib/fileIO.ts
@@ -5,6 +5,8 @@ import { isFiniteNumber, isNonEmptyString, isRecord, isStringArray, isStringReco
 import { sidecarName } from '@/lib/sidecar'
 import { safeSuggestedDslName } from '@/lib/filenames'
 import { readJSON, writeJSON, writeString, removeKey } from '@/lib/safeStorage'
+import { recordSelfDslWrite, recordSelfSidecarWrite } from '@/lib/saveCoordinator'
+import type { WatchedSnapshot } from '@/lib/fileWatch'
 
 const log = createLogger('fileIO')
 
@@ -107,10 +109,36 @@ export function getCurrentFileHandle(): FileSystemFileHandle | null {
   return currentFileHandle
 }
 
+/** Read the open single file (and its sidecar, when one is linked) for the
+ *  disk watcher. Resolves `null` when the file no longer exists; rethrows
+ *  anything else so a transient failure isn't mistaken for a deletion. */
+export async function readCurrentFile(): Promise<WatchedSnapshot | null> {
+  if (!currentFileHandle) return null
+  let content: string
+  try {
+    const file = await currentFileHandle.getFile()
+    content = await readTextFileWithLimit(file, 'DSL file')
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'NotFoundError') return null
+    throw err
+  }
+  let sidecarJson: string | undefined
+  if (currentSidecarHandle) {
+    try {
+      const sidecarFile = await currentSidecarHandle.getFile()
+      sidecarJson = await readTextFileWithLimit(sidecarFile, 'Sidecar file')
+    } catch {
+      // Sidecar gone or unreadable: treat as "no sidecar" rather than "file gone".
+    }
+  }
+  return { content, sidecarJson }
+}
+
 /** Write DSL content to the current file handle (for auto-save) */
 export async function writeToCurrentHandle(content: string): Promise<boolean> {
   if (!currentFileHandle || !hasFileSystemAccess()) return false
   try {
+    recordSelfDslWrite(content)
     const writable = await currentFileHandle.createWritable()
     await writable.write(content)
     await writable.close()
@@ -125,6 +153,7 @@ export async function writeToCurrentHandle(content: string): Promise<boolean> {
 export async function writeSidecarToHandle(json: string): Promise<boolean> {
   if (!hasFileSystemAccess()) return false
   try {
+    recordSelfSidecarWrite(json)
     // If we have an existing sidecar handle, write to it
     if (currentSidecarHandle) {
       const writable = await currentSidecarHandle.createWritable()
@@ -242,6 +271,7 @@ export async function saveDSLFile(content: string, suggestedName?: string): Prom
           excludeAcceptAllOption: false,
         })
       }
+      recordSelfDslWrite(content)
       const writable = await currentFileHandle.createWritable()
       await writable.write(content)
       await writable.close()

--- a/src/lib/fileWatch.test.ts
+++ b/src/lib/fileWatch.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createFileWatcher, hashContent, hashSnapshot, type WatchedSnapshot } from './fileWatch'
+
+function makeSource(initial: WatchedSnapshot | null) {
+  let current = initial
+  const read = vi.fn(async () => current)
+  return {
+    read,
+    set(next: WatchedSnapshot | null) { current = next },
+  }
+}
+
+async function flush() {
+  // Let the awaited read + microtasks settle.
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('hashContent', () => {
+  it('is deterministic and distinguishes different text', () => {
+    expect(hashContent('abc')).toBe(hashContent('abc'))
+    expect(hashContent('abc')).not.toBe(hashContent('abd'))
+    expect(hashContent('')).not.toBe(hashContent(' '))
+  })
+})
+
+describe('createFileWatcher', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('seeds a baseline on start without firing, then fires on a content change', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    const w = createFileWatcher({ read: src.read, onChange, intervalMs: 100 })
+    await w.start()
+    expect(onChange).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).not.toHaveBeenCalled() // unchanged
+
+    src.set({ content: 'b' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toEqual({ content: 'b' })
+    expect(onChange.mock.calls[0][1]).toEqual(hashSnapshot({ content: 'b' }))
+    w.dispose()
+  })
+
+  it('treats a sidecar-only change as a change', async () => {
+    const src = makeSource({ content: 'a', sidecarJson: '{}' })
+    const onChange = vi.fn()
+    const w = createFileWatcher({ read: src.read, onChange, intervalMs: 100 })
+    await w.start()
+    src.set({ content: 'a', sidecarJson: '{"x":1}' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    w.dispose()
+  })
+
+  it('ignores a self-write but moves the baseline past it', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    const isSelfWrite = vi.fn((h: { dsl: string }) => h.dsl === hashContent('ours'))
+    const w = createFileWatcher({ read: src.read, onChange, isSelfWrite, intervalMs: 100 })
+    await w.start()
+
+    src.set({ content: 'ours' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).not.toHaveBeenCalled()
+    expect(isSelfWrite).toHaveBeenCalledWith(hashSnapshot({ content: 'ours' }), hashSnapshot({ content: 'a' }))
+    expect(w.getBaseline()).toEqual(hashSnapshot({ content: 'ours' }))
+
+    // A later external edit is still detected relative to the new baseline.
+    src.set({ content: 'theirs' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    w.dispose()
+  })
+
+  it('does not poll while hidden and checks immediately on wake', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    let visible = false
+    let wake: (() => void) | null = null
+    const w = createFileWatcher({
+      read: src.read,
+      onChange,
+      intervalMs: 100,
+      isVisible: () => visible,
+      subscribeWake: (cb) => { wake = cb; return () => { wake = null } },
+    })
+    await w.start()
+    const readsAfterStart = src.read.mock.calls.length
+
+    src.set({ content: 'b' })
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(src.read.mock.calls.length).toBe(readsAfterStart) // no polling while hidden
+    expect(onChange).not.toHaveBeenCalled()
+
+    visible = true
+    wake!()
+    await flush()
+    expect(onChange).toHaveBeenCalledTimes(1) // immediate check on wake
+
+    // Polling resumes while visible.
+    src.set({ content: 'c' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).toHaveBeenCalledTimes(2)
+
+    // Going hidden again stops the interval.
+    visible = false
+    wake!()
+    src.set({ content: 'd' })
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(onChange).toHaveBeenCalledTimes(2)
+    w.dispose()
+  })
+
+  it('prefers a native observer over polling when one is available', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    let notify: (() => void) | null = null
+    const unobserve = vi.fn()
+    const w = createFileWatcher({
+      read: src.read,
+      onChange,
+      intervalMs: 100,
+      observe: (cb) => { notify = cb; return unobserve },
+    })
+    await w.start()
+    const readsAfterStart = src.read.mock.calls.length
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(src.read.mock.calls.length).toBe(readsAfterStart) // no interval polling
+
+    src.set({ content: 'b' })
+    notify!()
+    await flush()
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    w.dispose()
+    expect(unobserve).toHaveBeenCalled()
+  })
+
+  it('reports a missing file once and recovers when it reappears', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    const onMissing = vi.fn()
+    const w = createFileWatcher({ read: src.read, onChange, onMissing, intervalMs: 100 })
+    await w.start()
+
+    src.set(null)
+    await vi.advanceTimersByTimeAsync(300)
+    expect(onMissing).toHaveBeenCalledTimes(1)
+
+    src.set({ content: 'a' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).not.toHaveBeenCalled() // same bytes as before it vanished
+
+    src.set(null)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onMissing).toHaveBeenCalledTimes(2)
+    w.dispose()
+  })
+
+  it('swallows a transient read failure', async () => {
+    let fail = false
+    const read = vi.fn(async () => {
+      if (fail) throw new Error('NotAllowedError')
+      return { content: 'a' }
+    })
+    const onChange = vi.fn()
+    const w = createFileWatcher({ read, onChange, intervalMs: 100 })
+    await w.start()
+    fail = true
+    await vi.advanceTimersByTimeAsync(100)
+    fail = false
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).not.toHaveBeenCalled()
+    w.dispose()
+  })
+
+  it('acceptBaseline suppresses a re-fire for the accepted contents', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    const w = createFileWatcher({ read: src.read, onChange, intervalMs: 100 })
+    await w.start()
+    w.acceptBaseline(hashSnapshot({ content: 'b' }))
+    src.set({ content: 'b' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onChange).not.toHaveBeenCalled()
+    w.dispose()
+  })
+
+  it('does nothing after dispose', async () => {
+    const src = makeSource({ content: 'a' })
+    const onChange = vi.fn()
+    const w = createFileWatcher({ read: src.read, onChange, intervalMs: 100 })
+    await w.start()
+    w.dispose()
+    src.set({ content: 'b' })
+    await vi.advanceTimersByTimeAsync(500)
+    await w.checkNow()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/fileWatch.ts
+++ b/src/lib/fileWatch.ts
@@ -1,0 +1,165 @@
+// Watch the open workspace file for changes made outside c4hero.
+//
+// Pure and injectable: no File System Access types leak into the logic, so
+// the state machine is unit-testable with a fake `read`. The hook that mounts
+// it (`useDiskWatch`) supplies the real handle reads and the DOM wake events.
+//
+// Strategy: prefer `FileSystemObserver` where the caller can provide one;
+// otherwise poll — but only while the tab is visible, plus an immediate check
+// whenever the tab regains focus/visibility. A background tab must not spin.
+//
+// Change detection compares content hashes, never mtime alone: FSA writes bump
+// mtime, so mtime-only would fire on every one of our own autosaves.
+
+/** What a single read of the watched file(s) yields. `null` = file is gone. */
+export interface WatchedSnapshot {
+  content: string
+  sidecarJson?: string
+}
+
+export interface SnapshotHashes {
+  dsl: string
+  sidecar: string
+}
+
+export interface FileWatcherOpts {
+  read: () => Promise<WatchedSnapshot | null>
+  /** Fired for a change that is not ours (see `isSelfWrite`). */
+  onChange: (snapshot: WatchedSnapshot, hashes: SnapshotHashes) => void
+  /** Fired once when the file stops being readable (deleted / moved). */
+  onMissing?: () => void
+  /** Return true when these hashes correspond to something c4hero wrote itself
+   *  (or the user chose to keep their version over). Such reads only move the
+   *  baseline; they never fire `onChange`. */
+  isSelfWrite?: (hashes: SnapshotHashes, previous: SnapshotHashes) => boolean
+  /** Poll cadence while visible. */
+  intervalMs?: number
+  /** Visibility probe — polling stops entirely while this is false. */
+  isVisible?: () => boolean
+  /** Subscribe to "the tab is back" events (visibilitychange, focus). The
+   *  callback triggers an immediate check and restarts polling. Returns an
+   *  unsubscribe. */
+  subscribeWake?: (cb: () => void) => () => void
+  /** Optional native observer hookup (FileSystemObserver). When it returns an
+   *  unsubscribe, polling is skipped — wake checks still run as a safety net. */
+  observe?: (cb: () => void) => (() => void) | null
+}
+
+/** Cheap, deterministic string hash (FNV-1a, 32-bit) — enough to tell "same
+ *  bytes" from "different bytes" for change detection; not for security. */
+export function hashContent(text: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return `${text.length}:${h.toString(16)}`
+}
+
+export function hashSnapshot(snapshot: WatchedSnapshot): SnapshotHashes {
+  return { dsl: hashContent(snapshot.content), sidecar: hashContent(snapshot.sidecarJson ?? '') }
+}
+
+function sameHashes(a: SnapshotHashes, b: SnapshotHashes): boolean {
+  return a.dsl === b.dsl && a.sidecar === b.sidecar
+}
+
+export function createFileWatcher(opts: FileWatcherOpts) {
+  const intervalMs = opts.intervalMs ?? 2000
+  const isVisible = opts.isVisible ?? (() => true)
+  const isSelfWrite = opts.isSelfWrite ?? (() => false)
+
+  let baseline: SnapshotHashes | null = null
+  let started = false
+  let disposed = false
+  let checking = false
+  let missingReported = false
+  let timer: ReturnType<typeof setInterval> | null = null
+  let unsubscribeWake: (() => void) | null = null
+  let unsubscribeObserver: (() => void) | null = null
+
+  function stopPolling() {
+    if (timer) { clearInterval(timer); timer = null }
+  }
+
+  function startPolling() {
+    if (disposed || timer || unsubscribeObserver) return
+    if (!isVisible()) return
+    timer = setInterval(() => { void check() }, intervalMs)
+  }
+
+  /** Read once and compare against the baseline. Safe to call at any time;
+   *  overlapping calls collapse into one read. */
+  async function check(): Promise<void> {
+    if (disposed || checking) return
+    checking = true
+    try {
+      const snapshot = await opts.read()
+      if (disposed) return
+      if (snapshot === null) {
+        if (!missingReported) {
+          missingReported = true
+          opts.onMissing?.()
+        }
+        return
+      }
+      missingReported = false
+      const hashes = hashSnapshot(snapshot)
+      if (baseline === null) { baseline = hashes; return }
+      if (sameHashes(baseline, hashes)) return
+      const previous = baseline
+      baseline = hashes
+      if (isSelfWrite(hashes, previous)) return
+      opts.onChange(snapshot, hashes)
+    } catch {
+      // A transient read failure (permission re-prompt, file mid-replace) is
+      // not a change. Try again on the next tick.
+    } finally {
+      checking = false
+    }
+  }
+
+  function onWake() {
+    if (disposed) return
+    if (isVisible()) {
+      void check()
+      startPolling()
+    } else {
+      stopPolling()
+    }
+  }
+
+  return {
+    /** Take the baseline from the current file contents and begin watching. */
+    async start(): Promise<void> {
+      if (started || disposed) return
+      started = true
+      await check() // seeds the baseline without firing
+      if (disposed) return
+      unsubscribeObserver = opts.observe?.(() => { void check() }) ?? null
+      unsubscribeWake = opts.subscribeWake?.(onWake) ?? null
+      startPolling()
+    },
+
+    /** Force a comparison now (e.g. after the user dismissed a conflict). */
+    checkNow: () => check(),
+
+    /** Accept the given hashes as the new baseline without firing. Used after
+     *  a reload or a "keep mine" so the same contents don't re-prompt. */
+    acceptBaseline(hashes: SnapshotHashes) {
+      baseline = hashes
+    },
+
+    /** The hashes the watcher currently considers "what's on disk". */
+    getBaseline: () => baseline,
+
+    dispose() {
+      disposed = true
+      stopPolling()
+      unsubscribeWake?.(); unsubscribeWake = null
+      unsubscribeObserver?.(); unsubscribeObserver = null
+    },
+  }
+}
+
+export type FileWatcher = ReturnType<typeof createFileWatcher>

--- a/src/lib/folderIO.ts
+++ b/src/lib/folderIO.ts
@@ -2,6 +2,8 @@ import { sidecarName } from '@/lib/sidecar'
 import { createLogger } from '@/lib/logger'
 import { readTextFileWithLimit } from '@/lib/fileIO'
 import { isRecord } from '@/lib/guards'
+import { recordSelfDslWrite, recordSelfSidecarWrite } from '@/lib/saveCoordinator'
+import type { WatchedSnapshot } from '@/lib/fileWatch'
 
 const log = createLogger('folderIO')
 
@@ -105,10 +107,36 @@ export async function readDSLFile(filename: string): Promise<{ content: string; 
   }
 }
 
+/** Read a workspace file for the disk watcher. Unlike `readDSLFile` this is
+ *  silent and distinguishes "gone" (`null`) from a transient failure (throws),
+ *  because it runs every couple of seconds. */
+export async function readDSLFileForWatch(filename: string): Promise<WatchedSnapshot | null> {
+  if (!currentDirHandle) return null
+  let content: string
+  try {
+    const fileHandle = await currentDirHandle.getFileHandle(filename)
+    const file = await fileHandle.getFile()
+    content = await readTextFileWithLimit(file, 'DSL file')
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'NotFoundError') return null
+    throw err
+  }
+  let sidecarJson: string | undefined
+  try {
+    const sidecarHandle = await currentDirHandle.getFileHandle(sidecarName(filename))
+    const sidecarFile = await sidecarHandle.getFile()
+    sidecarJson = await readTextFileWithLimit(sidecarFile, 'Sidecar file')
+  } catch {
+    // No sidecar — expected for new workspaces
+  }
+  return { content, sidecarJson }
+}
+
 /** Write DSL content to a file in the current directory (creates if not present) */
 export async function writeDSLFile(filename: string, content: string): Promise<boolean> {
   if (!currentDirHandle) return false
   try {
+    recordSelfDslWrite(content)
     const fileHandle = await currentDirHandle.getFileHandle(filename, { create: true })
     const writable = await fileHandle.createWritable()
     await writable.write(content)
@@ -125,6 +153,7 @@ export async function writeSidecarFile(dslFilename: string, json: string): Promi
   if (!currentDirHandle) return false
   try {
     const filename = sidecarName(dslFilename)
+    recordSelfSidecarWrite(json)
     const fileHandle = await currentDirHandle.getFileHandle(filename, { create: true })
     const writable = await fileHandle.createWritable()
     await writable.write(json)

--- a/src/lib/saveCoordinator.test.ts
+++ b/src/lib/saveCoordinator.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { recordSelfWrite, isSelfWrite, suppressSnapshot, resetSaveCoordinator } from './saveCoordinator'
+import { hashSnapshot } from './fileWatch'
+
+describe('saveCoordinator', () => {
+  beforeEach(() => resetSaveCoordinator())
+
+  it('recognises exactly what was written', () => {
+    recordSelfWrite('dsl-1', 'side-1')
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-1', sidecarJson: 'side-1' }), null)).toBe(true)
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-2', sidecarJson: 'side-1' }), null)).toBe(false)
+  })
+
+  it('accepts a half-written pair when the other half is unchanged from the baseline', () => {
+    const previous = hashSnapshot({ content: 'dsl-0', sidecarJson: 'side-0' })
+    recordSelfWrite('dsl-1', 'side-1')
+    // DSL landed, sidecar not yet: sidecar still equals the baseline.
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-1', sidecarJson: 'side-0' }), previous)).toBe(true)
+    // Sidecar landed first.
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-0', sidecarJson: 'side-1' }), previous)).toBe(true)
+    // Both differ and neither was ours: external.
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-9', sidecarJson: 'side-9' }), previous)).toBe(false)
+  })
+
+  it('an external DSL edit next to our own sidecar is still external', () => {
+    const previous = hashSnapshot({ content: 'dsl-0', sidecarJson: 'side-0' })
+    recordSelfWrite('dsl-0', 'side-1')
+    expect(isSelfWrite(hashSnapshot({ content: 'edited', sidecarJson: 'side-1' }), previous)).toBe(false)
+  })
+
+  it('treats "no sidecar on disk" as matching a workspace saved without one', () => {
+    recordSelfWrite('dsl-1', undefined)
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-1' }), null)).toBe(true)
+  })
+
+  it('suppressSnapshot makes that exact on-disk state count as ours', () => {
+    const theirs = hashSnapshot({ content: 'theirs', sidecarJson: '' })
+    expect(isSelfWrite(theirs, null)).toBe(false)
+    suppressSnapshot(theirs)
+    expect(isSelfWrite(theirs, null)).toBe(true)
+    // A further external edit is not covered by the suppression.
+    expect(isSelfWrite(hashSnapshot({ content: 'theirs-2' }), theirs)).toBe(false)
+  })
+
+  it('remembers a bounded number of recent writes', () => {
+    for (let i = 0; i < 40; i++) recordSelfWrite(`dsl-${i}`, `side-${i}`)
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-39', sidecarJson: 'side-39' }), null)).toBe(true)
+    expect(isSelfWrite(hashSnapshot({ content: 'dsl-0', sidecarJson: 'side-0' }), null)).toBe(false)
+  })
+})

--- a/src/lib/saveCoordinator.ts
+++ b/src/lib/saveCoordinator.ts
@@ -1,0 +1,68 @@
+// Tells the disk watcher which file contents c4hero wrote itself.
+//
+// Autosave and manual save both record the hash of what they put on disk;
+// the watcher treats a read matching a recorded hash as "ours" and only moves
+// its baseline. Without this every autosave would look like an external edit.
+//
+// The DSL and the sidecar are written as two separate files, so a poll can
+// observe the new DSL next to the still-old sidecar (or vice versa). Hashes
+// are therefore tracked per file: a snapshot is ours when each part is either
+// something we wrote recently or unchanged from what the watcher last saw.
+
+import { hashContent, type SnapshotHashes } from '@/lib/fileWatch'
+
+const MAX_REMEMBERED = 16
+
+const selfDsl: string[] = []
+const selfSidecar: string[] = []
+/** Snapshots the user chose to keep their in-memory version over ("Keep mine"). */
+const suppressed = new Set<string>()
+
+function remember(list: string[], hash: string) {
+  const idx = list.indexOf(hash)
+  if (idx !== -1) list.splice(idx, 1)
+  list.push(hash)
+  if (list.length > MAX_REMEMBERED) list.shift()
+}
+
+/** Call right after writing DSL text to disk (the low-level writers do). */
+export function recordSelfDslWrite(dsl: string): void {
+  remember(selfDsl, hashContent(dsl))
+}
+
+/** Call right after writing sidecar JSON to disk (the low-level writers do). */
+export function recordSelfSidecarWrite(json: string): void {
+  remember(selfSidecar, hashContent(json))
+}
+
+/** Convenience for callers that write both at once. */
+export function recordSelfWrite(dsl: string, sidecarJson?: string): void {
+  recordSelfDslWrite(dsl)
+  // A workspace with no sidecar leaves whatever sidecar is on disk untouched;
+  // an empty-string hash matches "no sidecar file" on the read side.
+  recordSelfSidecarWrite(sidecarJson ?? '')
+}
+
+/** Did c4hero itself produce this on-disk state? `previous` is the watcher's
+ *  last baseline, so an unchanged half (DSL or sidecar) doesn't need to have
+ *  been written by us to count. */
+export function isSelfWrite(hashes: SnapshotHashes, previous: SnapshotHashes | null): boolean {
+  const key = `${hashes.dsl}|${hashes.sidecar}`
+  if (suppressed.has(key)) return true
+  const dslOk = selfDsl.includes(hashes.dsl) || (previous !== null && previous.dsl === hashes.dsl)
+  const sidecarOk = selfSidecar.includes(hashes.sidecar) || (previous !== null && previous.sidecar === hashes.sidecar)
+  return dslOk && sidecarOk
+}
+
+/** "Keep mine": stop prompting about this exact on-disk state. The next
+ *  autosave overwrites it anyway. */
+export function suppressSnapshot(hashes: SnapshotHashes): void {
+  suppressed.add(`${hashes.dsl}|${hashes.sidecar}`)
+}
+
+/** Test/reset hook — also called when the watched file changes identity. */
+export function resetSaveCoordinator(): void {
+  selfDsl.length = 0
+  selfSidecar.length = 0
+  suppressed.clear()
+}

--- a/src/lib/testFileSource.ts
+++ b/src/lib/testFileSource.ts
@@ -1,0 +1,30 @@
+// Dev/E2E-only stand-in for a file on disk.
+//
+// Playwright cannot drive the File System Access API, so `main.tsx` exposes
+// `window.__testFileSource` (DEV builds only) which installs an in-memory
+// source here. `useDiskWatch` watches it exactly as it would a real handle.
+
+import type { WatchedSnapshot } from '@/lib/fileWatch'
+
+export interface TestFileSource {
+  filename: string
+  read: () => Promise<WatchedSnapshot | null>
+}
+
+let source: TestFileSource | null = null
+const listeners = new Set<() => void>()
+
+export function getTestFileSource(): TestFileSource | null {
+  return source
+}
+
+export function setTestFileSource(next: TestFileSource | null): void {
+  source = next
+  for (const cb of listeners) cb()
+}
+
+/** Re-render hook: fires when the source is installed or removed. */
+export function subscribeTestFileSource(cb: () => void): () => void {
+  listeners.add(cb)
+  return () => { listeners.delete(cb) }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import { initCloudflareAnalytics } from './lib/observability/cloudflareAnalytics
 import { initSentry } from './lib/observability/sentry'
 import { normalizeRemoteLogEndpoint } from './lib/remoteLogEndpoint'
 import { useWorkspaceStore } from './store/workspace'
+import { setTestFileSource } from './lib/testFileSource'
 import {
   createBigBankSample,
   createBlankWorkspace,
@@ -63,6 +64,24 @@ if (import.meta.env.DEV) {
       default: throw new Error(`Unknown template: ${name}`)
     }
   }
+  // In-memory stand-in for a watched file on disk (FSA isn't drivable from
+  // Playwright). `set` replaces the "file", `remove` deletes it, `clear`
+  // uninstalls the source.
+  ;(window as unknown as Record<string, unknown>).__testFileSource = (() => {
+    let snapshot: { content: string; sidecarJson?: string } | null = null
+    const install = (filename: string) => {
+      setTestFileSource({ filename, read: async () => snapshot })
+    }
+    return {
+      install: (filename: string, content: string, sidecarJson?: string) => {
+        snapshot = { content, sidecarJson }
+        install(filename)
+      },
+      set: (content: string, sidecarJson?: string) => { snapshot = { content, sidecarJson } },
+      remove: () => { snapshot = null },
+      clear: () => { snapshot = null; setTestFileSource(null) },
+    }
+  })()
   ;(window as unknown as Record<string, unknown>).__testListViews = () => {
     const ws = useWorkspaceStore.getState().workspace
     if (!ws) return []

--- a/src/store/reload-from-disk.test.ts
+++ b/src/store/reload-from-disk.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from './workspace'
+import { parseDSL } from '@/lib/dsl'
+
+const BASE_DSL = `workspace "Test" {
+    model {
+        u = person "User"
+        sys = softwareSystem "Sys" {
+            web = container "Web"
+        }
+        u -> sys "Uses"
+    }
+    views {
+        systemLandscape "Land" {
+            include *
+        }
+        systemContext sys "Ctx" {
+            include *
+        }
+        container sys "Containers" {
+            include *
+        }
+    }
+}`
+
+function parse(dsl: string) {
+  const { workspace, errors } = parseDSL(dsl)
+  expect(errors).toEqual([])
+  return workspace
+}
+
+function store() {
+  return useWorkspaceStore.getState()
+}
+
+describe('reloadWorkspaceFromDisk', () => {
+  beforeEach(() => {
+    store().loadWorkspace(parse(BASE_DSL))
+  })
+
+  it('keeps the active view when its key survives', () => {
+    store().setActiveView('Ctx')
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL.replace('"Web"', '"Web App"')))
+    expect(store().activeViewKey).toBe('Ctx')
+    expect(store().workspace!.model.softwareSystems[0].containers[0].name).toBe('Web App')
+  })
+
+  it('falls back to a view of the same type, then to the first view', () => {
+    store().setActiveView('Ctx')
+    // Ctx renamed → another systemContext view exists → pick it.
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL.replace('systemContext sys "Ctx"', 'systemContext sys "Overview"')))
+    expect(store().activeViewKey).toBe('Overview')
+
+    // No systemContext view at all → first view.
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL.replace(/systemContext sys "Ctx" \{\s*include \*\s*\}/, '')))
+    expect(store().activeViewKey).toBe('Land')
+  })
+
+  it('prunes view history and keeps only surviving selected elements', () => {
+    store().setActiveView('Containers')
+    // drillInto is what normally pushes history; seed it directly here.
+    useWorkspaceStore.setState({ viewHistory: ['Land', 'Containers'] })
+    store().selectElements(['u', 'web'])
+
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL
+      .replace(/container sys "Containers" \{\s*include \*\s*\}/, '')
+      .replace(/web = container "Web"\s*/, '')))
+
+    expect(store().viewHistory).toEqual(['Land'])
+    expect(store().selectedElementIds).toEqual(['u'])
+    // The active view was removed and was a container view; none remain → first view.
+    expect(store().activeViewKey).toBe('Land')
+  })
+
+  it('clears undo history and marks the workspace clean', () => {
+    store().updateWorkspaceMeta({ name: 'Renamed' })
+    expect(store().undoStack.length).toBe(1)
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL))
+    expect(store().undoStack).toEqual([])
+    expect(store().redoStack).toEqual([])
+    expect(store().lastSavedUndoLength).toBe(0)
+    expect(store().canUndo()).toBe(false)
+  })
+
+  it('clears any disk conflict and missing-file flag', () => {
+    store().setDiskConflict({
+      filename: 'test.dsl',
+      snapshot: { content: 'x' },
+      hashes: { dsl: 'a', sidecar: 'b' },
+      reason: 'dirty',
+    })
+    store().setDiskFileMissing(true)
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL))
+    expect(store().diskConflict).toBeNull()
+    expect(store().diskFileMissing).toBe(false)
+  })
+
+  it('leaves canvas highlight filters alone, unlike loadWorkspace', () => {
+    useWorkspaceStore.setState({ activeTagFilter: ['Person'] })
+    store().reloadWorkspaceFromDisk(parse(BASE_DSL))
+    expect(store().activeTagFilter).toEqual(['Person'])
+  })
+})
+
+describe('watch mode flags', () => {
+  it('turning watch off drops any pending prompt', () => {
+    store().setDiskFileMissing(true)
+    store().setWatchDisk(false)
+    expect(store().watchDisk).toBe(false)
+    expect(store().diskFileMissing).toBe(false)
+    store().toggleWatchDisk()
+    expect(store().watchDisk).toBe(true)
+  })
+
+  it('setCodePaneDirty is a no-op when unchanged', () => {
+    const before = useWorkspaceStore.getState()
+    store().setCodePaneDirty(false)
+    expect(useWorkspaceStore.getState()).toBe(before)
+    store().setCodePaneDirty(true)
+    expect(store().codePaneDirty).toBe(true)
+    store().setCodePaneDirty(false)
+  })
+})

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -62,6 +62,7 @@ function carryOverViewLayout(prev: Workspace, next: Workspace): void {
 export type LifecycleSlice = Pick<WorkspaceState,
   | 'workspace'
   | 'loadWorkspace' | 'closeWorkspace' | 'updateWorkspaceMeta'
+  | 'reloadWorkspaceFromDisk'
   | 'replaceWorkspaceFromDSL'
   | 'scopeViolations' | 'revalidateScope'
   | 'activeWorkspaceFilename' | 'setActiveWorkspaceFilename'
@@ -105,6 +106,8 @@ export const createLifecycleSlice: StateCreator<
       pendingZoomConfirm: null,
       createViewDefaults: null,
       impactTargetIds: null,
+      diskConflict: null,
+      diskFileMissing: false,
       undoStack: [],
       redoStack: [],
       lastSavedUndoLength: 0, // reset so the save indicator doesn't inherit a stale saved position
@@ -115,6 +118,41 @@ export const createLifecycleSlice: StateCreator<
       activeTeamFilter: [],
       lastClearedHighlightFilters: null,
       scopeViolations: validateScope(workspace),
+    })
+  },
+
+  reloadWorkspaceFromDisk: (workspace) => {
+    normalizeWorkspaceShape(workspace)
+    set((s) => {
+      const previousActive = s.activeViewKey ? findViewHelper(s.workspace ?? workspace, s.activeViewKey) : undefined
+      const survivingIds = new Set<string>()
+      forEachElementHelper(workspace, (el) => { survivingIds.add(el.id) })
+
+      s.workspace = workspace
+      // Keep the user's place: same key, else the nearest view of the same
+      // type, else the first view — never dump them onto a random diagram.
+      if (s.activeViewKey && findViewHelper(workspace, s.activeViewKey)) {
+        // unchanged
+      } else if (previousActive) {
+        const sameType = allViewsOf(workspace).find((v) => v.type === previousActive.type)
+        s.activeViewKey = sameType?.key ?? getFirstViewKey(workspace)
+      } else {
+        s.activeViewKey = getFirstViewKey(workspace)
+      }
+      s.viewHistory = s.viewHistory.filter((k) => !!findViewHelper(workspace, k))
+      s.selectedElementIds = s.selectedElementIds.filter((id) => survivingIds.has(id))
+      s.selectedRelationshipId = null
+      s.selectedGroupId = null
+      s.focusElementId = null
+      s.pendingDelete = null
+      s.pendingZoomConfirm = null
+      s.impactTargetIds = null
+      s.undoStack = []
+      s.redoStack = []
+      s.lastSavedUndoLength = 0
+      s.diskConflict = null
+      s.diskFileMissing = false
+      s.scopeViolations = validateScope(workspace)
     })
   },
 
@@ -135,6 +173,8 @@ export const createLifecycleSlice: StateCreator<
       pendingZoomConfirm: null,
       createViewDefaults: null,
       impactTargetIds: null,
+      diskConflict: null,
+      diskFileMissing: false,
       undoStack: [],
       redoStack: [],
       lastClearedHighlightFilters: null,

--- a/src/store/slices/ui-slice.ts
+++ b/src/store/slices/ui-slice.ts
@@ -2,6 +2,9 @@ import type { StateCreator } from 'zustand'
 import type { Workspace } from '@/types/model'
 import type { WorkspaceState } from '../workspace-types'
 import { pushUndoSnapshot } from '../internals'
+import { readString, writeString } from '@/lib/safeStorage'
+
+const WATCH_DISK_KEY = 'c4hero_watch_disk'
 
 // Per-batch bookkeeping for setBatchApplying's no-op guard (single store instance).
 let batchBaseWs: Workspace | null = null
@@ -16,6 +19,9 @@ export type UiSlice = Pick<WorkspaceState,
   | 'canvasSettingsOpen' | 'canvasGuideOpen' | 'addElementPanelOpen' | 'highlighterOpenFacet'
   | 'viewsPanelOpen' | 'createViewDialogOpen'
   | 'codePanelOpen' | 'setCodePanelOpen' | 'toggleCodePanel'
+  | 'watchDisk' | 'setWatchDisk' | 'toggleWatchDisk'
+  | 'diskConflict' | 'setDiskConflict' | 'diskFileMissing' | 'setDiskFileMissing'
+  | 'codePaneDirty' | 'setCodePaneDirty'
   | 'impactTargetIds' | 'openImpactPanel' | 'closeImpactPanel'
   | 'pendingDelete' | 'confirmDelete' | 'cancelDelete'
   | 'presentationMode' | 'setPresentationMode'
@@ -57,6 +63,10 @@ export const createUiSlice: StateCreator<
   viewsPanelOpen: false,
   createViewDialogOpen: false,
   codePanelOpen: false,
+  watchDisk: readString(WATCH_DISK_KEY) !== '0',
+  diskConflict: null,
+  diskFileMissing: false,
+  codePaneDirty: false,
   impactTargetIds: null,
   pendingDelete: null,
   presentationMode: false,
@@ -130,6 +140,16 @@ export const createUiSlice: StateCreator<
     if (s.codePanelOpen) s.commandPaletteOpen = false
   }),
   setCreateViewDialogOpen: (open) => set({ createViewDialogOpen: open, commandPaletteOpen: false }),
+
+  setWatchDisk: (on) => {
+    writeString(WATCH_DISK_KEY, on ? '1' : '0')
+    // Turning the watch off also drops any prompt it raised.
+    set(on ? { watchDisk: true } : { watchDisk: false, diskConflict: null, diskFileMissing: false })
+  },
+  toggleWatchDisk: () => get().setWatchDisk(!get().watchDisk),
+  setDiskConflict: (conflict) => set({ diskConflict: conflict }),
+  setDiskFileMissing: (missing) => set({ diskFileMissing: missing }),
+  setCodePaneDirty: (dirty) => set((s) => { if (s.codePaneDirty !== dirty) s.codePaneDirty = dirty }),
 
   // The targets are snapshotted when the panel opens: the analysis answers a
   // question about a specific set of elements, and changing the canvas

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -42,6 +42,23 @@ export interface UndoState {
 
 export type HighlighterFacet = 'tags' | 'status' | 'tech' | 'teams'
 
+// ─── Disk watch ──────────────────────────────────────────────────────
+
+/** Why an external file change was not applied automatically. */
+export interface DiskConflict {
+  /** Display name of the changed file (e.g. 'payments.dsl'). */
+  filename: string
+  /** What's on disk now, so "Reload" doesn't need another read. */
+  snapshot: { content: string; sidecarJson?: string }
+  /** Content hashes of that snapshot, for "Keep mine" suppression. */
+  hashes: { dsl: string; sidecar: string }
+  /** 'dirty': there are unsaved local edits. 'unparseable': the new text has
+   *  parse errors or parses to an empty model; the canvas is kept as-is. */
+  reason: 'dirty' | 'unparseable'
+  /** Human-readable detail for the 'unparseable' case. */
+  detail?: string
+}
+
 // ─── State Interface ─────────────────────────────────────────────────
 
 export interface WorkspaceState extends UndoState {
@@ -103,12 +120,34 @@ export interface WorkspaceState extends UndoState {
   activeWorkspaceFilename: string | null
   setActiveWorkspaceFilename: (name: string | null) => void
 
+  // Disk watch (TEA-323): reload the workspace when the .dsl changes on disk.
+  /** User preference, persisted. Default on; only effective when a file/folder handle exists. */
+  watchDisk: boolean
+  setWatchDisk: (on: boolean) => void
+  toggleWatchDisk: () => void
+  /** An external change that could not be applied silently — see DiskConflict. */
+  diskConflict: DiskConflict | null
+  setDiskConflict: (conflict: DiskConflict | null) => void
+  /** The watched file disappeared from disk; the in-memory model is kept. */
+  diskFileMissing: boolean
+  setDiskFileMissing: (missing: boolean) => void
+  /** True while the DSL code pane holds text not yet applied (or failing to
+   *  apply) — a disk reload must never hot-swap text under the user's cursor. */
+  codePaneDirty: boolean
+  setCodePaneDirty: (dirty: boolean) => void
+
   // Scope validation
   scopeViolations: ScopeViolation[]
   revalidateScope: () => void
 
   // Workspace lifecycle
   loadWorkspace: (workspace: Workspace) => void
+  /** Swap in a workspace re-read from disk (watch mode). Unlike loadWorkspace
+   *  this keeps the active view when its key survives (else the nearest view
+   *  of the same type, else the first), prunes view history, re-selects the
+   *  surviving selection, and leaves canvas filters alone. Undo history is
+   *  cleared: disk is the source of truth and the workspace was clean. */
+  reloadWorkspaceFromDisk: (workspace: Workspace) => void
   closeWorkspace: () => void
   updateWorkspaceMeta: (patch: { name?: string; description?: string }) => void
   /** Replace the whole workspace from DSL text (the code pane's apply path).


### PR DESCRIPTION
## Summary

Closes the one-way disk sync gap: c4hero now watches the open workspace's `.dsl` (and `.c4hero.json` sidecar) and reloads when it changes outside the app — an external editor, a `git checkout`. Same two-writer ownership rules as the code pane (TEA-252), with disk as the second writer.

Linear: [TEA-323](https://linear.app/kevnord/issue/TEA-323)

### What's in it

- **Watcher** (`src/lib/fileWatch.ts`): pure and injectable. Uses `FileSystemObserver` when the caller provides one, otherwise polls every 2s **only while the tab is visible**, with an immediate check on `focus` / `visibilitychange`. Compares content hashes, never mtime.
- **Self-write coordination** (`src/lib/saveCoordinator.ts`): the low-level writers in `fileIO`/`folderIO` record the hash of everything c4hero writes, so autosave and manual saves never trigger a false "changed on disk". DSL and sidecar hashes are tracked separately because they land as two files.
- **Reload path** (`reloadWorkspaceFromDisk`): keeps the active view when its key survives (else nearest same-type view, else first), prunes view history, re-selects surviving elements, leaves highlight filters alone, clears undo (workspace was clean; disk is truth). Viewport is untouched when the view key and element count are unchanged; a structural change refits as usual.
- **Conflict bar**: unsaved local edits (store dirty, or the code pane holding unapplied/broken text) are never discarded. The bar offers *Reload (discard my changes)* or *Keep mine* (suppresses that on-disk state; next save overwrites). Text with parse errors, or that parses to an empty model, is reported with *Retry* and not applied. A deleted file shows a friendly state and keeps the model.
- **Toggle**: *Watch Mode* command (view category), persisted, default on wherever a handle exists. Save indicator tooltip shows the watch. Welcome-screen collection list refreshes on tab focus.
- With watch mode off, behaviour is what it was.

### Not in scope (per ticket)
Watching every file in a collection, git awareness, three-way merge, locking the file.

### Known trade-off
Autosave already re-serialises on load, so after a reload c4hero writes its canonical formatting back to the file (pre-existing behaviour on open). The write is recognised as ours, so there's no ping-pong; it will however normalise formatting in an editor that has the file open.

## Test plan

- [x] `npm run check` green (lint, typecheck, 2585 unit tests, build)
- [x] `npm run test:coverage` green (CI's test job)
- [x] Full Playwright suite: 183 passed, including the new `e2e/file-io/watch-mode.spec.ts` (reload keeps view; conflict bar Keep mine + Reload; unparseable reported; deleted file friendly; watch off inert)
- [x] Unit: `fileWatch.test.ts` (self-write ignored, hidden tab doesn't poll, wake checks immediately, observer preferred, missing file, transient failure), `saveCoordinator.test.ts`, `reload-from-disk.test.ts`, `useDiskWatch.test.ts`
- [ ] Manual: open a folder collection in Chromium, edit the `.dsl` in another editor, confirm reload within ~2s of refocusing the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs