### PR TITLE
feat(ai): fetch available models from the provider instead of hardcoding them (TEA-249)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -70,6 +70,7 @@ to the provider you choose — c4hero never sees your key or your model data.
 Open it from the tool rail, the menu, or the command palette (`AI: …`), or toggle
 it with the `I` shortcut.
 
+- **Live model list.** With a key set, the picker shows the models the provider currently offers (filtered to chat-capable ones), cached per key for 24h with a manual refresh. Falls back to curated suggestions without a key or offline; any model id can still be typed. Retired curated defaults resolve to their same-family successor so cheap-draft routing stays valid.
 - **Bring your own key** — **Anthropic**, **OpenAI**, or **Google Gemini**, with a
   recommended balanced-tier model per provider (and any model you prefer). The
   provider layer is pluggable for adding more.

--- a/src/components/ai/SettingsView.tsx
+++ b/src/components/ai/SettingsView.tsx
@@ -1,7 +1,9 @@
-import { useState, type CSSProperties } from 'react'
-import { X, KeyRound, ExternalLink, ArrowRight, ArrowLeft, Check, ShieldCheck, Activity } from 'lucide-react'
+import { useEffect, useState, type CSSProperties } from 'react'
+import { X, KeyRound, ExternalLink, ArrowRight, ArrowLeft, Check, ShieldCheck, Activity, RefreshCw } from 'lucide-react'
 import { useAiSettingsStore } from '@/store/ai-settings'
+import { useAiModelsStore } from '@/store/ai-models'
 import { AI_PROVIDER_META, AI_PROVIDER_IDS, type AiProviderId } from '@/lib/ai/providerMeta'
+import { pickerOptions } from '@/lib/ai/modelCatalog'
 import { resetAiUsage } from '@/lib/ai'
 import { C, iconBtn, fieldLabel, keyInput, headerRow, secondaryBtn, primaryBtn } from './aiTheme'
 import { useAiUsage, formatTokens } from './aiUsage'
@@ -91,6 +93,20 @@ export function SettingsView({ onClose, onDone }: { onClose: () => void; onDone?
   // (or closing) must not leave a half-typed key/provider written to the store.
   const [draft, setDraft] = useState<{ provider: AiProviderId; apiKeys: Record<AiProviderId, string>; models: Record<AiProviderId, string> } | null>(null)
   const editMeta = AI_PROVIDER_META[draft?.provider ?? provider]
+  // Live model list for the provider being edited (TEA-249). Cache-first; the
+  // fetch runs when the draft has a key for that provider. Curated list otherwise.
+  const draftProvider = draft?.provider ?? provider
+  const draftKey = (draft ? draft.apiKeys[draftProvider] : apiKeys[draftProvider]) ?? ''
+  const liveList = useAiModelsStore((s) => s.lists[draftProvider])
+  const listStatus = useAiModelsStore((s) => s.status[draftProvider])
+  const listError = useAiModelsStore((s) => s.error[draftProvider])
+  const refreshModels = useAiModelsStore((s) => s.refresh)
+  useEffect(() => {
+    if (edit && draftKey.trim()) void refreshModels(draftProvider, draftKey)
+  }, [edit, draftProvider, draftKey, refreshModels])
+  const draftModelId = draft ? (draft.models[draft.provider] || editMeta.defaultModel) : ''
+  const modelOptions = pickerOptions(draftProvider, liveList?.models, draftModelId)
+  const [customModel, setCustomModel] = useState('')
   function startEdit() { setDraft({ provider, apiKeys: { ...apiKeys }, models: { ...models } }); setReveal(false); setEdit(true) }
   function cancelEdit() { setDraft(null); setEdit(false) }
   function saveEdit() { if (draft) update({ provider: draft.provider, apiKeys: draft.apiKeys, models: draft.models }); setDraft(null); setEdit(false) }
@@ -165,9 +181,19 @@ export function SettingsView({ onClose, onDone }: { onClose: () => void; onDone?
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <div style={fieldLabel}>Model</div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {editMeta.models.map((m) => {
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+                <div style={fieldLabel}>Model</div>
+                <ModelListStatus
+                  providerLabel={editMeta.label.replace(/ \(Claude\)$/, '')}
+                  hasKey={!!draftKey.trim()}
+                  list={liveList}
+                  status={listStatus}
+                  error={listError}
+                  onRefresh={() => { void refreshModels(draftProvider, draftKey, { force: true }) }}
+                />
+              </div>
+              <div data-model-picker style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 264, overflowY: 'auto' }}>
+                {modelOptions.map((m) => {
                   const on = (draft && (draft.models[draft.provider] || editMeta.defaultModel)) === m.id
                   const recommended = m.id === editMeta.defaultModel
                   return (
@@ -182,6 +208,20 @@ export function SettingsView({ onClose, onDone }: { onClose: () => void; onDone?
                   )
                 })}
               </div>
+              {/* Any model id the provider accepts can be typed in — the list is a
+                  suggestion, not a whitelist. */}
+              <input
+                type="text"
+                aria-label="Other model id"
+                value={customModel}
+                onChange={(e) => setCustomModel(e.target.value)}
+                onBlur={() => { const id = customModel.trim(); if (id) { setDraft((d) => (d ? { ...d, models: { ...d.models, [d.provider]: id } } : d)); setCustomModel('') } }}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); (e.target as HTMLInputElement).blur() } }}
+                placeholder="Or type a model id…"
+                autoComplete="off"
+                spellCheck={false}
+                style={{ ...keyInput, height: 34, fontSize: 12 }}
+              />
             </div>
             <SecurityNote />
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
@@ -193,6 +233,43 @@ export function SettingsView({ onClose, onDone }: { onClose: () => void; onDone?
       </div>
     </div>
   )
+}
+
+// One-line provenance for the model picker: live list (and how fresh), loading,
+// fetch failed (curated list shown), or no key yet. Never blocks anything.
+function ModelListStatus({ providerLabel, hasKey, list, status, error, onRefresh }: {
+  providerLabel: string
+  hasKey: boolean
+  list: { fetchedAt: number; source: 'fetched' | 'cache' } | undefined
+  status: 'idle' | 'loading' | 'ready' | 'error'
+  error: string | undefined
+  onRefresh: () => void
+}) {
+  const style: CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: C.muted, whiteSpace: 'nowrap', minWidth: 0 }
+  const refreshBtn = (
+    <button type="button" onClick={onRefresh} className="c4ai-ghost" aria-label="Refresh model list" title="Refresh model list"
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 6px', borderRadius: 6, border: 'none', background: 'transparent', color: C.accent, fontSize: 11, cursor: 'pointer' }}>
+      <RefreshCw size={11} /> Refresh
+    </button>
+  )
+  if (!hasKey) return <span data-model-list-status="curated" style={style}>Suggested models — add a key to list what's available</span>
+  if (status === 'loading' && !list) return <span data-model-list-status="loading" style={style}><RefreshCw size={11} /> Fetching models from {providerLabel}…</span>
+  if (list) {
+    // No clock read here (render stays pure): a list fetched this session is
+    // "just now"; a cached one says so, with the exact time on hover.
+    const fresh = list.source === 'fetched' ? 'just now' : 'cached'
+    const when = `Fetched ${new Date(list.fetchedAt).toLocaleString()}`
+    const title = error ? `${when}. Last refresh failed: ${error}. Showing the previous list.` : when
+    return (
+      <span data-model-list-status="live" style={style} title={title}>
+        Live from {providerLabel} · {fresh}{refreshBtn}
+      </span>
+    )
+  }
+  if (status === 'error') {
+    return <span data-model-list-status="error" style={{ ...style, color: C.warnText }} title={error}>Couldn't fetch models — showing suggestions{refreshBtn}</span>
+  }
+  return <span data-model-list-status="curated" style={style}>Suggested models{refreshBtn}</span>
 }
 
 // Session usage meter (TEA-47): calls fired this session (+ tokens where the

--- a/src/lib/ai/modelCatalog.test.ts
+++ b/src/lib/ai/modelCatalog.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  parseAnthropicModels, parseOpenAiModels, parseGeminiModels, fetchProviderModels, ModelListError,
+  readCachedModels, writeCachedModels, clearCachedModels, MODEL_CACHE_TTL_MS, keyFingerprint,
+  modelFamily, resolveCuratedModel, pickerOptions,
+} from './modelCatalog'
+import { AI_PROVIDER_META } from './providerMeta'
+
+describe('parseAnthropicModels', () => {
+  it('keeps every model, newest first, labelled by display name', () => {
+    const out = parseAnthropicModels({
+      data: [
+        { id: 'claude-sonnet-4-6', display_name: 'Claude Sonnet 4.6', created_at: '2026-02-01T00:00:00Z' },
+        { id: 'claude-sonnet-5', display_name: 'Claude Sonnet 5', created_at: '2026-08-01T00:00:00Z' },
+        { id: 'claude-opus-5', display_name: 'Claude Opus 5', created_at: '2026-08-01T00:00:00Z' },
+        { bogus: true },
+      ],
+    })
+    expect(out.map((m) => m.id)).toEqual(['claude-opus-5', 'claude-sonnet-5', 'claude-sonnet-4-6'])
+    expect(out[0].label).toBe('Claude Opus 5')
+  })
+
+  it('returns [] for an unexpected body', () => {
+    expect(parseAnthropicModels(null)).toEqual([])
+    expect(parseAnthropicModels({ data: 'nope' })).toEqual([])
+  })
+})
+
+describe('parseOpenAiModels', () => {
+  it('keeps chat families, drops the noise, hides dated snapshots of a present alias', () => {
+    const out = parseOpenAiModels({
+      data: [
+        { id: 'gpt-5', created: 300 },
+        { id: 'gpt-5-mini', created: 300 },
+        { id: 'gpt-4o', created: 100 },
+        { id: 'gpt-4o-2024-08-06', created: 100 },
+        { id: 'gpt-4o-2099-01-01', created: 100 }, // alias present → hidden
+        { id: 'o3', created: 200 },
+        { id: 'text-embedding-3-large', created: 500 },
+        { id: 'gpt-4o-audio-preview', created: 500 },
+        { id: 'gpt-4o-realtime-preview', created: 500 },
+        { id: 'whisper-1', created: 500 },
+        { id: 'dall-e-3', created: 500 },
+        { id: 'tts-1', created: 500 },
+        { id: 'omni-moderation-latest', created: 500 },
+        { id: 'gpt-3.5-turbo-instruct', created: 500 },
+        { id: 'gpt-4o-transcribe', created: 500 },
+      ],
+    })
+    expect(out.map((m) => m.id)).toEqual(['gpt-5', 'gpt-5-mini', 'o3', 'gpt-4o'])
+  })
+
+  it('keeps a dated snapshot whose alias is absent', () => {
+    const out = parseOpenAiModels({ data: [{ id: 'gpt-4.1-2025-04-14', created: 1 }] })
+    expect(out.map((m) => m.id)).toEqual(['gpt-4.1-2025-04-14'])
+  })
+})
+
+describe('parseGeminiModels', () => {
+  it('keeps generateContent text models, strips the prefix, ranks stable before preview', () => {
+    const out = parseGeminiModels({
+      models: [
+        { name: 'models/gemini-2.5-flash-preview-05-20', displayName: 'Gemini 2.5 Flash Preview', supportedGenerationMethods: ['generateContent'] },
+        { name: 'models/gemini-2.0-flash', displayName: 'Gemini 2.0 Flash', supportedGenerationMethods: ['generateContent'] },
+        { name: 'models/gemini-2.5-pro', displayName: 'Gemini 2.5 Pro', supportedGenerationMethods: ['generateContent'] },
+        { name: 'models/gemini-embedding-001', displayName: 'Embedding', supportedGenerationMethods: ['embedContent'] },
+        { name: 'models/gemini-2.5-flash-preview-tts', displayName: 'TTS', supportedGenerationMethods: ['generateContent'] },
+        { name: 'models/imagen-4.0', displayName: 'Imagen', supportedGenerationMethods: ['predict'] },
+        { name: 'models/gemini-2.5-flash-live', displayName: 'Live', supportedGenerationMethods: ['bidiGenerateContent'] },
+      ],
+    })
+    expect(out.map((m) => m.id)).toEqual(['gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-2.5-flash-preview-05-20'])
+    expect(out[0].label).toBe('Gemini 2.5 Pro')
+  })
+})
+
+describe('fetchProviderModels', () => {
+  function fakeFetch(status: number, body: unknown, capture?: { url?: string; headers?: Record<string, string> }) {
+    return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      if (capture) { capture.url = String(url); capture.headers = init?.headers as Record<string, string> }
+      return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+    }) as unknown as typeof fetch
+  }
+
+  it('sends the provider auth header and parses the list', async () => {
+    const cap: { url?: string; headers?: Record<string, string> } = {}
+    const models = await fetchProviderModels('anthropic', 'sk-ant-x', fakeFetch(200, {
+      data: [{ id: 'claude-sonnet-5', display_name: 'Claude Sonnet 5', created_at: '2026-08-01T00:00:00Z' }],
+    }, cap))
+    expect(models).toEqual([{ id: 'claude-sonnet-5', label: 'Claude Sonnet 5' }])
+    expect(cap.url).toContain('https://api.anthropic.com/v1/models')
+    expect(cap.headers?.['x-api-key']).toBe('sk-ant-x')
+    expect(cap.headers?.['anthropic-dangerous-direct-browser-access']).toBe('true')
+  })
+
+  it('uses bearer auth for OpenAI and the goog header for Gemini', async () => {
+    const cap: { headers?: Record<string, string> } = {}
+    await fetchProviderModels('openai', 'sk-o', fakeFetch(200, { data: [{ id: 'gpt-5', created: 1 }] }, cap))
+    expect(cap.headers?.authorization).toBe('Bearer sk-o')
+    await fetchProviderModels('gemini', 'AIza', fakeFetch(200, {
+      models: [{ name: 'models/gemini-2.5-pro', supportedGenerationMethods: ['generateContent'] }],
+    }, cap))
+    expect(cap.headers?.['x-goog-api-key']).toBe('AIza')
+  })
+
+  it('throws ModelListError on HTTP failure, network failure, bad JSON, and an empty list', async () => {
+    await expect(fetchProviderModels('openai', 'k', fakeFetch(401, { error: { message: 'bad key' } })))
+      .rejects.toMatchObject({ name: 'ModelListError', status: 401 })
+    const boom = vi.fn(async () => { throw new TypeError('Failed to fetch') }) as unknown as typeof fetch
+    await expect(fetchProviderModels('openai', 'k', boom)).rejects.toBeInstanceOf(ModelListError)
+    const notJson = vi.fn(async () => new Response('<html>', { status: 200 })) as unknown as typeof fetch
+    await expect(fetchProviderModels('openai', 'k', notJson)).rejects.toBeInstanceOf(ModelListError)
+    await expect(fetchProviderModels('openai', 'k', fakeFetch(200, { data: [{ id: 'whisper-1' }] })))
+      .rejects.toThrow(/no chat models/)
+  })
+})
+
+describe('model cache', () => {
+  beforeEach(() => { localStorage.clear() })
+
+  it('round-trips per provider and is keyed to the API key', () => {
+    const now = 1_000_000
+    writeCachedModels('anthropic', 'key-a', [{ id: 'm', label: 'M' }], now)
+    expect(readCachedModels('anthropic', 'key-a', now)?.models).toEqual([{ id: 'm', label: 'M' }])
+    expect(readCachedModels('anthropic', 'key-b', now)).toBeNull()
+    expect(readCachedModels('openai', 'key-a', now)).toBeNull()
+  })
+
+  it('expires after the TTL', () => {
+    const now = 1_000_000
+    writeCachedModels('gemini', 'k', [{ id: 'g', label: 'G' }], now)
+    expect(readCachedModels('gemini', 'k', now + MODEL_CACHE_TTL_MS - 1)).not.toBeNull()
+    expect(readCachedModels('gemini', 'k', now + MODEL_CACHE_TTL_MS + 1)).toBeNull()
+  })
+
+  it('never stores the key itself', () => {
+    writeCachedModels('openai', 'sk-super-secret', [{ id: 'gpt-5', label: 'gpt-5' }])
+    expect(localStorage.getItem('c4hero.ai.models.json')).not.toContain('sk-super-secret')
+    expect(keyFingerprint('sk-super-secret')).not.toContain('secret')
+  })
+
+  it('clears one provider or all', () => {
+    writeCachedModels('openai', 'k', [{ id: 'a', label: 'a' }], 1)
+    writeCachedModels('gemini', 'k', [{ id: 'b', label: 'b' }], 1)
+    clearCachedModels('openai')
+    expect(readCachedModels('openai', 'k', 1)).toBeNull()
+    expect(readCachedModels('gemini', 'k', 1)).not.toBeNull()
+    clearCachedModels()
+    expect(readCachedModels('gemini', 'k', 1)).toBeNull()
+  })
+
+  it('ignores a corrupt cache entry', () => {
+    localStorage.setItem('c4hero.ai.models.json', JSON.stringify({ openai: { models: 'nope' } }))
+    expect(readCachedModels('openai', 'k')).toBeNull()
+  })
+})
+
+describe('resolution', () => {
+  it('modelFamily strips versions, dates and preview tags', () => {
+    expect(modelFamily('claude-sonnet-4-6')).toBe('claude-sonnet')
+    expect(modelFamily('claude-sonnet-5')).toBe('claude-sonnet')
+    expect(modelFamily('claude-haiku-4-5-20251001')).toBe('claude-haiku')
+    expect(modelFamily('gpt-4o-2024-08-06')).toBe('gpt-4o')
+    expect(modelFamily('gpt-5-mini')).toBe('gpt-mini') // mini tiers upgrade across generations
+    expect(modelFamily('gemini-2.5-flash')).toBe('gemini-flash')
+    expect(modelFamily('gemini-2.0-flash')).toBe('gemini-flash')
+  })
+
+  it('keeps a curated id the provider still offers', () => {
+    expect(resolveCuratedModel('claude-sonnet-4-6', [{ id: 'claude-sonnet-4-6', label: '' }])).toBe('claude-sonnet-4-6')
+  })
+
+  it('upgrades a retired curated id to the newest same-family live model', () => {
+    const live = [{ id: 'claude-opus-5', label: '' }, { id: 'claude-sonnet-5', label: '' }, { id: 'claude-haiku-4-5', label: '' }]
+    expect(resolveCuratedModel('claude-sonnet-4-6', live)).toBe('claude-sonnet-5')
+    expect(resolveCuratedModel('claude-haiku-4-5', live)).toBe('claude-haiku-4-5')
+  })
+
+  it('falls back to the curated id when nothing in the family is live, or no list', () => {
+    expect(resolveCuratedModel('claude-sonnet-4-6', [{ id: 'gpt-5', label: '' }])).toBe('claude-sonnet-4-6')
+    expect(resolveCuratedModel('claude-sonnet-4-6', null)).toBe('claude-sonnet-4-6')
+    expect(resolveCuratedModel('claude-sonnet-4-6', [])).toBe('claude-sonnet-4-6')
+  })
+
+  it('pickerOptions prefers the live list and always includes the selection', () => {
+    expect(pickerOptions('anthropic', null)).toBe(AI_PROVIDER_META.anthropic.models)
+    const live = [{ id: 'claude-sonnet-5', label: 'Claude Sonnet 5' }]
+    expect(pickerOptions('anthropic', live, 'claude-sonnet-5')).toEqual(live)
+    expect(pickerOptions('anthropic', live, 'my-custom-id')).toEqual([...live, { id: 'my-custom-id', label: 'my-custom-id' }])
+  })
+})

--- a/src/lib/ai/modelCatalog.ts
+++ b/src/lib/ai/modelCatalog.ts
@@ -1,0 +1,249 @@
+// Live model catalog (TEA-249): ask each provider which models the user's key
+// can actually use, instead of trusting the curated list in providerMeta.ts
+// (which goes stale between releases). Pure: the fetch is injectable, parsing
+// and ranking are plain functions, and the cache is a small localStorage blob.
+//
+// Every list endpoint is on a host already in the CSP connect-src allowlist
+// and takes the same BYOK key the chat calls use, so no new permissions.
+
+import { AI_PROVIDER_META, type AiModelOption, type AiProviderId } from './providerMeta'
+import { readJSON, writeJSON } from '@/lib/safeStorage'
+import { isRecord } from '@/lib/guards'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('ai/models')
+
+export const MODEL_CACHE_KEY = 'c4hero.ai.models.json'
+export const MODEL_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+// ─── Per-provider list endpoints ─────────────────────────────────────
+
+const LIST_URLS: Record<AiProviderId, string> = {
+  anthropic: 'https://api.anthropic.com/v1/models?limit=100',
+  openai: 'https://api.openai.com/v1/models',
+  gemini: 'https://generativelanguage.googleapis.com/v1beta/models?pageSize=200',
+}
+
+function listHeaders(provider: AiProviderId, apiKey: string): Record<string, string> {
+  switch (provider) {
+    case 'anthropic':
+      return {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+      }
+    case 'openai':
+      return { authorization: `Bearer ${apiKey}` }
+    case 'gemini':
+      return { 'x-goog-api-key': apiKey }
+  }
+}
+
+// ─── Parsing + filtering ─────────────────────────────────────────────
+
+/** Anthropic: `{ data: [{ id, display_name, created_at }] }`, every entry is a
+ *  chat model. Newest first. */
+export function parseAnthropicModels(body: unknown): AiModelOption[] {
+  if (!isRecord(body) || !Array.isArray(body.data)) return []
+  const rows = body.data.flatMap((row): Array<AiModelOption & { created: number }> => {
+    if (!isRecord(row) || typeof row.id !== 'string') return []
+    const label = typeof row.display_name === 'string' && row.display_name ? row.display_name : row.id
+    const created = typeof row.created_at === 'string' ? Date.parse(row.created_at) || 0 : 0
+    return [{ id: row.id, label, created }]
+  })
+  rows.sort((a, b) => b.created - a.created || a.id.localeCompare(b.id))
+  return rows.map(({ id, label }) => ({ id, label }))
+}
+
+// OpenAI's list is dominated by embeddings, audio, image and moderation models.
+// Keep the chat families, drop everything that can't take a chat completion.
+const OPENAI_CHAT_PREFIX = /^(gpt-|o\d|chatgpt-)/
+const OPENAI_NOT_CHAT = /(embedding|audio|realtime|tts|transcribe|whisper|image|dall-e|moderation|-search|instruct|computer-use|codex|deep-research|-pro\b)/
+// Dated snapshots (`gpt-4o-2024-08-06`) duplicate their alias; hide them when
+// the alias itself is in the list.
+const DATED_SNAPSHOT = /-\d{4}-\d{2}-\d{2}$/
+
+export function parseOpenAiModels(body: unknown): AiModelOption[] {
+  if (!isRecord(body) || !Array.isArray(body.data)) return []
+  const rows = body.data.flatMap((row): Array<{ id: string; created: number }> => {
+    if (!isRecord(row) || typeof row.id !== 'string') return []
+    const id = row.id
+    if (!OPENAI_CHAT_PREFIX.test(id) || OPENAI_NOT_CHAT.test(id)) return []
+    return [{ id, created: typeof row.created === 'number' ? row.created : 0 }]
+  })
+  const ids = new Set(rows.map((r) => r.id))
+  const kept = rows.filter((r) => !(DATED_SNAPSHOT.test(r.id) && ids.has(r.id.replace(DATED_SNAPSHOT, ''))))
+  kept.sort((a, b) => b.created - a.created || a.id.localeCompare(b.id))
+  return kept.map(({ id }) => ({ id, label: id }))
+}
+
+// Gemini: `{ models: [{ name: 'models/gemini-2.5-pro', displayName,
+// supportedGenerationMethods }] }`. Keep text generators, drop embedding /
+// image / audio / live variants that share the prefix.
+const GEMINI_NOT_CHAT = /(embedding|imagen|image|tts|audio|live|aqa|veo|learnlm)/
+
+export function parseGeminiModels(body: unknown): AiModelOption[] {
+  if (!isRecord(body) || !Array.isArray(body.models)) return []
+  const rows = body.models.flatMap((row): AiModelOption[] => {
+    if (!isRecord(row) || typeof row.name !== 'string') return []
+    const methods = Array.isArray(row.supportedGenerationMethods) ? row.supportedGenerationMethods : []
+    if (!methods.includes('generateContent')) return []
+    const id = row.name.replace(/^models\//, '')
+    if (!id.startsWith('gemini') || GEMINI_NOT_CHAT.test(id)) return []
+    const label = typeof row.displayName === 'string' && row.displayName ? row.displayName : id
+    return [{ id, label }]
+  })
+  // Stable releases before previews/experiments; within a group, higher version
+  // first (string compare on the numeric segment is good enough for x.y ids).
+  const rank = (id: string) => (/(preview|exp|latest)/.test(id) ? 1 : 0)
+  rows.sort((a, b) => rank(a.id) - rank(b.id) || b.id.localeCompare(a.id, undefined, { numeric: true }))
+  return rows
+}
+
+export function parseProviderModels(provider: AiProviderId, body: unknown): AiModelOption[] {
+  switch (provider) {
+    case 'anthropic': return parseAnthropicModels(body)
+    case 'openai': return parseOpenAiModels(body)
+    case 'gemini': return parseGeminiModels(body)
+  }
+}
+
+// ─── Fetch ───────────────────────────────────────────────────────────
+
+export class ModelListError extends Error {
+  readonly status?: number
+  constructor(message: string, status?: number) {
+    super(message)
+    this.name = 'ModelListError'
+    this.status = status
+  }
+}
+
+/** Fetch the live model list. Throws ModelListError on any failure — callers
+ *  fall back to the curated list and never block chat on this. */
+export async function fetchProviderModels(
+  provider: AiProviderId,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AiModelOption[]> {
+  let res: Response
+  try {
+    res = await fetchImpl(LIST_URLS[provider], { method: 'GET', headers: listHeaders(provider, apiKey) })
+  } catch {
+    throw new ModelListError(`Could not reach ${AI_PROVIDER_META[provider].endpointHost}`)
+  }
+  if (!res.ok) throw new ModelListError(`Model list request failed (${res.status})`, res.status)
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch {
+    throw new ModelListError('Malformed model list response')
+  }
+  const models = parseProviderModels(provider, body)
+  if (models.length === 0) throw new ModelListError('The provider returned no chat models')
+  return models
+}
+
+// ─── Cache ───────────────────────────────────────────────────────────
+
+export interface CachedModelList {
+  models: AiModelOption[]
+  fetchedAt: number
+  /** Fingerprint of the key the list was fetched with — a different key may
+   *  see a different set of models, so it invalidates the cache. */
+  keyFingerprint: string
+}
+
+type ModelCache = Partial<Record<AiProviderId, CachedModelList>>
+
+/** Non-reversible short fingerprint of a key. Only for cache invalidation;
+ *  the key itself is never written by this module. */
+export function keyFingerprint(apiKey: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < apiKey.length; i++) {
+    h ^= apiKey.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return `${apiKey.length}:${h.toString(16)}`
+}
+
+function isModelOption(v: unknown): v is AiModelOption {
+  return isRecord(v) && typeof v.id === 'string' && typeof v.label === 'string'
+}
+
+function isCachedList(v: unknown): v is CachedModelList {
+  return isRecord(v)
+    && Array.isArray(v.models) && v.models.every(isModelOption)
+    && typeof v.fetchedAt === 'number'
+    && typeof v.keyFingerprint === 'string'
+}
+
+function readCache(): ModelCache {
+  const raw = readJSON<unknown>(MODEL_CACHE_KEY, (v): v is unknown => isRecord(v))
+  if (!isRecord(raw)) return {}
+  const out: ModelCache = {}
+  for (const id of Object.keys(AI_PROVIDER_META) as AiProviderId[]) {
+    if (isCachedList(raw[id])) out[id] = raw[id]
+  }
+  return out
+}
+
+export function readCachedModels(provider: AiProviderId, apiKey: string, now = Date.now()): CachedModelList | null {
+  const entry = readCache()[provider]
+  if (!entry) return null
+  if (entry.keyFingerprint !== keyFingerprint(apiKey)) return null
+  if (now - entry.fetchedAt > MODEL_CACHE_TTL_MS) return null
+  return entry
+}
+
+export function writeCachedModels(provider: AiProviderId, apiKey: string, models: AiModelOption[], now = Date.now()): CachedModelList {
+  const entry: CachedModelList = { models, fetchedAt: now, keyFingerprint: keyFingerprint(apiKey) }
+  writeJSON(MODEL_CACHE_KEY, { ...readCache(), [provider]: entry })
+  return entry
+}
+
+export function clearCachedModels(provider?: AiProviderId): void {
+  if (!provider) { writeJSON(MODEL_CACHE_KEY, {}); return }
+  const cache = readCache()
+  delete cache[provider]
+  writeJSON(MODEL_CACHE_KEY, cache)
+}
+
+// ─── Resolution against a live list ──────────────────────────────────
+
+/** Strip the version/date tail from a model id so `claude-sonnet-4-6` and
+ *  `claude-sonnet-5` share a family (`claude-sonnet`). */
+export function modelFamily(id: string): string {
+  return id
+    .replace(/-\d{4}-\d{2}-\d{2}$/, '')       // dated snapshot
+    .replace(/(-\d+(\.\d+)?)+$/, '')          // trailing -4-6 / -2.5
+    .replace(/-(latest|preview|exp)$/, '')
+    .replace(/-\d+(\.\d+)?-/, '-')            // gemini-2.5-flash -> gemini-flash
+}
+
+/** Pick the id to actually send for a curated default/cheap id: itself when
+ *  the live list has it, else the newest live model of the same family, else
+ *  the curated id unchanged (providers accept aliases). User-typed ids are
+ *  never rewritten — pass only curated ids here. */
+export function resolveCuratedModel(id: string, live: AiModelOption[] | null | undefined): string {
+  if (!live || live.length === 0) return id
+  if (live.some((m) => m.id === id)) return id
+  const family = modelFamily(id)
+  const match = live.find((m) => modelFamily(m.id) === family)
+  if (match) {
+    log.info('Curated model id not offered by provider; using same-family model', { curated: id, resolved: match.id })
+    return match.id
+  }
+  return id
+}
+
+/** The options to show in the picker: the live list when we have one, else
+ *  the curated list. The user's current selection is always present so the
+ *  picker never shows "nothing selected" for a hand-typed or retired id. */
+export function pickerOptions(provider: AiProviderId, live: AiModelOption[] | null | undefined, selected?: string): AiModelOption[] {
+  const base = live && live.length > 0 ? live : AI_PROVIDER_META[provider].models
+  if (selected && !base.some((m) => m.id === selected)) {
+    return [...base, { id: selected, label: selected }]
+  }
+  return base
+}

--- a/src/store/ai-models.test.ts
+++ b/src/store/ai-models.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useAiModelsStore, liveModels } from './ai-models'
+import { writeCachedModels } from '@/lib/ai/modelCatalog'
+
+function respond(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('useAiModelsStore.refresh', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useAiModelsStore.setState({ lists: {}, error: {}, status: { anthropic: 'idle', openai: 'idle', gemini: 'idle' } })
+  })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('does nothing without a key', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await useAiModelsStore.getState().refresh('anthropic', '   ')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(liveModels('anthropic')).toBeNull()
+  })
+
+  it('fetches, stores, and caches the list', async () => {
+    const fetchMock = vi.fn(async () => respond({ data: [{ id: 'claude-sonnet-5', display_name: 'Claude Sonnet 5', created_at: '2026-08-01T00:00:00Z' }] }))
+    vi.stubGlobal('fetch', fetchMock)
+    await useAiModelsStore.getState().refresh('anthropic', 'sk-ant-1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const s = useAiModelsStore.getState()
+    expect(s.status.anthropic).toBe('ready')
+    expect(s.lists.anthropic?.source).toBe('fetched')
+    expect(liveModels('anthropic')?.map((m) => m.id)).toEqual(['claude-sonnet-5'])
+
+    // A second refresh with the same key is served from cache: no fetch.
+    useAiModelsStore.setState({ lists: {} })
+    await useAiModelsStore.getState().refresh('anthropic', 'sk-ant-1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(useAiModelsStore.getState().lists.anthropic?.source).toBe('cache')
+
+    // force bypasses the cache.
+    await useAiModelsStore.getState().refresh('anthropic', 'sk-ant-1', { force: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('serves a warm cache without touching the network', async () => {
+    writeCachedModels('openai', 'sk-o', [{ id: 'gpt-5', label: 'gpt-5' }])
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await useAiModelsStore.getState().refresh('openai', 'sk-o')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(liveModels('openai')?.map((m) => m.id)).toEqual(['gpt-5'])
+  })
+
+  it('records an error and keeps any previous list on failure', async () => {
+    useAiModelsStore.setState({ lists: { gemini: { models: [{ id: 'gemini-2.5-pro', label: 'x' }], fetchedAt: 1, source: 'cache' } } })
+    vi.stubGlobal('fetch', vi.fn(async () => respond({ error: { message: 'nope' } }, 403)))
+    await useAiModelsStore.getState().refresh('gemini', 'AIza', { force: true })
+    const s = useAiModelsStore.getState()
+    expect(s.status.gemini).toBe('error')
+    expect(s.error.gemini).toMatch(/403/)
+    expect(liveModels('gemini')?.map((m) => m.id)).toEqual(['gemini-2.5-pro'])
+  })
+
+  it('collapses concurrent refreshes into one fetch', async () => {
+    const fetchMock = vi.fn(async () => respond({ data: [{ id: 'gpt-5', created: 1 }] }))
+    vi.stubGlobal('fetch', fetchMock)
+    await Promise.all([
+      useAiModelsStore.getState().refresh('openai', 'sk-o', { force: true }),
+      useAiModelsStore.getState().refresh('openai', 'sk-o', { force: true }),
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('forget drops the in-memory list', async () => {
+    useAiModelsStore.setState({ lists: { openai: { models: [{ id: 'gpt-5', label: 'x' }], fetchedAt: 1, source: 'cache' } }, status: { anthropic: 'idle', openai: 'ready', gemini: 'idle' } })
+    useAiModelsStore.getState().forget('openai')
+    expect(liveModels('openai')).toBeNull()
+    expect(useAiModelsStore.getState().status.openai).toBe('idle')
+  })
+})

--- a/src/store/ai-models.ts
+++ b/src/store/ai-models.ts
@@ -1,0 +1,95 @@
+// Live model lists per provider (TEA-249). Sits beside the settings store:
+// settings hold the user's choice, this holds what the provider says exists.
+// Cold start reads the 24h localStorage cache; `refresh` fetches when a key is
+// present and the cache is stale (or `force`). Failures fall back to the
+// curated list silently — the picker is never empty and chat never waits.
+
+import { create } from 'zustand'
+import type { AiModelOption, AiProviderId } from '@/lib/ai/providerMeta'
+import { AI_PROVIDER_IDS } from '@/lib/ai/providerMeta'
+import {
+  fetchProviderModels, readCachedModels, writeCachedModels, ModelListError,
+} from '@/lib/ai/modelCatalog'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('ai/models')
+
+export type ModelListStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+export interface ProviderModelList {
+  models: AiModelOption[]
+  fetchedAt: number
+  source: 'fetched' | 'cache'
+}
+
+interface AiModelsState {
+  lists: Partial<Record<AiProviderId, ProviderModelList>>
+  status: Record<AiProviderId, ModelListStatus>
+  error: Partial<Record<AiProviderId, string>>
+  /** Load the list for `provider` using `apiKey`. Serves the cache when fresh,
+   *  otherwise fetches. No-op without a key. Resolves when settled; never throws. */
+  refresh: (provider: AiProviderId, apiKey: string, opts?: { force?: boolean }) => Promise<void>
+  /** Drop an in-memory list (e.g. the key was cleared). */
+  forget: (provider: AiProviderId) => void
+}
+
+const inflight = new Map<string, Promise<void>>()
+
+export const useAiModelsStore = create<AiModelsState>((set) => ({
+  lists: {},
+  status: AI_PROVIDER_IDS.reduce((acc, id) => { acc[id] = 'idle'; return acc }, {} as Record<AiProviderId, ModelListStatus>),
+  error: {},
+
+  refresh: (provider, apiKey, opts) => {
+    const key = apiKey.trim()
+    if (!key) return Promise.resolve()
+
+    const cached = readCachedModels(provider, key)
+    if (cached && !opts?.force) {
+      set((s) => ({
+        lists: { ...s.lists, [provider]: { models: cached.models, fetchedAt: cached.fetchedAt, source: 'cache' } },
+        status: { ...s.status, [provider]: 'ready' },
+        error: { ...s.error, [provider]: undefined },
+      }))
+      return Promise.resolve()
+    }
+
+    // One fetch per provider+key at a time; concurrent callers share it.
+    const inflightKey = `${provider}:${key.length}:${key.slice(-4)}`
+    const existing = inflight.get(inflightKey)
+    if (existing) return existing
+
+    set((s) => ({ status: { ...s.status, [provider]: 'loading' } }))
+    const run = (async () => {
+      try {
+        const models = await fetchProviderModels(provider, key)
+        const entry = writeCachedModels(provider, key, models)
+        set((s) => ({
+          lists: { ...s.lists, [provider]: { models, fetchedAt: entry.fetchedAt, source: 'fetched' } },
+          status: { ...s.status, [provider]: 'ready' },
+          error: { ...s.error, [provider]: undefined },
+        }))
+      } catch (err) {
+        const message = err instanceof ModelListError ? err.message : 'Could not load the model list'
+        log.warn('Model list fetch failed; using curated list', { provider, message })
+        // Keep whatever list we already had (a stale cache beats nothing).
+        set((s) => ({ status: { ...s.status, [provider]: 'error' }, error: { ...s.error, [provider]: message } }))
+      } finally {
+        inflight.delete(inflightKey)
+      }
+    })()
+    inflight.set(inflightKey, run)
+    return run
+  },
+
+  forget: (provider) => set((s) => {
+    const lists = { ...s.lists }
+    delete lists[provider]
+    return { lists, status: { ...s.status, [provider]: 'idle' }, error: { ...s.error, [provider]: undefined } }
+  }),
+}))
+
+/** Live models for a provider, or null when only the curated list is known. */
+export function liveModels(provider: AiProviderId): AiModelOption[] | null {
+  return useAiModelsStore.getState().lists[provider]?.models ?? null
+}

--- a/src/store/ai-settings.test.ts
+++ b/src/store/ai-settings.test.ts
@@ -106,3 +106,25 @@ describe('isAiReady', () => {
     expect(isAiReady({ ...base, provider: 'openai' })).toBe(false)
   })
 })
+
+describe('live-list resolution (TEA-249)', () => {
+  const base = normalizeAiSettings({ provider: 'anthropic', apiKeys: { anthropic: 'k' } })
+  const live = [{ id: 'claude-opus-5', label: '' }, { id: 'claude-sonnet-5', label: '' }, { id: 'claude-haiku-4-5', label: '' }]
+
+  it('upgrades the curated default when the provider no longer offers it', () => {
+    expect(activeAiConfig(base).model).toBe('claude-sonnet-4-6')
+    expect(activeAiConfig(base, live).model).toBe('claude-sonnet-5')
+  })
+
+  it('never rewrites an explicitly chosen model', () => {
+    const chosen = normalizeAiSettings({ provider: 'anthropic', models: { anthropic: 'claude-opus-4-8' } })
+    expect(activeAiConfig(chosen, live).model).toBe('claude-opus-4-8')
+  })
+
+  it('resolves the cheap-draft tier against the live list too', () => {
+    expect(draftModel(base, live)).toBe('claude-haiku-4-5')
+    const liveNoHaiku = [{ id: 'claude-haiku-5', label: '' }, { id: 'claude-sonnet-5', label: '' }]
+    expect(draftModel(base, liveNoHaiku)).toBe('claude-haiku-5')
+    expect(draftModel({ ...base, routeCheapDrafts: false }, liveNoHaiku)).toBe('claude-sonnet-5')
+  })
+})

--- a/src/store/ai-settings.ts
+++ b/src/store/ai-settings.ts
@@ -1,11 +1,13 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { create } from 'zustand'
 import { isRecord } from '@/lib/guards'
 import { readJSON, writeJSON } from '@/lib/safeStorage'
 import { createProvider, type AiProvider } from '@/lib/ai'
 import {
-  AI_PROVIDER_IDS, AI_PROVIDER_META, isAiProviderId, type AiProviderId,
+  AI_PROVIDER_IDS, AI_PROVIDER_META, isAiProviderId, type AiProviderId, type AiModelOption,
 } from '@/lib/ai/providerMeta'
+import { resolveCuratedModel } from '@/lib/ai/modelCatalog'
+import { useAiModelsStore } from './ai-models'
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -78,12 +80,20 @@ export function normalizeAiSettings(value: unknown): AiSettings {
   }
 }
 
-/** Resolved config for the active provider: its id, key, and model. */
-export function activeAiConfig(settings: AiSettings): { provider: AiProviderId; apiKey: string; model: string } {
+/** Resolved config for the active provider: its id, key, and model.
+ *  `live` (the provider's current model list, when known) lets a curated
+ *  default that the provider has since retired resolve to its same-family
+ *  successor; an id the user typed or picked explicitly is never rewritten. */
+export function activeAiConfig(
+  settings: AiSettings,
+  live?: AiModelOption[] | null,
+): { provider: AiProviderId; apiKey: string; model: string } {
+  const chosen = settings.models[settings.provider]
+  const curatedDefault = AI_PROVIDER_META[settings.provider].defaultModel
   return {
     provider: settings.provider,
     apiKey: settings.apiKeys[settings.provider] ?? '',
-    model: settings.models[settings.provider] || AI_PROVIDER_META[settings.provider].defaultModel,
+    model: chosen && chosen !== curatedDefault ? chosen : resolveCuratedModel(curatedDefault, live),
   }
 }
 
@@ -91,11 +101,12 @@ export function activeAiConfig(settings: AiSettings): { provider: AiProviderId; 
  *  routing is on, else the selected model. Returns the SAME string as
  *  `activeAiConfig().model` when routing is off or the cheap tier already equals
  *  the selection — callers can compare to decide whether a second provider is
- *  even needed. */
-export function draftModel(settings: AiSettings): string {
-  const { model } = activeAiConfig(settings)
+ *  even needed. The cheap id is curated, so it resolves against `live` too. */
+export function draftModel(settings: AiSettings, live?: AiModelOption[] | null): string {
+  const { model } = activeAiConfig(settings, live)
   if (!settings.routeCheapDrafts) return model
-  return AI_PROVIDER_META[settings.provider].cheapModel || model
+  const cheap = AI_PROVIDER_META[settings.provider].cheapModel
+  return cheap ? resolveCuratedModel(cheap, live) : model
 }
 
 /** True when the active provider has a non-empty key — i.e. AI can actually run.
@@ -170,8 +181,17 @@ export function useAiProvider(): {
 } {
   const settings = useAiSettingsStore()
   const ready = isAiReady(settings)
-  const { provider: providerId, apiKey, model } = activeAiConfig(settings)
-  const draft = draftModel(settings)
+  // Live model list for the active provider (cache-first, refreshed at most
+  // once a day). Only used to keep curated default/cheap ids pointing at models
+  // the provider still offers — chat never waits on it.
+  const live = useAiModelsStore((s) => s.lists[settings.provider]?.models ?? null)
+  const refreshModels = useAiModelsStore((s) => s.refresh)
+  const activeKey = settings.apiKeys[settings.provider] ?? ''
+  useEffect(() => {
+    if (activeKey.trim()) void refreshModels(settings.provider, activeKey)
+  }, [settings.provider, activeKey, refreshModels])
+  const { provider: providerId, apiKey, model } = activeAiConfig(settings, live)
+  const draft = draftModel(settings, live)
   const provider = useMemo(
     () => (ready ? createProvider(providerId, { apiKey, model }) : null),
     [ready, providerId, apiKey, model],


### PR DESCRIPTION
## Summary

The AI model picker was a hardcoded list in `providerMeta.ts` that went stale (no Claude 5 family). With a key present, c4hero now asks the provider which models the key can use and shows those. The curated list becomes the fallback.

Linear: [TEA-249](https://linear.app/kevnord/issue/TEA-249)

### What's in it

- **Live catalog** (`src/lib/ai/modelCatalog.ts`): Anthropic `GET /v1/models`, OpenAI `GET /v1/models`, Gemini `GET /v1beta/models`. Same hosts as chat (already in both CSP `connect-src` copies), same BYOK headers. Parsers keep chat-capable models only: OpenAI's embeddings/audio/realtime/image/moderation noise is dropped and dated snapshots are hidden when their alias is listed; Gemini is filtered to `generateContent` text models with stable releases ranked before previews; Anthropic is newest-first by `created_at`.
- **Cache**: 24h in localStorage, keyed by a non-reversible fingerprint of the key (a different key invalidates it; the key itself is never stored). Settings open instantly and work offline. *Refresh* forces a re-fetch.
- **Fallback**: no key, fetch failure, or cold cache shows the curated list. A failed refresh keeps the previous list. The picker is never empty, and a free-text model id input is now present so any id the provider accepts can be used.
- **Routing stays sane**: `activeAiConfig` / `draftModel` resolve the curated default and cheap-draft ids against the live list. A retired id (e.g. `claude-sonnet-4-6` once the provider only lists Claude 5) maps to the newest same-family model; explicit user choices are never rewritten. `useAiProvider` triggers the cache-first refresh whenever a key is set, so routing has data without the settings screen ever being opened.
- **Never blocks chat**: the fetch is fire-and-forget; provider construction does not await it.

### Not changed
The curated fallback list itself is left as-is per the ticket (staleness is cosmetic now).

## Test plan

- [x] `npm run check` green (lint, typecheck, unit, build)
- [x] Unit: `modelCatalog.test.ts` (parsers/filters/ranking per provider, auth headers, error mapping, cache TTL + key fingerprint + no key leakage, family resolution, picker options), `ai-models.test.ts` (cache-first, force, failure keeps previous list, in-flight dedupe), `ai-settings.test.ts` additions (default upgraded, explicit choice preserved, cheap tier resolved)
- [ ] Manual with a real Anthropic key: open AI settings → Change key or provider → picker shows the Claude 5 family with "Live from Anthropic"; same for OpenAI and Gemini keys; airplane mode shows the cached list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs