### PR TITLE
chore(release): prepare 0.6.0 (watch mode, live model list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-10
+
 ### Added
 
 - **Watch mode: the canvas follows the file on disk.** Disk sync used to be
@@ -22,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   c4hero's own saves never count as changes, and the collection list refreshes
   when the tab regains focus. Toggle it with the *Watch Mode* command;
   default on wherever a file or folder is linked. (TEA-323)
+- **The AI model picker now lists what your key can actually use.** With a
+  key present, c4hero asks the provider for its current models (Anthropic
+  `/v1/models`, OpenAI `/v1/models`, Gemini `/v1beta/models`), keeps the
+  chat-capable ones, and shows them — so new releases such as the Claude 5
+  family appear without a code change. The list is cached for a day per key
+  so settings open instantly and work offline; a *Refresh* control forces a
+  re-fetch. No key, a failed fetch, or a cold cache falls back to the curated
+  suggestions, never an empty picker, and you can still type any model id.
+  Curated default and cheap-draft ids that a provider has retired resolve to
+  their same-family successor, so per-task routing keeps working. The fetch
+  never blocks chat. (TEA-249)
 
 ## [0.5.0] - 2026-09-05
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c4hero",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Local-first visual architecture modelling for the C4 model. Edit visually, save as Structurizr DSL — your architecture lives in your repo.",
   "license": "Apache-2.0",

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -28,24 +28,16 @@ export interface WhatsNewRelease {
 }
 
 export const WHATS_NEW: WhatsNewRelease | null = {
-  id: '2026-09-code-pane-impact-export',
+  id: '2026-09-watch-mode-live-models',
   date: 'September 2026',
   items: [
     {
-      title: 'Live DSL code pane',
-      body: 'Open the workspace as Structurizr DSL beside the canvas and edit either one — changes flow both ways. Your layout survives the round trip, and a document that does not parse simply never applies.',
+      title: 'The canvas follows the file on disk',
+      body: 'Edit the .dsl in another editor or check out a different git branch and the diagram reloads within a couple of seconds, keeping your view and selection. Unsaved local edits are never discarded: you choose Reload or Keep mine.',
     },
     {
-      title: 'See what breaks before you delete',
-      body: 'Ask what happens if an element is removed and get the exact blast radius: what goes with it, which relationships lose an end, what depended on it, and which views disappear. Counted from your model, not estimated.',
-    },
-    {
-      title: 'Export one interactive HTML file',
-      body: 'Every view, rendered and wrapped in a small read-only viewer with tabs, zoom, drill-through and search. No dependencies and no network calls, so it opens from disk or a wiki years later.',
-    },
-    {
-      title: 'Readable element IDs',
-      body: 'Elements now take a readable id derived from their name instead of a random string, and you can edit it. Exported DSL reads like something a person wrote.',
+      title: 'AI model picker lists what your key can use',
+      body: 'With a key set, settings ask the provider for its current models and show them, so new releases appear without waiting for a c4hero update. Cached for a day, with the curated list as a fallback.',
     },
   ],
   link: { label: 'Full release notes', url: 'https://c4hero.com/changelog' },


### PR DESCRIPTION
## Summary

Release paperwork for 0.6.0, following the release-check playbook.

- `package.json` 0.5.0 → 0.6.0
- `CHANGELOG.md`: `[Unreleased]` cut into `[0.6.0] - 2026-09-10`. Gap audit against `git log v0.5.0..HEAD` found that #171 (TEA-249) shipped without its entry (the edit in that PR targeted a heading that didn't exist on its base); written now.
- `src/lib/whatsNew.ts`: new id `2026-09-watch-mode-live-models`, two items (watch mode, live model list).

Shipped since 0.5.0: #170 watch mode (TEA-323), #171 live AI model list (TEA-249), #169 README refresh (docs, no entry).

Landing-site sync is a separate PR in `c4hero-landing`. After this merges: tag `v0.6.0` and publish the GitHub Release.

## Test plan

- [x] `npm run check` green (2612 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs