### PR TITLE
feat(dsl): preserve ! directives and resolve !include multi-file workspaces (TEA-325 A+B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Saving no longer deletes `!include`, `!const`, `!var`, `!docs` or `!adrs`
+  lines.** The parser used to consume every `!` preprocessor directive and
+  drop it, so opening a real Structurizr workspace whose model is split across
+  files and saving it silently removed the include lines — the same
+  data-loss family as the escape-sequence drift. Directives are now kept
+  verbatim, in their original block and order, and written back on save.
+  Included content is not loaded yet; the code pane says so with a
+  "preserved, not resolved" note rather than pretending the model is
+  complete. (TEA-325, phase A)
+
 ## [0.6.0] - 2026-09-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-file workspaces: `!include` is resolved when you open a folder.**
+  A root `workspace.dsl` that pulls in `teams/payments.dsl` and
+  `teams/identity.dsl` now renders the whole stitched model, so an
+  organisation can keep one landscape over models that each team owns in its
+  own file. Every element, relationship, group and view remembers which file
+  declared it — the inspector shows *Defined in teams/payments.dsl* — and
+  parse errors in an included file name that file and line. Saving never
+  flattens: the root file keeps its own content plus the `!include` lines,
+  and a plain model fragment included from inside `model { }` is written back
+  to its own file with just the content it declared. Anything c4hero can't
+  route back yet (a file included inside an element or the views block, a
+  file with its own `!` directives, or one wrapped in `model { }`) is shown
+  read-only and its edits are refused rather than dropped. Cycles, missing
+  files and oversized include graphs fail with a clear message instead of a
+  hang or a half-loaded model. Includes are relative to the including file;
+  URLs, absolute paths and paths that escape the folder are left as-is.
+  (TEA-325, phase B)
+
 ### Fixed
 
 - **Saving no longer deletes `!include`, `!const`, `!var`, `!docs` or `!adrs`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -17,7 +17,8 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 - Parses and serializes the [Structurizr DSL](https://docs.structurizr.com/dsl/language) — the same format used by Structurizr Lite, Studio, and the Java/JSON exporters.
 - Round-trips: `parse(serialize(workspace)) === workspace` for everything c4hero models. Substantial round-trip test coverage protects this contract.
 - Supports element styles, relationship styles, tags (with cascade), `properties { … }` blocks, owners, technology, status, custom URLs, and `!docs` / `!adrs` references.
-- **Preprocessor directives survive.** `!include`, `!const`, `!var`, `!docs`, `!adrs` and any other `!` line are kept verbatim in their block and re-emitted on save. `!include` is not resolved yet (the code pane flags it), but the line is never lost.
+- **Preprocessor directives survive.** `!include`, `!const`, `!var`, `!docs`, `!adrs` and any other `!` line are kept verbatim in their block (or element) and re-emitted on save.
+- **Multi-file workspaces.** When a folder is open, `!include <relative path>` is resolved (recursively, relative to the including file) and the stitched model is rendered. Declarations remember their file; the inspector shows *Defined in …*. Saves are routed: the root keeps its own content plus the include lines, and plain model fragments included from inside `model { }` are written back to their own file. Files c4hero can't route back yet are shown read-only. Cycles, missing files and oversized graphs are reported, never hung. URLs, absolute paths and `..` escapes are left unresolved. Single-file opens (no folder handle) don't resolve includes; the code pane flags them.
 - Sidecar JSON file (`<workspace>.c4hero.json`) holds non-DSL metadata — node positions, view auto-layout direction, viewport state — so layout survives DSL edits.
 
 ## File workflows

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -17,6 +17,7 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 - Parses and serializes the [Structurizr DSL](https://docs.structurizr.com/dsl/language) — the same format used by Structurizr Lite, Studio, and the Java/JSON exporters.
 - Round-trips: `parse(serialize(workspace)) === workspace` for everything c4hero models. Substantial round-trip test coverage protects this contract.
 - Supports element styles, relationship styles, tags (with cascade), `properties { … }` blocks, owners, technology, status, custom URLs, and `!docs` / `!adrs` references.
+- **Preprocessor directives survive.** `!include`, `!const`, `!var`, `!docs`, `!adrs` and any other `!` line are kept verbatim in their block and re-emitted on save. `!include` is not resolved yet (the code pane flags it), but the line is never lost.
 - Sidecar JSON file (`<workspace>.c4hero.json`) holds non-DSL metadata — node positions, view auto-layout direction, viewport state — so layout survives DSL edits.
 
 ## File workflows

--- a/src/components/code-pane/CodePane.tsx
+++ b/src/components/code-pane/CodePane.tsx
@@ -9,7 +9,7 @@ import { lintGutter, setDiagnostics, type Diagnostic } from '@codemirror/lint'
 import { search, searchKeymap, openSearchPanel } from '@codemirror/search'
 import { tags as t } from '@lezer/highlight'
 import { useWorkspaceStore } from '@/store/workspace'
-import { serializeDSL } from '@/lib/dsl'
+import { serializeRoot } from '@/lib/includeWriteback'
 import type { ParseError } from '@/lib/dsl'
 import { readJSON, writeJSON, readString, writeString } from '@/lib/safeStorage'
 import { structurizrLanguage } from './structurizrLanguage'
@@ -297,7 +297,7 @@ export default function CodePane() {
         const ws = useWorkspaceStore.getState().workspace
         if (!ws) return { error: 'No workspace open' }
         try {
-          return { text: serializeDSL(ws) }
+          return { text: serializeRoot(ws) }
         } catch (err) {
           return { error: err instanceof Error ? err.message : 'Serialization failed' }
         }

--- a/src/components/code-pane/CodePane.tsx
+++ b/src/components/code-pane/CodePane.tsx
@@ -179,7 +179,7 @@ export default function CodePane() {
   const workspaceName = useWorkspaceStore((s) => s.workspace?.name)
   const hostElRef = useRef<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
-  const [status, setStatus] = useState<DslSyncStatus>({ errors: [], serializeError: null, pendingApply: false })
+  const [status, setStatus] = useState<DslSyncStatus>({ errors: [], warnings: [], serializeError: null, pendingApply: false })
   const statusRef = useRef(status)
   const [copied, setCopied] = useState(false)
   const [histDepths, setHistDepths] = useState({ undo: 0, redo: 0 })
@@ -581,6 +581,15 @@ export default function CodePane() {
           ) : (
             <span style={{ color: 'var(--color-text-secondary)' }}>
               Editable — changes here update the canvas as you type
+            </span>
+          )}
+          {!status.pendingApply && errorCount === 0 && status.warnings.length > 0 && (
+            <span
+              data-code-pane-warnings
+              title={status.warnings.map((w) => `${w.line}:${w.column} ${w.message}`).join('\n')}
+              style={{ marginLeft: 'auto', whiteSpace: 'nowrap', opacity: 0.8 }}
+            >
+              {status.warnings.length} {status.warnings.length === 1 ? 'directive' : 'directives'} preserved, not resolved
             </span>
           )}
           {status.pendingApply && (

--- a/src/components/code-pane/dslSyncEngine.ts
+++ b/src/components/code-pane/dslSyncEngine.ts
@@ -4,6 +4,8 @@ import type { ParseError } from '@/lib/dsl'
 export interface DslSyncStatus {
   /** Parse/integrity errors from the last rejected apply (empty when clean). */
   errors: ParseError[]
+  /** Non-fatal notes from the last successful apply (e.g. an unresolved `!include`). */
+  warnings: ParseError[]
   /** Serialization failure (e.g. GroupSerializationError) — store-to-editor sync is stalled. */
   serializeError: string | null
   /** True while the editor holds text that has not (yet) been applied to the store. */
@@ -18,7 +20,7 @@ export interface DslSyncEngineOpts {
   /** Serialize the current workspace, or report why it can't be. */
   serialize: () => { text: string } | { error: string }
   /** Apply editor text to the store (replaceWorkspaceFromDSL). */
-  apply: (text: string) => { ok: boolean; errors: ParseError[] }
+  apply: (text: string) => { ok: boolean; errors: ParseError[]; warnings?: ParseError[] }
   onStatus: (status: DslSyncStatus) => void
   /** Debounce for editor keystrokes before an apply attempt. */
   editorDebounceMs?: number
@@ -49,10 +51,10 @@ export function createDslSyncEngine(opts: DslSyncEngineOpts) {
   let disposed = false
   let editorTimer: ReturnType<typeof setTimeout> | null = null
   let storeTimer: ReturnType<typeof setTimeout> | null = null
-  const status: DslSyncStatus = { errors: [], serializeError: null, pendingApply: false }
+  const status: DslSyncStatus = { errors: [], warnings: [], serializeError: null, pendingApply: false }
 
   function emit() {
-    opts.onStatus({ ...status, errors: [...status.errors] })
+    opts.onStatus({ ...status, errors: [...status.errors], warnings: [...status.warnings] })
   }
 
   function syncFromStore() {
@@ -72,7 +74,7 @@ export function createDslSyncEngine(opts: DslSyncEngineOpts) {
     if (disposed) return
     const text = opts.readText()
     applying = true
-    let result: { ok: boolean; errors: ParseError[] }
+    let result: { ok: boolean; errors: ParseError[]; warnings?: ParseError[] }
     try {
       result = opts.apply(text)
     } catch (err) {
@@ -87,6 +89,7 @@ export function createDslSyncEngine(opts: DslSyncEngineOpts) {
     }
     if (result.ok) {
       status.errors = []
+      status.warnings = result.warnings ?? []
       status.pendingApply = false
       // The workspace was just rebuilt from this text, so any earlier
       // serialization failure is moot — don't leave a stale banner up.

--- a/src/components/layout/DiskConflictBar.tsx
+++ b/src/components/layout/DiskConflictBar.tsx
@@ -21,9 +21,9 @@ export default function DiskConflictBar() {
 
   const reload = () => {
     if (!conflict) return
-    if (applyDiskSnapshot(conflict.filename, conflict.snapshot, conflict.hashes)) {
-      useWorkspaceStore.getState().setDiskConflict(null)
-    }
+    void applyDiskSnapshot(conflict.filename, conflict.snapshot, conflict.hashes).then((ok) => {
+      if (ok) useWorkspaceStore.getState().setDiskConflict(null)
+    })
   }
   const keepMine = () => {
     if (!conflict) return

--- a/src/components/layout/FloatingTopPill.tsx
+++ b/src/components/layout/FloatingTopPill.tsx
@@ -197,7 +197,7 @@ export default function FloatingTopPill() {
       if (type === 'png-dark') ok = await copyCanvasAsPNG('dark')
       else if (type === 'png-light') ok = await copyCanvasAsPNG('light')
       else if (type === 'png-current') ok = await copyCanvasAsPNG('current')
-      else if (type === 'dsl') ok = await copyTextToClipboard(serializeDSL(workspace))
+      else if (type === 'dsl') ok = await copyTextToClipboard(serializeRoot(workspace))
       const themeLabel = type === 'png-dark' ? 'dark' : type === 'png-light' ? 'light' : 'current'
       const label = type === 'dsl' ? 'DSL' : `PNG (${themeLabel})`
       const msg = ok ? `Copied ${label}` : 'Copy failed'

--- a/src/components/layout/FloatingTopPill.tsx
+++ b/src/components/layout/FloatingTopPill.tsx
@@ -4,6 +4,7 @@ import LoadingDot from '@/components/shared/LoadingDot'
 import { useWorkspaceStore, getAllViews } from '@/store/workspace'
 import { downloadFile, downloadBlob, exportCanvasAsPNG, exportCanvasAsSVG, copyCanvasAsPNG, copyTextToClipboard, type ExportTheme } from '@/lib/exportUtils'
 import { serializeDSL } from '@/lib/dsl'
+import { serializeRoot } from '@/lib/includeWriteback'
 import { createBlankWorkspace } from '@/lib/templates'
 import { saveDSLFile } from '@/lib/fileIO'
 import { announce } from '@/lib/announce'
@@ -26,11 +27,11 @@ import {
 import { useSettingsStore } from '@/store/settings'
 import { THEMES, THEME_CANVAS_BACKGROUNDS } from '@/lib/themes'
 
-import { listDSLFiles, readDSLFile, writeDSLFile, getCurrentDirHandle, slugifyName } from '@/lib/folderIO'
+import { listDSLFiles, readDSLFile, readDSLFileAt, writeDSLFile, getCurrentDirHandle, slugifyName } from '@/lib/folderIO'
 import { parseDSL } from '@/lib/dsl'
 import { useNavigate } from 'react-router-dom'
 import { WorkspaceTile } from '@/components/welcome/WelcomeLeaves'
-import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
+import { loadWorkspaceDocument } from '@/lib/workspaceDocument'
 
 interface WsEntry {
   filename: string
@@ -110,10 +111,11 @@ export default function FloatingTopPill() {
     setWsPickerOpen(false)
     const file = await readDSLFile(filename)
     if (!file) return
-    const { workspace } = parseWorkspaceDocument({
+    const { workspace } = await loadWorkspaceDocument({
       content: file.content,
       fallbackName: filename.replace(/\.dsl$/, ''),
       sidecarJson: file.sidecarJson,
+      readInclude: readDSLFileAt,
     })
     loadWorkspace(workspace)
     useWorkspaceStore.getState().setActiveWorkspaceFilename(filename)
@@ -155,7 +157,7 @@ export default function FloatingTopPill() {
     try {
       switch (format) {
         case 'dsl':
-          await saveDSLFile(serializeDSL(workspace), `${wsName}.dsl`)
+          await saveDSLFile(serializeRoot(workspace), `${wsName}.dsl`)
           break
         case 'png': {
           const blob = await exportCanvasAsPNG(theme)

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -147,6 +147,10 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
   const location = (element as Person | SoftwareSystem).location
   const typeColor = TYPE_COLORS[element.type] ?? 'var(--color-accent)'
   const safeUrl = element.url ? normalizeSafeExternalUrl(element.url) : null
+  // Provenance for multi-file workspaces (TEA-325): where this element is
+  // declared, and whether edits here can be written back to that file.
+  const includedFile = element.sourcePath ? workspace?.includedFiles?.find((f) => f.path === element.sourcePath) : undefined
+  const sourceReadOnly = !!element.sourcePath && !(includedFile?.writable ?? false)
 
   // AI auto-suggest: fill empty description / technology / tag fields. Only
   // available when a key is set and AI is enabled. These are all mechanical
@@ -368,6 +372,20 @@ function ElementProperties({ element, onClose }: { element: ModelElement; onClos
                 {aiReady && missingDesc && <SuggestButton onClick={() => suggest(['description'])} busy={busyField === 'description'} multiline title="Write a description with AI" />}
               </div>
             </div>
+
+            {element.sourcePath && (
+              <div
+                data-element-source
+                data-read-only={sourceReadOnly ? 'true' : undefined}
+                title={sourceReadOnly
+                  ? `Declared in ${element.sourcePath}. ${includedFile?.reason ? `This file is ${includedFile.reason}, so ` : ''}edits here can't be written back to it yet — change it in that file.`
+                  : `Declared in ${element.sourcePath}. Edits are saved back to that file.`}
+                style={{ fontSize: 'var(--text-xxs)', color: sourceReadOnly ? 'var(--color-warning)' : 'var(--color-text-muted)', display: 'flex', alignItems: 'center', gap: 6 }}
+              >
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>Defined in {element.sourcePath}</span>
+                {sourceReadOnly && <span style={{ flex: 'none', fontWeight: 600 }}>· read-only</span>}
+              </div>
+            )}
 
             {/* Status */}
             <div>

--- a/src/components/layout/SaveIndicator.tsx
+++ b/src/components/layout/SaveIndicator.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { Save } from 'lucide-react'
 import { useWorkspaceStore } from '@/store/workspace'
-import { serializeDSL } from '@/lib/dsl'
+import { serializeRoot } from '@/lib/includeWriteback'
 import { saveDSLFile, getCurrentFileHandle, hasFileSystemAccess } from '@/lib/fileIO'
 import { getCurrentDirHandle } from '@/lib/folderIO'
 import { announce } from '@/lib/announce'
@@ -39,7 +39,7 @@ export default function SaveIndicator() {
     setSaveStatus('saving')
     try {
       const wsName = workspace.name ?? 'workspace'
-      const dsl = serializeDSL(workspace)
+      const dsl = serializeRoot(workspace)
       const ok = await saveDSLFile(dsl, `${wsName}.dsl`)
       if (!ok) throw new Error('Save failed')
       const n = useWorkspaceStore.getState().undoStack.length

--- a/src/components/welcome/WelcomeScreen.tsx
+++ b/src/components/welcome/WelcomeScreen.tsx
@@ -8,6 +8,7 @@ import { createLogger } from '@/lib/logger'
 import {
   openFolder,
   readDSLFile,
+  readDSLFileAt,
   writeDSLFile,
   hasFolderAccess,
   getCurrentDirHandle,
@@ -21,7 +22,7 @@ import {
 import { getRecentFolders, addRecentFolder, pruneRecentFolders, removeRecentFolder } from '@/lib/fileIO'
 import { parseDSL, serializeDSL } from '@/lib/dsl'
 import { sidecarName } from '@/lib/sidecar'
-import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
+import { parseWorkspaceDocument, loadWorkspaceDocument } from '@/lib/workspaceDocument'
 import { AlertTriangle } from 'lucide-react'
 import {
   TemplateDialog,
@@ -297,10 +298,11 @@ export default function WelcomeScreen({ initialView }: { initialView?: 'startup'
     try {
       const file = await readDSLFile(filename)
       if (!file) return
-      const { workspace, errors } = parseWorkspaceDocument({
+      const { workspace, errors } = await loadWorkspaceDocument({
         content: file.content,
         fallbackName: filename.replace(/\.dsl$/, ''),
         sidecarJson: file.sidecarJson,
+        readInclude: readDSLFileAt,
       })
       if (errors.length > 0) log.warn("DSL parse warnings", errors)
       loadWorkspace(workspace)

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -8,8 +8,11 @@ import { createLogger } from '@/lib/logger'
 
 const log = createLogger('useAutoSave')
 
-/** Last fragment written per included path, so unchanged files aren't rewritten. */
+/** Last fragment written per included path, so unchanged files aren't
+ *  rewritten. Scoped to one root file: switching folder or workspace must
+ *  not let a memo from another workspace suppress a needed write. */
 const lastIncludedWrites = new Map<string, string>()
+let lastIncludedWritesFor: string | null = null
 
 const scheduleIdle = typeof requestIdleCallback === 'function'
   ? requestIdleCallback
@@ -71,6 +74,8 @@ export function useAutoSave() {
               if (sidecar) writeSidecarFile(filename, serializeSidecar(sidecar))
               // Write-back: each writable !include'd file gets its own fragment,
               // only when it actually changed (TEA-325).
+              const scope = `${dirHandle.name}/${filename}`
+              if (lastIncludedWritesFor !== scope) { lastIncludedWrites.clear(); lastIncludedWritesFor = scope }
               for (const w of planIncludedWrites(state.workspace)) {
                 if (lastIncludedWrites.get(w.path) === w.content) continue
                 lastIncludedWrites.set(w.path, w.content)

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,12 +1,15 @@
 import { useEffect, useRef } from 'react'
 import { useWorkspaceStore } from '@/store/workspace'
 import { saveToLocalStorage, getCurrentFileHandle, writeToCurrentHandle, writeSidecarToHandle } from '@/lib/fileIO'
-import { getCurrentDirHandle, writeDSLFile, writeSidecarFile } from '@/lib/folderIO'
-import { serializeDSL } from '@/lib/dsl'
+import { getCurrentDirHandle, writeDSLFile, writeSidecarFile, writeDSLFileAt } from '@/lib/folderIO'
+import { serializeRoot, planIncludedWrites } from '@/lib/includeWriteback'
 import { extractSidecar, serializeSidecar } from '@/lib/sidecar'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('useAutoSave')
+
+/** Last fragment written per included path, so unchanged files aren't rewritten. */
+const lastIncludedWrites = new Map<string, string>()
 
 const scheduleIdle = typeof requestIdleCallback === 'function'
   ? requestIdleCallback
@@ -55,7 +58,7 @@ export function useAutoSave() {
 
         if (hasSingleFile || (dirHandle && filename)) {
           try {
-            const dsl = serializeDSL(state.workspace)
+            const dsl = serializeRoot(state.workspace)
             const sidecar = extractSidecar(state.workspace)
 
             if (hasSingleFile) {
@@ -66,6 +69,15 @@ export function useAutoSave() {
             if (dirHandle && filename) {
               writeDSLFile(filename, dsl)
               if (sidecar) writeSidecarFile(filename, serializeSidecar(sidecar))
+              // Write-back: each writable !include'd file gets its own fragment,
+              // only when it actually changed (TEA-325).
+              for (const w of planIncludedWrites(state.workspace)) {
+                if (lastIncludedWrites.get(w.path) === w.content) continue
+                lastIncludedWrites.set(w.path, w.content)
+                writeDSLFileAt(w.path, w.content).then((ok) => {
+                  if (!ok) log.warn('Included file write-back failed', w.path)
+                })
+              }
             }
 
             useWorkspaceStore.getState().setLastSavedUndoLength(state.undoStack.length)

--- a/src/hooks/useDiskWatch.test.ts
+++ b/src/hooks/useDiskWatch.test.ts
@@ -23,39 +23,39 @@ describe('applyDiskSnapshot', () => {
     store().loadWorkspace(workspace)
   })
 
-  it('reloads clean DSL and reports success', () => {
+  it('reloads clean DSL and reports success', async () => {
     const snapshot = { content: DSL.replace('"User"', '"Customer"') }
-    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(true)
+    expect(await applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(true)
     expect(store().workspace!.model.people[0].name).toBe('Customer')
     expect(store().diskConflict).toBeNull()
   })
 
-  it('applies the sidecar from disk alongside the DSL', () => {
+  it('applies the sidecar from disk alongside the DSL', async () => {
     const sidecar = JSON.stringify({
       version: 1,
       views: { Land: { elements: { u: { x: 123, y: 456 } } } },
     })
     const snapshot = { content: DSL, sidecarJson: sidecar }
-    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(true)
+    expect(await applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(true)
     const land = store().workspace!.views.systemLandscapeViews[0]
     const placed = land.elements.find((e) => e.id === 'u')
     expect(placed?.x).toBe(123)
     expect(placed?.y).toBe(456)
   })
 
-  it('raises an unparseable conflict instead of applying broken text', () => {
+  it('raises an unparseable conflict instead of applying broken text', async () => {
     const before = store().workspace
     const snapshot = { content: 'workspace "Broken" { model { u = person }' }
-    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(false)
+    expect(await applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(false)
     expect(store().workspace).toBe(before)
     expect(store().diskConflict?.reason).toBe('unparseable')
     expect(store().diskConflict?.detail).toMatch(/parse error/)
   })
 
-  it('refuses to empty a populated model silently', () => {
+  it('refuses to empty a populated model silently', async () => {
     const before = store().workspace
     const snapshot = { content: 'workspace "Empty" { model { } views { } }' }
-    expect(applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(false)
+    expect(await applyDiskSnapshot('w.dsl', snapshot, hashSnapshot(snapshot))).toBe(false)
     expect(store().workspace).toBe(before)
     expect(store().diskConflict?.detail).toMatch(/empty model/)
   })

--- a/src/hooks/useDiskWatch.ts
+++ b/src/hooks/useDiskWatch.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useSyncExternalStore } from 'react'
 import { useWorkspaceStore } from '@/store/workspace'
 import { getCurrentFileHandle, readCurrentFile } from '@/lib/fileIO'
-import { getCurrentDirHandle, readDSLFileForWatch } from '@/lib/folderIO'
+import { getCurrentDirHandle, readDSLFileForWatch, readDSLFileAt } from '@/lib/folderIO'
 import { createFileWatcher, type SnapshotHashes, type WatchedSnapshot } from '@/lib/fileWatch'
 import { isSelfWrite, resetSaveCoordinator } from '@/lib/saveCoordinator'
-import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
+import { loadWorkspaceDocument } from '@/lib/workspaceDocument'
 import { announce } from '@/lib/announce'
 import { createLogger } from '@/lib/logger'
 import { getTestFileSource, subscribeTestFileSource } from '@/lib/testFileSource'
@@ -34,13 +34,14 @@ function hasUnsavedLocalEdits(): boolean {
 
 /** Parse what's on disk and swap it in. Returns false (and raises a conflict)
  *  when the text can't be applied safely. */
-export function applyDiskSnapshot(filename: string, snapshot: WatchedSnapshot, hashes: SnapshotHashes): boolean {
+export async function applyDiskSnapshot(filename: string, snapshot: WatchedSnapshot, hashes: SnapshotHashes): Promise<boolean> {
   const store = useWorkspaceStore.getState()
   const current = store.workspace
-  const { workspace, errors } = parseWorkspaceDocument({
+  const { workspace, errors } = await loadWorkspaceDocument({
     content: snapshot.content,
     fallbackName: filename.replace(/\.dsl$/, ''),
     sidecarJson: snapshot.sidecarJson,
+    readInclude: getCurrentDirHandle() ? readDSLFileAt : undefined,
   })
   if (errors.length > 0) {
     store.setDiskConflict({
@@ -122,7 +123,7 @@ export function useDiskWatch() {
           announce(`${filename} changed on disk — you have unsaved changes`)
           return
         }
-        applyDiskSnapshot(filename, snapshot, hashes)
+        void applyDiskSnapshot(filename, snapshot, hashes)
       },
     })
     watcherRef.current = watcher

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -3,7 +3,7 @@ import { useReactFlow } from '@xyflow/react'
 import { useWorkspaceStore, getCreatableTypes, getActiveView, isFocalScopeElement } from '@/store/workspace'
 import { computeCascadeImpact } from '@/store/workspace-helpers'
 import { formatImpactSummary } from '@/lib/impactMessage'
-import { serializeDSL } from '@/lib/dsl'
+import { serializeRoot } from '@/lib/includeWriteback'
 import { saveDSLFile, openDSLFile, writeSidecarToHandle } from '@/lib/fileIO'
 import { extractSidecar, serializeSidecar } from '@/lib/sidecar'
 import { createLogger } from '@/lib/logger'
@@ -87,7 +87,7 @@ const GLOBAL_SHORTCUTS: Record<string, KeyHandler> = {
   'mod+s': (store) => {
     if (store.workspace) {
       try {
-        const dsl = serializeDSL(store.workspace)
+        const dsl = serializeRoot(store.workspace)
         saveDSLFile(dsl, `${store.workspace.name ?? 'workspace'}.dsl`)
         const sidecar = extractSidecar(store.workspace)
         if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))

--- a/src/hooks/useRouteSync.test.ts
+++ b/src/hooks/useRouteSync.test.ts
@@ -4,7 +4,7 @@ import { useWorkspaceStore } from '@/store/workspace'
 import { useRouteSync, useRefreshRedirect } from './useRouteSync'
 import { getCurrentDirHandle, restoreDirHandleByName, readDSLFile } from '@/lib/folderIO'
 import { loadFromLocalStorage } from '@/lib/fileIO'
-import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
+import { loadWorkspaceDocument } from '@/lib/workspaceDocument'
 import type { Workspace } from '@/types/model'
 
 // Controllable router doubles — this file-level mock overrides the static one
@@ -35,7 +35,7 @@ vi.mock('@/lib/fileIO', async (importOriginal) => ({
 
 vi.mock('@/lib/workspaceDocument', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/workspaceDocument')>()),
-  parseWorkspaceDocument: vi.fn(),
+  loadWorkspaceDocument: vi.fn(),
 }))
 
 function makeWs(): Workspace {
@@ -86,7 +86,7 @@ beforeEach(() => {
   vi.mocked(restoreDirHandleByName).mockReset().mockResolvedValue(null)
   vi.mocked(readDSLFile).mockReset().mockResolvedValue(null)
   vi.mocked(loadFromLocalStorage).mockReset().mockReturnValue(null)
-  vi.mocked(parseWorkspaceDocument).mockReset().mockReturnValue({ workspace: makeWs(), errors: [] })
+  vi.mocked(loadWorkspaceDocument).mockReset().mockResolvedValue({ workspace: makeWs(), errors: [], warnings: [] })
 })
 
 describe('useRouteSync — state → URL', () => {
@@ -217,7 +217,7 @@ describe('useRefreshRedirect', () => {
   it('restores the workspace from disk and applies the URL view key', async () => {
     vi.mocked(restoreDirHandleByName).mockResolvedValue(teamHandle)
     vi.mocked(readDSLFile).mockResolvedValue({ content: 'workspace {}', sidecarJson: '{}' })
-    vi.mocked(parseWorkspaceDocument).mockReturnValue({
+    vi.mocked(loadWorkspaceDocument).mockResolvedValue({
       workspace: makeWs(),
       errors: [{ message: 'warn', line: 1, column: 1 }],
     })

--- a/src/hooks/useRouteSync.ts
+++ b/src/hooks/useRouteSync.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
 import { useWorkspaceStore, allViewsOf } from '@/store/workspace'
-import { getCurrentDirHandle, restoreDirHandleByName, readDSLFile } from '@/lib/folderIO'
+import { getCurrentDirHandle, restoreDirHandleByName, readDSLFile, readDSLFileAt } from '@/lib/folderIO'
 import { loadFromLocalStorage } from '@/lib/fileIO'
 import { createLogger } from '@/lib/logger'
-import { parseWorkspaceDocument } from '@/lib/workspaceDocument'
+import { loadWorkspaceDocument } from '@/lib/workspaceDocument'
 
 const log = createLogger('routeSync')
 
@@ -154,11 +154,13 @@ export function useRefreshRedirect() {
       }
 
       // 3. Parse, apply sidecar, load into store
-      const { workspace: parsed, errors } = parseWorkspaceDocument({
+      const { workspace: parsed, errors } = await loadWorkspaceDocument({
         content: file.content,
         fallbackName: workspaceSlug,
         sidecarJson: file.sidecarJson,
+        readInclude: readDSLFileAt,
       })
+      if (cancelled) return
       if (errors.length > 0) log.warn('DSL parse warnings', errors)
 
       useWorkspaceStore.getState().loadWorkspace(parsed)

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -10,6 +10,7 @@ import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews, isFoc
 import { computeCascadeImpact } from '@/store/workspace-helpers'
 import { formatImpactSummary } from '@/lib/impactMessage'
 import { serializeDSL } from '@/lib/dsl'
+import { serializeRoot } from '@/lib/includeWriteback'
 import { saveDSLFile, writeSidecarToHandle } from '@/lib/fileIO'
 import { downloadFile, downloadBlob, exportCanvasAsPNG, exportCanvasAsSVG } from '@/lib/exportUtils'
 import { extractSidecar, serializeSidecar } from '@/lib/sidecar'
@@ -410,7 +411,7 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
         const s = store()
         if (!s.workspace) return
         try {
-          const dsl = serializeDSL(s.workspace)
+          const dsl = serializeRoot(s.workspace)
           await saveDSLFile(dsl, `${s.workspace.name ?? 'workspace'}.dsl`)
           const sidecar = extractSidecar(s.workspace)
           if (sidecar) writeSidecarToHandle(serializeSidecar(sidecar))

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -9,7 +9,6 @@ import {
 import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews, isFocalScopeElement } from '@/store/workspace'
 import { computeCascadeImpact } from '@/store/workspace-helpers'
 import { formatImpactSummary } from '@/lib/impactMessage'
-import { serializeDSL } from '@/lib/dsl'
 import { serializeRoot } from '@/lib/includeWriteback'
 import { saveDSLFile, writeSidecarToHandle } from '@/lib/fileIO'
 import { downloadFile, downloadBlob, exportCanvasAsPNG, exportCanvasAsSVG } from '@/lib/exportUtils'
@@ -430,7 +429,7 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
         const s = store()
         if (!s.workspace) return
         try {
-          await saveDSLFile(serializeDSL(s.workspace), `${s.workspace.name ?? 'workspace'}.dsl`)
+          await saveDSLFile(serializeRoot(s.workspace), `${s.workspace.name ?? 'workspace'}.dsl`)
         } catch (error) {
           announce(error instanceof Error ? error.message : 'Export failed')
         }

--- a/src/lib/dsl/directives-roundtrip.test.ts
+++ b/src/lib/dsl/directives-roundtrip.test.ts
@@ -1,0 +1,130 @@
+/**
+ * TEA-325 phase A: `!` preprocessor lines c4hero does not evaluate must survive
+ * a parse → serialize round trip byte-for-byte, in their original block and
+ * order. Before this, saving a file with `!include` silently deleted the line.
+ */
+import { describe, it, expect } from 'vitest'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+import { isWorkspaceShape } from '@/lib/fileIO'
+
+const DSL = `workspace "Federated" "Org landscape" {
+    !const ORG "Acme"
+    !var REGION eu-west-1
+    !docs docs
+    !adrs decisions
+
+    model {
+        !include teams/payments/model.dsl
+        !include teams/identity/model.dsl
+        !const TIER "gold"
+        u = person "User"
+        sys = softwareSystem "Sys" {
+            !docs sys-docs
+        }
+        u -> sys "Uses"
+    }
+
+    views {
+        !include views/shared.dsl
+        systemLandscape "Land" {
+            include *
+        }
+    }
+}
+`
+
+function block(text: string, name: 'model' | 'views'): string {
+  const start = text.indexOf(`${name} {`)
+  let depth = 0
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === '{') depth++
+    if (text[i] === '}') { depth--; if (depth === 0) return text.slice(start, i + 1) }
+  }
+  return text.slice(start)
+}
+
+describe('preprocessor directives round-trip (TEA-325 A)', () => {
+  it('captures directives with their block scope, in source order', () => {
+    const { workspace, errors } = parseDSL(DSL)
+    expect(errors).toEqual([])
+    expect(workspace.directives).toEqual([
+      { scope: 'workspace', raw: '!const ORG "Acme"' },
+      { scope: 'workspace', raw: '!var REGION eu-west-1' },
+      { scope: 'workspace', raw: '!docs docs' },
+      { scope: 'workspace', raw: '!adrs decisions' },
+      { scope: 'model', raw: '!include teams/payments/model.dsl' },
+      { scope: 'model', raw: '!include teams/identity/model.dsl' },
+      { scope: 'model', raw: '!const TIER "gold"' },
+      { scope: 'views', raw: '!include views/shared.dsl' },
+    ])
+    // The model itself still parses normally around them.
+    expect(workspace.model.people.map((p) => p.name)).toEqual(['User'])
+    expect(workspace.model.relationships).toHaveLength(1)
+  })
+
+  it('re-emits every directive in its own block, ahead of generated content', () => {
+    const { workspace } = parseDSL(DSL)
+    const out = serializeDSL(workspace)
+
+    // Workspace-scope lines sit before `model {`.
+    const modelAt = out.indexOf('model {')
+    for (const line of ['!const ORG "Acme"', '!var REGION eu-west-1', '!docs docs', '!adrs decisions']) {
+      const at = out.indexOf(line)
+      expect(at, line).toBeGreaterThan(-1)
+      expect(at, `${line} before model block`).toBeLessThan(modelAt)
+    }
+
+    const model = block(out, 'model')
+    expect(model.indexOf('!include teams/payments/model.dsl')).toBeLessThan(model.indexOf('!include teams/identity/model.dsl'))
+    expect(model.indexOf('!include teams/identity/model.dsl')).toBeLessThan(model.indexOf('!const TIER "gold"'))
+    expect(model.indexOf('!const TIER "gold"')).toBeLessThan(model.indexOf('person "User"'))
+
+    const views = block(out, 'views')
+    expect(views.indexOf('!include views/shared.dsl')).toBeLessThan(views.indexOf('systemLandscape'))
+  })
+
+  it('is stable: a second round trip is byte-identical to the first', () => {
+    const once = serializeDSL(parseDSL(DSL).workspace)
+    const twice = serializeDSL(parseDSL(once).workspace)
+    expect(twice).toBe(once)
+    expect(parseDSL(once).workspace.directives).toEqual(parseDSL(DSL).workspace.directives)
+  })
+
+  it('reports unresolved !include as a warning, never an error', () => {
+    const { errors, warnings } = parseDSL(DSL)
+    expect(errors).toEqual([])
+    expect(warnings.map((w) => w.message)).toEqual([
+      '!include teams/payments/model.dsl is preserved but not resolved — included content is not shown',
+      '!include teams/identity/model.dsl is preserved but not resolved — included content is not shown',
+      '!include views/shared.dsl is preserved but not resolved — included content is not shown',
+    ])
+    expect(warnings[0].line).toBe(8)
+  })
+
+  it('consumes !identifiers instead of preserving it (c4hero always writes flat ids)', () => {
+    const { workspace } = parseDSL(`workspace {
+    !identifiers hierarchical
+    model {
+        u = person "U"
+    }
+    views {}
+}`)
+    expect(workspace.directives).toBeUndefined()
+    expect(serializeDSL(workspace)).not.toContain('!identifiers')
+  })
+
+  it('leaves workspaces without directives untouched', () => {
+    const { workspace } = parseDSL('workspace { model { u = person "U" } views {} }')
+    expect(workspace.directives).toBeUndefined()
+    expect(serializeDSL(workspace)).not.toContain('!')
+  })
+
+  it('crash-recovery shape guard accepts and rejects the directives field correctly', () => {
+    const { workspace } = parseDSL(DSL)
+    expect(isWorkspaceShape(JSON.parse(JSON.stringify(workspace)))).toBe(true)
+    const bad = { ...JSON.parse(JSON.stringify(workspace)), directives: [{ scope: 'nope', raw: '!x' }] }
+    expect(isWorkspaceShape(bad)).toBe(false)
+    const bad2 = { ...JSON.parse(JSON.stringify(workspace)), directives: 'oops' }
+    expect(isWorkspaceShape(bad2)).toBe(false)
+  })
+})

--- a/src/lib/dsl/includeResolver.test.ts
+++ b/src/lib/dsl/includeResolver.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import { resolveIncludes, locateLine, normalizeIncludePath } from './includeResolver'
+
+function fs(files: Record<string, string>) {
+  return { read: async (p: string) => (p in files ? files[p] : null) }
+}
+
+const ROOT = `workspace "Org" {
+    model {
+        !include teams/payments.dsl
+        u = person "User"
+        !include teams/identity.dsl
+    }
+    views {
+        !include views.dsl
+    }
+}
+`
+
+describe('normalizeIncludePath', () => {
+  it('resolves relative to the including file and strips . segments', () => {
+    expect(normalizeIncludePath('', 'a.dsl')).toBe('a.dsl')
+    expect(normalizeIncludePath('teams', './sub/b.dsl')).toBe('teams/sub/b.dsl')
+    expect(normalizeIncludePath('teams/sub', '../c.dsl')).toBe('teams/c.dsl')
+    expect(normalizeIncludePath('', '"quoted name.dsl"')).toBe('quoted name.dsl')
+    expect(normalizeIncludePath('', 'win\\style.dsl')).toBe('win/style.dsl')
+  })
+
+  it('rejects absolute paths, URLs, and escapes above the root', () => {
+    expect(normalizeIncludePath('', '/etc/passwd')).toBeNull()
+    expect(normalizeIncludePath('', 'C:\\x.dsl')).toBeNull()
+    expect(normalizeIncludePath('', 'https://example.com/x.dsl')).toBeNull()
+    expect(normalizeIncludePath('', '../outside.dsl')).toBeNull()
+    expect(normalizeIncludePath('teams', '../../outside.dsl')).toBeNull()
+  })
+})
+
+describe('resolveIncludes', () => {
+  it('splices included content after each !include line and keeps the line', async () => {
+    const r = await resolveIncludes(ROOT, fs({
+      'teams/payments.dsl': 'pay = softwareSystem "Payments"\n',
+      'teams/identity.dsl': 'idp = softwareSystem "Identity"\n',
+      'views.dsl': 'systemLandscape "Land" { include * }\n',
+    }))
+    expect(r.errors).toEqual([])
+    expect(r.files).toEqual(['teams/payments.dsl', 'teams/identity.dsl', 'views.dsl'])
+    expect(r.scopes.get('teams/payments.dsl')).toBe('model')
+    expect(r.scopes.get('views.dsl')).toBe('views')
+    const lines = r.content.split('\n')
+    expect(lines[2]).toBe('        !include teams/payments.dsl')
+    expect(lines[3]).toBe('pay = softwareSystem "Payments"')
+    expect(lines[4]).toBe('        u = person "User"')
+    expect(lines[5]).toBe('        !include teams/identity.dsl')
+    expect(lines[6]).toBe('idp = softwareSystem "Identity"')
+    expect(r.content.endsWith('\n')).toBe(true)
+  })
+
+  it('maps flattened lines back to their file and line', async () => {
+    const r = await resolveIncludes(ROOT, fs({
+      'teams/payments.dsl': 'pay = softwareSystem "Payments"\nbilling = softwareSystem "Billing"\n',
+      'teams/identity.dsl': 'idp = softwareSystem "Identity"\n',
+      'views.dsl': 'systemLandscape "Land" { include * }\n',
+    }))
+    expect(locateLine(r.segments, 1)).toEqual({ path: '', line: 1 })
+    expect(locateLine(r.segments, 3)).toEqual({ path: '', line: 3 })          // the !include line itself
+    expect(locateLine(r.segments, 4)).toEqual({ path: 'teams/payments.dsl', line: 1 })
+    expect(locateLine(r.segments, 5)).toEqual({ path: 'teams/payments.dsl', line: 2 })
+    expect(locateLine(r.segments, 6)).toEqual({ path: '', line: 4 })          // u = person
+    expect(locateLine(r.segments, 8)).toEqual({ path: 'teams/identity.dsl', line: 1 })
+    expect(locateLine(r.segments, 12)).toEqual({ path: 'views.dsl', line: 1 })
+  })
+
+  it('resolves nested includes relative to the including file', async () => {
+    const r = await resolveIncludes('workspace {\n  model {\n    !include teams/a.dsl\n  }\n}\n', fs({
+      'teams/a.dsl': 'a = softwareSystem "A"\n!include sub/b.dsl\n',
+      'teams/sub/b.dsl': 'b = softwareSystem "B"\n',
+    }))
+    expect(r.errors).toEqual([])
+    expect(r.files).toEqual(['teams/a.dsl', 'teams/sub/b.dsl'])
+    expect(r.content).toContain('b = softwareSystem "B"')
+    expect(locateLine(r.segments, 6)).toEqual({ path: 'teams/sub/b.dsl', line: 1 })
+  })
+
+  it('reports a cycle naming both files and never hangs', async () => {
+    const r = await resolveIncludes('workspace {\n  model {\n    !include a.dsl\n  }\n}\n', fs({
+      'a.dsl': '!include b.dsl\n',
+      'b.dsl': '!include a.dsl\n',
+    }))
+    expect(r.errors).toHaveLength(1)
+    expect(r.errors[0].message).toMatch(/cycle/)
+    expect(r.errors[0].message).toContain('a.dsl')
+    expect(r.errors[0].message).toContain('b.dsl')
+    expect(r.errors[0].path).toBe('b.dsl')
+  })
+
+  it('reports a missing file with the path and the line of the include', async () => {
+    const r = await resolveIncludes(ROOT, fs({ 'teams/payments.dsl': 'x = person "X"\n' }))
+    expect(r.errors.map((e) => `${e.path || 'root'}:${e.line} ${e.message}`)).toEqual([
+      'root:5 !include teams/identity.dsl: file not found',
+      'root:8 !include views.dsl: file not found',
+    ])
+    // The rest still resolved.
+    expect(r.content).toContain('x = person "X"')
+  })
+
+  it('leaves URLs, absolute paths and .. escapes in place as unresolved', async () => {
+    const r = await resolveIncludes('workspace {\n!include https://x/y.dsl\n!include /abs.dsl\n!include ../up.dsl\n}\n', fs({}))
+    expect(r.errors).toEqual([])
+    expect(r.unresolved.map((u) => u.raw)).toEqual(['!include https://x/y.dsl', '!include /abs.dsl', '!include ../up.dsl'])
+  })
+
+  it('enforces depth, file-count and byte caps', async () => {
+    const deep: Record<string, string> = {}
+    for (let i = 0; i < 12; i++) deep[`f${i}.dsl`] = `!include f${i + 1}.dsl\n`
+    const r1 = await resolveIncludes('workspace {\n!include f0.dsl\n}\n', { ...fs(deep), maxDepth: 3 })
+    expect(r1.errors[0].message).toMatch(/deeper than 3/)
+
+    const many: Record<string, string> = {}
+    let root = 'workspace {\n'
+    for (let i = 0; i < 5; i++) { many[`m${i}.dsl`] = `m${i} = person "M${i}"\n`; root += `!include m${i}.dsl\n` }
+    const r2 = await resolveIncludes(root + '}\n', { ...fs(many), maxFiles: 3 })
+    expect(r2.errors[0].message).toMatch(/more than 3 files/)
+    expect(r2.files).toHaveLength(3)
+
+    const r3 = await resolveIncludes('workspace {\n!include big.dsl\n}\n', { ...fs({ 'big.dsl': 'x'.repeat(2000) }), maxTotalBytes: 1000 })
+    expect(r3.errors[0].message).toMatch(/total size/)
+  })
+
+  it('treats a read that throws as missing rather than crashing', async () => {
+    const r = await resolveIncludes('workspace {\n!include a.dsl\n}\n', { read: async () => { throw new Error('perm') } })
+    expect(r.errors[0].message).toMatch(/not found/)
+  })
+
+  it('records element scope for an include inside a system block', async () => {
+    const r = await resolveIncludes('workspace {\n  model {\n    sys = softwareSystem "S" {\n      !include containers.dsl\n    }\n  }\n}\n', fs({
+      'containers.dsl': 'web = container "Web"\n',
+    }))
+    expect(r.scopes.get('containers.dsl')).toBe('element')
+  })
+
+  it('is a no-op for a document without includes', async () => {
+    const text = 'workspace {\n  model {\n    u = person "U"\n  }\n}\n'
+    const r = await resolveIncludes(text, fs({}))
+    expect(r.content).toBe(text)
+    expect(r.files).toEqual([])
+    expect(r.segments).toEqual([{ path: '', start: 1, count: 5, sourceStart: 1 }])
+  })
+})

--- a/src/lib/dsl/includeResolver.ts
+++ b/src/lib/dsl/includeResolver.ts
@@ -1,0 +1,276 @@
+// Resolve `!include <relative path>` directives by splicing the included file's
+// text into the document (TEA-325 phase B).
+//
+// Pure: file access is an injected `read`, so this runs the same in unit tests
+// and against a File System Access directory handle. The parser stays
+// synchronous and single-document; this runs *before* it.
+//
+// Shape of the output: every `!include` line is KEPT (phase A preserves it as
+// a directive, so a save still writes the line) and the included content is
+// inserted directly after it. A source map records which flattened lines came
+// from which file so parse errors and element provenance point at real files.
+
+export interface ResolveIncludesOptions {
+  /** Read a file by path relative to the root file. `null` = does not exist. */
+  read: (path: string) => Promise<string | null>
+  /** Max nesting depth of includes. */
+  maxDepth?: number
+  /** Max number of distinct files. */
+  maxFiles?: number
+  /** Max total bytes across all files. */
+  maxTotalBytes?: number
+}
+
+export interface SourceSegment {
+  /** File path (`''` = the root document). */
+  path: string
+  /** First flattened line (1-based, inclusive). */
+  start: number
+  /** Number of lines. */
+  count: number
+  /** Line in `path` that `start` corresponds to (1-based). */
+  sourceStart: number
+}
+
+export interface ResolveError {
+  message: string
+  /** File the offending `!include` line is in (`''` = root). */
+  path: string
+  line: number
+}
+
+export interface ResolveIncludesResult {
+  /** The flattened document. */
+  content: string
+  /** Every included file, in first-inclusion order (root excluded). */
+  files: string[]
+  /** For each included file: the block scope it was included into. */
+  scopes: Map<string, 'workspace' | 'model' | 'views' | 'element'>
+  segments: SourceSegment[]
+  errors: ResolveError[]
+  /** `!include` lines left in place because they point at something out of
+   *  scope (URLs, absolute paths, `..` escapes, directories). */
+  unresolved: { path: string; line: number; raw: string }[]
+}
+
+export const DEFAULT_MAX_DEPTH = 10
+export const DEFAULT_MAX_FILES = 50
+export const DEFAULT_MAX_TOTAL_BYTES = 10 * 1024 * 1024
+
+const INCLUDE_LINE = /^(\s*)!include\s+(.+?)\s*$/
+
+/** Normalise a relative path: forward slashes, no `.` segments; `null` when it
+ *  is absolute, a URL, or escapes the root through `..`. */
+export function normalizeIncludePath(fromDir: string, target: string): string | null {
+  let t = target.trim()
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) t = t.slice(1, -1)
+  if (/^[a-z]+:\/\//i.test(t)) return null
+  if (t.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(t)) return null
+  const parts = (fromDir ? `${fromDir}/${t}` : t).split(/[\\/]+/)
+  const out: string[] = []
+  for (const part of parts) {
+    if (part === '' || part === '.') continue
+    if (part === '..') {
+      if (out.length === 0) return null
+      out.pop()
+      continue
+    }
+    out.push(part)
+  }
+  return out.join('/')
+}
+
+function dirOf(path: string): string {
+  const i = path.lastIndexOf('/')
+  return i === -1 ? '' : path.slice(0, i)
+}
+
+/** Track which block an `!include` sits in by counting braces on the lines
+ *  before it. Good enough for the well-formed files Structurizr accepts. */
+function scopeAt(lines: string[], upto: number): 'workspace' | 'model' | 'views' | 'element' {
+  const stack: string[] = []
+  const opener = /^\s*(?:[A-Za-z_][\w.]*\s*=\s*)?([A-Za-z!][\w]*)\b[^{]*\{\s*$/
+  for (let i = 0; i < upto; i++) {
+    const line = lines[i]
+    const stripped = stripStringsAndComments(line)
+    const opens = (stripped.match(/\{/g) ?? []).length
+    const closes = (stripped.match(/\}/g) ?? []).length
+    if (opens > closes) {
+      const m = stripped.match(opener)
+      stack.push((m?.[1] ?? '?').toLowerCase())
+    } else if (closes > opens) {
+      for (let n = closes - opens; n > 0; n--) stack.pop()
+    }
+  }
+  const top = stack[stack.length - 1]
+  if (top === 'workspace' || stack.length === 0) return 'workspace'
+  if (top === 'model') return 'model'
+  if (top === 'views') return 'views'
+  return 'element'
+}
+
+function stripStringsAndComments(line: string): string {
+  let out = ''
+  let inStr = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (inStr) {
+      if (ch === '\\') { i++; continue }
+      if (ch === '"') inStr = false
+      continue
+    }
+    if (ch === '"') { inStr = true; continue }
+    if (ch === '/' && line[i + 1] === '/') break
+    if (ch === '#') break
+    out += ch
+  }
+  return out
+}
+
+export interface ResolveIncludesSyncOptions {
+  /** Text of every file that has been read so far, by normalised path. */
+  files: Map<string, string>
+  /** Paths already known not to exist. */
+  missing?: Set<string>
+  maxDepth?: number
+  maxFiles?: number
+  maxTotalBytes?: number
+}
+
+export interface ResolveIncludesSyncResult extends ResolveIncludesResult {
+  /** Paths referenced by an `!include` that are in neither `files` nor
+   *  `missing`. Read them and call again. Empty when resolution is complete. */
+  needed: string[]
+}
+
+/** Async entry point: reads files through `opts.read` until the sync core has
+ *  everything it needs (bounded by `maxFiles`). */
+export async function resolveIncludes(root: string, opts: ResolveIncludesOptions): Promise<ResolveIncludesResult> {
+  const files = new Map<string, string>()
+  const missing = new Set<string>()
+  const maxFiles = opts.maxFiles ?? DEFAULT_MAX_FILES
+  for (;;) {
+    const r = resolveIncludesSync(root, { files, missing, maxDepth: opts.maxDepth, maxFiles, maxTotalBytes: opts.maxTotalBytes })
+    if (r.needed.length === 0 || files.size + missing.size > maxFiles + 1) {
+      const { needed: _n, ...rest } = r
+      void _n
+      return rest
+    }
+    for (const path of r.needed) {
+      let text: string | null
+      try { text = await opts.read(path) } catch { text = null }
+      if (text === null) missing.add(path)
+      else files.set(path, text)
+    }
+  }
+}
+
+/** Synchronous core: resolves against files already in memory. The code pane
+ *  uses this to re-stitch a document from the texts captured at load time,
+ *  so a pane edit parses exactly like a fresh open. */
+export function resolveIncludesSync(root: string, opts: ResolveIncludesSyncOptions): ResolveIncludesSyncResult {
+  const maxDepth = opts.maxDepth ?? DEFAULT_MAX_DEPTH
+  const maxFiles = opts.maxFiles ?? DEFAULT_MAX_FILES
+  const maxTotalBytes = opts.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES
+  const known = opts.files
+  const missing = opts.missing ?? new Set<string>()
+  const needed: string[] = []
+
+  const out: string[] = []
+  const segments: SourceSegment[] = []
+  const errors: ResolveError[] = []
+  const unresolved: ResolveIncludesResult['unresolved'] = []
+  const files: string[] = []
+  const scopes = new Map<string, 'workspace' | 'model' | 'views' | 'element'>()
+  let totalBytes = root.length
+  let budgetBlown = false
+
+  /** `undefined` = not read yet (recorded in `needed`); `null` = known missing. */
+  function lookup(path: string): string | null | undefined {
+    if (known.has(path)) return known.get(path)!
+    if (missing.has(path)) return null
+    if (!needed.includes(path)) needed.push(path)
+    return undefined
+  }
+
+  function emitFile(path: string, text: string, depth: number, chain: string[]): void {
+    const lines = text.split('\n')
+    // Drop a trailing empty line produced by a terminating newline so we don't
+    // inject blank lines between spliced files.
+    if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop()
+    let segStart = out.length + 1
+    let segSourceStart = 1
+
+    const flush = (uptoExclusive: number) => {
+      const count = out.length + 1 - segStart
+      if (count > 0) segments.push({ path, start: segStart, count, sourceStart: segSourceStart })
+      segStart = out.length + 1
+      segSourceStart = uptoExclusive + 1
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      const m = line.match(INCLUDE_LINE)
+      out.push(line)
+      if (!m || budgetBlown) continue
+
+      const rawTarget = m[2]
+      const target = normalizeIncludePath(dirOf(path), rawTarget)
+      if (target === null) {
+        unresolved.push({ path, line: i + 1, raw: line.trim() })
+        continue
+      }
+      if (chain.includes(target) || target === '' ) {
+        errors.push({
+          message: `!include cycle: ${[...chain, target].filter(Boolean).join(' -> ') || target} includes itself`,
+          path, line: i + 1,
+        })
+        continue
+      }
+      if (depth + 1 > maxDepth) {
+        errors.push({ message: `!include nesting deeper than ${maxDepth} (${target})`, path, line: i + 1 })
+        continue
+      }
+      const included = lookup(target)
+      if (included === undefined) continue // not read yet — caller will supply it
+      if (included === null) {
+        errors.push({ message: `!include ${rawTarget.trim()}: file not found`, path, line: i + 1 })
+        continue
+      }
+      if (!files.includes(target)) {
+        if (files.length + 1 > maxFiles) {
+          errors.push({ message: `!include: more than ${maxFiles} files`, path, line: i + 1 })
+          budgetBlown = true
+          continue
+        }
+        totalBytes += included.length
+        if (totalBytes > maxTotalBytes) {
+          errors.push({ message: `!include: total size exceeds ${Math.round(maxTotalBytes / 1024 / 1024)} MB`, path, line: i + 1 })
+          budgetBlown = true
+          continue
+        }
+        files.push(target)
+        scopes.set(target, scopeAt(out, out.length - 1))
+      }
+      // Close this file's segment at the include line, splice, reopen after.
+      flush(i + 1)
+      emitFile(target, included, depth + 1, [...chain, target])
+      segStart = out.length + 1
+      segSourceStart = i + 2
+    }
+    flush(lines.length)
+  }
+
+  emitFile('', root, 0, [''])
+  return { content: out.join('\n') + (root.endsWith('\n') ? '\n' : ''), files, scopes, segments, errors, unresolved, needed }
+}
+
+/** Map a line of the flattened document back to its file and line. */
+export function locateLine(segments: SourceSegment[], flatLine: number): { path: string; line: number } {
+  for (const seg of segments) {
+    if (flatLine >= seg.start && flatLine < seg.start + seg.count) {
+      return { path: seg.path, line: seg.sourceStart + (flatLine - seg.start) }
+    }
+  }
+  return { path: '', line: flatLine }
+}

--- a/src/lib/dsl/index.ts
+++ b/src/lib/dsl/index.ts
@@ -18,6 +18,8 @@ export { GroupSerializationError } from './serializer'
 export interface ParseDSLResult {
     workspace: Workspace
     errors: ParseError[]
+    /** Non-fatal: content preserved but not understood (unresolved `!include`). */
+    warnings: ParseError[]
 }
 
 /**

--- a/src/lib/dsl/index.ts
+++ b/src/lib/dsl/index.ts
@@ -8,14 +8,15 @@
 
 import type { Workspace } from '@/types/model'
 import { parse } from './parser'
-import type { ParseError } from './parser'
-import { serialize } from './serializer'
+import type { ParseError, ParseResult } from './parser'
+import { serialize, type SerializeOptions } from './serializer'
 import { generateDefaultViews } from './auto-views'
 
 export type { ParseError }
+export type { SerializeOptions }
 export { GroupSerializationError } from './serializer'
 
-export interface ParseDSLResult {
+export interface ParseDSLResult extends ParseResult {
     workspace: Workspace
     errors: ParseError[]
     /** Non-fatal: content preserved but not understood (unresolved `!include`). */
@@ -44,6 +45,6 @@ export function parseDSL(input: string): ParseDSLResult {
  * Produces clean, idiomatic DSL with 4-space indentation,
  * blank lines between sections, and proper formatting.
  */
-export function serializeDSL(workspace: Workspace): string {
-    return serialize(workspace)
+export function serializeDSL(workspace: Workspace, opts?: SerializeOptions): string {
+    return serialize(workspace, opts)
 }

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -225,8 +225,10 @@ export function lex(input: string): LexResult {
             }
         }
 
-        // Check if this is an opaque directive
-        if (OPAQUE_DIRECTIVES.has(value)) {
+        // Every `!` directive is opaque: the rest of the line is its argument
+        // and travels with the keyword so the parser can preserve it verbatim
+        // (TEA-325). The named set documents the ones Structurizr defines.
+        if (value.startsWith('!') || OPAQUE_DIRECTIVES.has(value)) {
             // Read the rest of the line as part of the value
             let rest = ''
             while (pos < input.length && peek() !== '\n') {

--- a/src/lib/dsl/parser-deployment.ts
+++ b/src/lib/dsl/parser-deployment.ts
@@ -37,6 +37,7 @@ export function parseDeploymentEnvironment(p: ContextAwareParser, model: Model, 
         p.expect('RBRACE')
     }
 
+    p.declarationLines.set(id, p.lastLine())
     model.deploymentEnvironments.push(env)
 }
 

--- a/src/lib/dsl/parser-deployment.ts
+++ b/src/lib/dsl/parser-deployment.ts
@@ -39,6 +39,7 @@ export function parseDeploymentEnvironment(p: ContextAwareParser, model: Model, 
 
     p.declarationLines.set(id, p.lastLine())
     model.deploymentEnvironments.push(env)
+    p.lastModelDeclId = id
 }
 
 function parseDeploymentEnvironmentBody(p: ContextAwareParser, env: DeploymentEnvironment, model: Model): void {

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -111,7 +111,15 @@ export function parseModelBody(
                     const memberRefs: string[] = []
                     const beforePeople = model.people.length
                     const beforeSystems = model.softwareSystems.length
+                    // Directives inside the group anchor to declarations
+                    // inside it (or its top), never to something outside.
+                    const outerGroup = p.currentGroupId
+                    const outerLast = p.lastModelDeclId
+                    p.currentGroupId = groupId
+                    p.lastModelDeclId = undefined
                     parseModelBody(p, model, memberRefs, groupId)
+                    p.currentGroupId = outerGroup
+                    p.lastModelDeclId = outerLast
                     p.skipNewlines()
                     p.expect('RBRACE')
                     const definedIds = [
@@ -123,19 +131,20 @@ export function parseModelBody(
                     if (parentGroupId) group.parentId = parentGroupId
                     p.declarationLines.set(groupId, p.lastLine())
                     model.groups.push(group)
+                    p.lastModelDeclId = groupId
                 }
                 continue
             }
 
             if (kw === 'person') {
                 const person = parsePerson(p)
-                if (person) model.people.push(person)
+                if (person) { model.people.push(person); p.lastModelDeclId = person.id }
                 continue
             }
 
             if (kw === 'softwaresystem') {
                 const sys = parseSoftwareSystem(p, undefined, model)
-                if (sys) model.softwareSystems.push(sys)
+                if (sys) { model.softwareSystems.push(sys); p.lastModelDeclId = sys.id }
                 continue
             }
 
@@ -180,10 +189,10 @@ export function parseModelBody(
 
                     if (elementKw === 'person') {
                         const person = parsePerson(p, varName)
-                        if (person) model.people.push(person)
+                        if (person) { model.people.push(person); p.lastModelDeclId = person.id }
                     } else if (elementKw === 'softwaresystem') {
                         const sys = parseSoftwareSystem(p, varName, model)
-                        if (sys) model.softwareSystems.push(sys)
+                        if (sys) { model.softwareSystems.push(sys); p.lastModelDeclId = sys.id }
                     } else if (elementKw === 'deploymentenvironment') {
                         parseDeploymentEnvironment(p, model, varName)
                     } else {

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -121,6 +121,7 @@ export function parseModelBody(
                     const allIds = [...new Set([...definedIds, ...memberRefs])]
                     const group: Group = { id: groupId, name: groupName, elementIds: allIds }
                     if (parentGroupId) group.parentId = parentGroupId
+                    p.declarationLines.set(groupId, p.lastLine())
                     model.groups.push(group)
                 }
                 continue
@@ -301,7 +302,7 @@ function parseSoftwareSystemBody(
         const token = p.peek()
 
         if (token.type === 'COMMENT') { p.advance(); continue }
-        if (token.type === 'KEYWORD' && token.value.startsWith('!')) { p.advance(); p.skipToNextLine(); continue }
+        if (token.type === 'KEYWORD' && token.value.startsWith('!')) { (sys.directives ??= []).push(token.value.trim()); p.advance(); p.skipToNextLine(); continue }
 
         if (token.type === 'KEYWORD') {
             const kw = token.value.toLowerCase()
@@ -323,6 +324,7 @@ function parseSoftwareSystemBody(
                             elementIds: sys.containers.slice(beforeContainers).map(container => container.id),
                         }
                         if (parentGroupId) group.parentId = parentGroupId
+                        p.declarationLines.set(groupId, p.lastLine())
                         model.groups.push(group)
                     }
                 }
@@ -445,7 +447,7 @@ function parseContainerBody(
         const token = p.peek()
 
         if (token.type === 'COMMENT') { p.advance(); continue }
-        if (token.type === 'KEYWORD' && token.value.startsWith('!')) { p.advance(); p.skipToNextLine(); continue }
+        if (token.type === 'KEYWORD' && token.value.startsWith('!')) { (container.directives ??= []).push(token.value.trim()); p.advance(); p.skipToNextLine(); continue }
 
         if (token.type === 'KEYWORD') {
             const kw = token.value.toLowerCase()
@@ -467,6 +469,7 @@ function parseContainerBody(
                             elementIds: container.components.slice(beforeComponents).map(component => component.id),
                         }
                         if (parentGroupId) group.parentId = parentGroupId
+                        p.declarationLines.set(groupId, p.lastLine())
                         model.groups.push(group)
                     }
                 }
@@ -570,6 +573,7 @@ function parseSimpleElementBlock(p: ContextAwareParser, element: Person | Compon
         if (token.type === 'COMMENT') { p.advance(); continue }
 
         if (token.type === 'KEYWORD' && token.value.startsWith('!')) {
+            (element.directives ??= []).push(token.value.trim())
             p.advance()
             p.skipToNextLine()
             continue
@@ -581,7 +585,9 @@ function parseSimpleElementBlock(p: ContextAwareParser, element: Person | Compon
                 p.advance()
                 const groupName = p.readOptionalString()
                 if (groupName && model) {
-                    model.groups.push({ id: nextId(), name: groupName, elementIds: [element.id] })
+                    const gid = nextId()
+                    p.declarationLines.set(gid, p.lastLine())
+                    model.groups.push({ id: gid, name: groupName, elementIds: [element.id] })
                 }
                 continue
             }

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -76,7 +76,7 @@ export function parseModelBody(
             // Preprocessor directives (!include, !const, !var, !identifiers, !docs, !adrs).
             // c4hero doesn't evaluate them, but must consume the keyword plus any inline
             // arguments on the same line to avoid mis-parsing them as model elements.
-            p.noteDirective(token.value)
+            p.noteDirective(token.value, 'model', token)
             p.advance()
             p.skipToNextLine()
             continue

--- a/src/lib/dsl/parser-relationship.ts
+++ b/src/lib/dsl/parser-relationship.ts
@@ -63,6 +63,7 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
         tags: initialTags,
         properties: {},
     }
+    p.declarationLines.set(rel.id, p.lastLine())
 
     p.skipNewlines()
     if (p.check('LBRACE')) {

--- a/src/lib/dsl/parser-styles.ts
+++ b/src/lib/dsl/parser-styles.ts
@@ -22,15 +22,17 @@ export function parseStylesBody(p: ContextAwareParser, config: ViewConfiguration
 
             if (kw === 'element') {
                 p.advance()
+                const line = token.line
                 const style = parseElementStyleBlock(p)
-                if (style) config.styles.elements.push(style)
+                if (style) { p.styleLines.set(style, line); config.styles.elements.push(style) }
                 continue
             }
 
             if (kw === 'relationship') {
                 p.advance()
+                const line = token.line
                 const style = parseRelationshipStyleBlock(p)
-                if (style) config.styles.relationships.push(style)
+                if (style) { p.styleLines.set(style, line); config.styles.relationships.push(style) }
                 continue
             }
         }

--- a/src/lib/dsl/parser-views.ts
+++ b/src/lib/dsl/parser-views.ts
@@ -65,6 +65,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 const view = parseSystemLandscapeView(p, model)
                 if (view) {
                     ensureViewKey(view, views, undefined)
+                    p.viewLines.set(view, p.lastLine())
                     views.systemLandscapeViews.push(view)
                 }
                 continue
@@ -73,6 +74,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 const view = parseElementView(p, 'systemContext', model)
                 if (view) {
                     ensureViewKey(view, views, view.softwareSystemId)
+                    p.viewLines.set(view, p.lastLine())
                     views.systemContextViews.push(view)
                 }
                 continue
@@ -81,6 +83,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 const view = parseElementView(p, 'container', model)
                 if (view) {
                     ensureViewKey(view, views, view.softwareSystemId)
+                    p.viewLines.set(view, p.lastLine())
                     views.containerViews.push(view)
                 }
                 continue
@@ -89,6 +92,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 const view = parseElementView(p, 'component', model)
                 if (view) {
                     ensureViewKey(view, views, view.containerId)
+                    p.viewLines.set(view, p.lastLine())
                     views.componentViews.push(view)
                 }
                 continue
@@ -123,6 +127,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 const view = parseDynamicView(p, model)
                 if (view) {
                     ensureViewKey(view, views, view.softwareSystemId ?? view.containerId)
+                    p.viewLines.set(view, p.lastLine())
                     views.dynamicViews.push(view)
                 }
                 continue
@@ -131,6 +136,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 const view = parseDeploymentView(p, model)
                 if (view) {
                     ensureViewKey(view, views, view.softwareSystemId ?? view.environment)
+                    p.viewLines.set(view, p.lastLine())
                     views.deploymentViews.push(view)
                 }
                 continue

--- a/src/lib/dsl/parser-views.ts
+++ b/src/lib/dsl/parser-views.ts
@@ -93,6 +93,13 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                 }
                 continue
             }
+            if (token.value.startsWith('!')) {
+                // Preprocessor directive inside views — preserved verbatim.
+                p.noteDirective(token.value, 'views', token)
+                p.advance()
+                p.skipToNextLine()
+                continue
+            }
             if (kw === 'styles') {
                 p.advance()
                 p.skipNewlines()

--- a/src/lib/dsl/parser-views.ts
+++ b/src/lib/dsl/parser-views.ts
@@ -121,6 +121,7 @@ export function parseViewsBody(p: ContextAwareParser, views: Workspace['views'],
                     themes.push(p.advance().value)
                 }
                 views.configuration.themes = themes
+                p.themesLine = token.line
                 continue
             }
             if (kw === 'dynamic') {

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -124,6 +124,12 @@ export interface ParseError {
 export interface ParseResult {
     workspace: Workspace
     errors: ParseError[]
+    /** Source line (1-based) where each element / relationship / group /
+     *  deployment environment id was declared. Lets a caller that flattened
+     *  `!include`s map ids back to their file (TEA-325 B). */
+    declarationLines: Map<string, number>
+    /** Same for views, keyed by the View object (keys are assigned late). */
+    viewLines: Map<View, number>
     /** Non-fatal notes: the model loaded, but something was preserved rather
      *  than understood (e.g. an unresolved `!include`). */
     warnings: ParseError[]
@@ -158,6 +164,15 @@ export class ContextAwareParser {
     warnings: ParseError[] = []
     /** Preprocessor lines captured verbatim, in source order (TEA-325). */
     directives: WorkspaceDirective[] = []
+    declarationLines = new Map<string, number>()
+    viewLines = new Map<View, number>()
+
+    /** Line of the most recently consumed token — the declaration line for
+     *  whatever was just parsed. */
+    lastLine(): number {
+        const t = this.tokens[this.pos - 1] ?? this.tokens[this.pos]
+        return t?.line ?? 1
+    }
     depth = 0
 
     // Variable name <-> element id mappings
@@ -317,6 +332,7 @@ export class ContextAwareParser {
      */
     registerElement(id: string, name: string, _type: string, varName?: string, parentPath?: string): string {
         this.elementsById.set(id, { name, type: _type })
+        if (!this.declarationLines.has(id)) this.declarationLines.set(id, this.lastLine())
         this.nameToId.set(name, id)
         if (varName) {
             this.varToId.set(varName, id)
@@ -489,7 +505,7 @@ export class ContextAwareParser {
             if (this.check('KEYWORD', 'extends') || this.check('IDENTIFIER', 'extends')) {
                 this.skipToNextLine()
                 this.skipBraceBlock()
-                return { workspace, errors: this.errors, warnings: this.warnings }
+                return { workspace, errors: this.errors, warnings: this.warnings, declarationLines: this.declarationLines, viewLines: this.viewLines }
             }
 
             workspace.name = this.readOptionalString() || undefined
@@ -504,7 +520,7 @@ export class ContextAwareParser {
         }
 
         if (this.directives.length > 0) workspace.directives = this.directives
-        return { workspace, errors: this.errors, warnings: this.warnings }
+        return { workspace, errors: this.errors, warnings: this.warnings, declarationLines: this.declarationLines, viewLines: this.viewLines }
     }
 
     private createEmptyWorkspace(): Workspace {
@@ -693,5 +709,7 @@ export function parse(input: string): ParseResult {
         workspace: ws,
         errors,
         warnings,
+        declarationLines: result.declarationLines,
+        viewLines: result.viewLines,
     }
 }

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -130,6 +130,11 @@ export interface ParseResult {
     declarationLines: Map<string, number>
     /** Same for views, keyed by the View object (keys are assigned late). */
     viewLines: Map<View, number>
+    /** Source line of each `workspace.directives` entry, parallel array. */
+    directiveLines: number[]
+    /** Source line per style object and of the `themes` line. */
+    styleLines: Map<object, number>
+    themesLine: number | undefined
     /** Non-fatal notes: the model loaded, but something was preserved rather
      *  than understood (e.g. an unresolved `!include`). */
     warnings: ParseError[]
@@ -166,6 +171,17 @@ export class ContextAwareParser {
     directives: WorkspaceDirective[] = []
     declarationLines = new Map<string, number>()
     viewLines = new Map<View, number>()
+    /** Source line of each entry in `directives`, parallel array. */
+    directiveLines: number[] = []
+    /** Source line per parsed style object and of the `themes` line. */
+    styleLines = new Map<object, number>()
+    themesLine: number | undefined
+    /** Last element / environment / group declared in the model block being
+     *  parsed — the anchor a following `!` directive is re-emitted after.
+     *  Reset on entering a group body (see parseModelBody). */
+    lastModelDeclId: string | undefined
+    /** Group body currently being parsed, for directive placement. */
+    currentGroupId: string | undefined
 
     /** Line of the most recently consumed token — the declaration line for
      *  whatever was just parsed. */
@@ -389,7 +405,13 @@ export class ContextAwareParser {
         // would make Structurizr reject the very references we write.
         const raw = value.trim()
         if (/^!identifiers\b/.test(raw)) return
-        this.directives.push({ scope, raw })
+        const directive: WorkspaceDirective = { scope, raw }
+        if (scope === 'model') {
+            if (this.currentGroupId) directive.groupId = this.currentGroupId
+            if (this.lastModelDeclId) directive.after = this.lastModelDeclId
+        }
+        this.directives.push(directive)
+        this.directiveLines.push((token ?? this.peek()).line)
         if (/^!include\b/.test(raw)) {
             const t = token ?? this.peek()
             this.warnings.push({
@@ -505,7 +527,7 @@ export class ContextAwareParser {
             if (this.check('KEYWORD', 'extends') || this.check('IDENTIFIER', 'extends')) {
                 this.skipToNextLine()
                 this.skipBraceBlock()
-                return { workspace, errors: this.errors, warnings: this.warnings, declarationLines: this.declarationLines, viewLines: this.viewLines }
+                return { workspace, errors: this.errors, warnings: this.warnings, declarationLines: this.declarationLines, viewLines: this.viewLines, directiveLines: this.directiveLines, styleLines: this.styleLines, themesLine: this.themesLine }
             }
 
             workspace.name = this.readOptionalString() || undefined
@@ -520,7 +542,7 @@ export class ContextAwareParser {
         }
 
         if (this.directives.length > 0) workspace.directives = this.directives
-        return { workspace, errors: this.errors, warnings: this.warnings, declarationLines: this.declarationLines, viewLines: this.viewLines }
+        return { workspace, errors: this.errors, warnings: this.warnings, declarationLines: this.declarationLines, viewLines: this.viewLines, directiveLines: this.directiveLines, styleLines: this.styleLines, themesLine: this.themesLine }
     }
 
     private createEmptyWorkspace(): Workspace {
@@ -711,5 +733,8 @@ export function parse(input: string): ParseResult {
         warnings,
         declarationLines: result.declarationLines,
         viewLines: result.viewLines,
+        directiveLines: result.directiveLines,
+        styleLines: result.styleLines,
+        themesLine: result.themesLine,
     }
 }

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -3,6 +3,7 @@
 
 import type {
     Workspace,
+    WorkspaceDirective,
     Model,
     View,
     ElementInView,
@@ -123,6 +124,9 @@ export interface ParseError {
 export interface ParseResult {
     workspace: Workspace
     errors: ParseError[]
+    /** Non-fatal notes: the model loaded, but something was preserved rather
+     *  than understood (e.g. an unresolved `!include`). */
+    warnings: ParseError[]
 }
 
 // ─── ID Generation ───────────────────────────────────────────────────
@@ -151,6 +155,9 @@ export class ContextAwareParser {
     tokens: Token[]
     pos = 0
     errors: ParseError[] = []
+    warnings: ParseError[] = []
+    /** Preprocessor lines captured verbatim, in source order (TEA-325). */
+    directives: WorkspaceDirective[] = []
     depth = 0
 
     // Variable name <-> element id mappings
@@ -352,9 +359,28 @@ export class ContextAwareParser {
      *  line into the keyword's value, so `!identifiers hierarchical` arrives as
      *  a single token. c4hero always registers bare *and* qualified names, so
      *  the flag only records intent — resolution prefers qualified regardless. */
-    noteDirective(value: string): void {
+    noteDirective(value: string, scope: WorkspaceDirective['scope'] = 'workspace', token?: Token): void {
         if (/^!identifiers\b/.test(value) && /\bhierarchical\b/.test(value)) {
             this.hierarchicalIdentifiers = true
+        }
+        // Preserve every directive byte-for-byte (minus surrounding whitespace)
+        // so a save never deletes a line the user wrote. Includes are kept but
+        // their content is not loaded here — say so, as a warning not an error.
+        //
+        // `!identifiers` is the one exception: it is a parse *mode*, not data.
+        // c4hero registers both flat and qualified names on read and always
+        // serializes flat identifiers, so re-emitting `!identifiers hierarchical`
+        // would make Structurizr reject the very references we write.
+        const raw = value.trim()
+        if (/^!identifiers\b/.test(raw)) return
+        this.directives.push({ scope, raw })
+        if (/^!include\b/.test(raw)) {
+            const t = token ?? this.peek()
+            this.warnings.push({
+                message: `${raw} is preserved but not resolved — included content is not shown`,
+                line: t.line,
+                column: t.column,
+            })
         }
     }
 
@@ -463,7 +489,7 @@ export class ContextAwareParser {
             if (this.check('KEYWORD', 'extends') || this.check('IDENTIFIER', 'extends')) {
                 this.skipToNextLine()
                 this.skipBraceBlock()
-                return { workspace, errors: this.errors }
+                return { workspace, errors: this.errors, warnings: this.warnings }
             }
 
             workspace.name = this.readOptionalString() || undefined
@@ -477,7 +503,8 @@ export class ContextAwareParser {
             }
         }
 
-        return { workspace, errors: this.errors }
+        if (this.directives.length > 0) workspace.directives = this.directives
+        return { workspace, errors: this.errors, warnings: this.warnings }
     }
 
     private createEmptyWorkspace(): Workspace {
@@ -533,7 +560,7 @@ export class ContextAwareParser {
                     }
                 } else if (token.value.startsWith('!')) {
                     // Preprocessor directive — consume keyword + inline args on this line
-                    this.noteDirective(token.value)
+                    this.noteDirective(token.value, 'workspace', token)
                     this.advance()
                     this.skipToNextLine()
                 } else if (kw === 'configuration') {
@@ -603,6 +630,7 @@ export function parse(input: string): ParseResult {
 
     // Combine lexer and parser errors
     const errors = [...lexResult.errors, ...result.errors]
+    const warnings = result.warnings
 
     // Implied instance relationships are NOT materialized here — the canvas
     // derives them per deployment view via deriveInstanceRelationships(), so
@@ -664,5 +692,6 @@ export function parse(input: string): ParseResult {
     return {
         workspace: ws,
         errors,
+        warnings,
     }
 }

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -71,10 +71,12 @@ export function serialize(workspace: Workspace, opts: SerializeOptions = {}): st
 function filterBySource(ws: Workspace, source: string | null): Workspace {
     const owned = (item: { sourcePath?: string }) => (source === null ? item.sourcePath === undefined : item.sourcePath === source)
     const model = ws.model
+    const config = ws.views.configuration
     return {
         ...ws,
-        // Preserved `!` lines belong to the root document only.
-        directives: source === null ? ws.directives : undefined,
+        // Preserved `!` lines belong to the root document only, and only
+        // the ones written there — not ones read from an included file.
+        directives: source === null ? ws.directives?.filter(owned) : undefined,
         model: {
             ...model,
             people: model.people.filter(owned),
@@ -94,6 +96,14 @@ function filterBySource(ws: Workspace, source: string | null): Workspace {
             componentViews: ws.views.componentViews.filter(owned),
             dynamicViews: (ws.views.dynamicViews ?? []).filter(owned),
             deploymentViews: (ws.views.deploymentViews ?? []).filter(owned),
+            configuration: {
+                ...config,
+                styles: {
+                    elements: config.styles.elements.filter(owned),
+                    relationships: config.styles.relationships.filter(owned),
+                },
+                themes: source === null && config.themesSourcePath ? undefined : (source === null ? config.themes : undefined),
+            },
         },
     }
 }
@@ -541,13 +551,34 @@ class SerializerContext {
     // ─── Model ──────────────────────────────────────────────────────
 
     /** Re-emit preserved `!` lines for one block, verbatim and in original
-     *  order, ahead of any generated content. Returns true if any were written. */
+     *  order. Model-scope lines that were written after a declaration (or
+     *  inside a group) are held back for `emitDirectivesAfter` /
+     *  `emitGroupDirectives` so their single-pass ordering survives; the rest
+     *  go ahead of any generated content. Returns true if any were written. */
     private emitDirectives(scope: 'workspace' | 'model' | 'views'): boolean {
         let any = false
         for (const d of this.workspace.directives ?? []) {
             if (d.scope !== scope) continue
+            if (scope === 'model' && (d.after || d.groupId)) continue
             this.emit(d.raw)
             any = true
+        }
+        return any
+    }
+
+    /** Model-scope directives anchored right after `id` (an element,
+     *  environment or group that has just been emitted). */
+    private emitDirectivesAfter(id: string): void {
+        for (const d of this.workspace.directives ?? []) {
+            if (d.scope === 'model' && d.after === id) this.emit(d.raw)
+        }
+    }
+
+    /** Directives written at the top of a group block. */
+    private emitGroupDirectives(groupId: string): boolean {
+        let any = false
+        for (const d of this.workspace.directives ?? []) {
+            if (d.scope === 'model' && d.groupId === groupId && !d.after) { this.emit(d.raw); any = true }
         }
         return any
     }
@@ -565,13 +596,17 @@ class SerializerContext {
             this.emitBlank()
         }
 
-        this.serializeGroupScope(this.topLevelGroups, element => this.serializeModelElement(element))
+        this.serializeGroupScope(this.topLevelGroups, element => {
+            this.serializeModelElement(element)
+            this.emitDirectivesAfter(element.id)
+        })
 
         // Deployment environments (before relationships — instance identifiers
         // must be defined before any relationship lines that reference them)
         for (const env of model.deploymentEnvironments ?? []) {
             this.emitBlank()
             this.serializeDeploymentEnvironment(env)
+            this.emitDirectivesAfter(env.id)
         }
 
         // Relationships
@@ -609,7 +644,7 @@ class SerializerContext {
     ): void {
         this.emit(`group "${this.escapeString(scoped.group.name)}" {`)
         this.depth++
-        let emitted = false
+        let emitted = this.emitGroupDirectives(scoped.group.id)
         for (const child of scoped.children) {
             if (emitted) this.emitBlank()
             this.serializeGroup(child, serializeElement)
@@ -622,6 +657,7 @@ class SerializerContext {
         }
         this.depth--
         this.emit('}')
+        this.emitDirectivesAfter(scoped.group.id)
     }
 
     private serializeModelElement(element: Person | SoftwareSystem): void {

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -452,6 +452,8 @@ class SerializerContext {
         this.emit(parts.join(' ') + ' {')
         this.depth++
 
+        if (this.emitDirectives('workspace')) this.emitBlank()
+
         this.emitBlank()
         this.serializeModel()
         this.emitBlank()
@@ -482,11 +484,25 @@ class SerializerContext {
 
     // ─── Model ──────────────────────────────────────────────────────
 
+    /** Re-emit preserved `!` lines for one block, verbatim and in original
+     *  order, ahead of any generated content. Returns true if any were written. */
+    private emitDirectives(scope: 'workspace' | 'model' | 'views'): boolean {
+        let any = false
+        for (const d of this.workspace.directives ?? []) {
+            if (d.scope !== scope) continue
+            this.emit(d.raw)
+            any = true
+        }
+        return any
+    }
+
     private serializeModel(): void {
         this.emit('model {')
         this.depth++
 
         const model = this.workspace.model
+
+        if (this.emitDirectives('model')) this.emitBlank()
 
         if (this.hasNestedGroups) {
             this.serializeProperties({ 'structurizr.groupSeparator': GROUP_SEPARATOR })
@@ -851,7 +867,7 @@ class SerializerContext {
         this.depth++
 
         const views = this.workspace.views
-        let needsBlank = false
+        let needsBlank = this.emitDirectives('views')
 
         // Skip parser-synthesised views — they exist to give the canvas
         // something to render when the DSL declares no views; serializing them

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -50,9 +50,52 @@ export class GroupSerializationError extends Error {
 
 // ─── Public API ─────────────────────────────────────────────────────
 
-export function serialize(workspace: Workspace): string {
-    const ctx = new SerializerContext(workspace)
-    return ctx.serialize()
+export interface SerializeOptions {
+    /** Which file's content to emit (TEA-325 phase B):
+     *  - `undefined` (default): everything, as one document.
+     *  - `null`: the root file only — content that came from an `!include`d
+     *    file is skipped (its `!include` line is still written).
+     *  - a path: only content declared in that included file, as a bare
+     *    model fragment (no `workspace`/`model` wrapper) ready to write back. */
+    source?: string | null
+}
+
+export function serialize(workspace: Workspace, opts: SerializeOptions = {}): string {
+    if (opts.source === undefined) return new SerializerContext(workspace).serialize()
+    const filtered = filterBySource(workspace, opts.source)
+    const ctx = new SerializerContext(filtered, workspace)
+    return opts.source === null ? ctx.serialize() : ctx.serializeFragment()
+}
+
+/** Shallow copy of `ws` keeping only content owned by `source` (`null` = root). */
+function filterBySource(ws: Workspace, source: string | null): Workspace {
+    const owned = (item: { sourcePath?: string }) => (source === null ? item.sourcePath === undefined : item.sourcePath === source)
+    const model = ws.model
+    return {
+        ...ws,
+        // Preserved `!` lines belong to the root document only.
+        directives: source === null ? ws.directives : undefined,
+        model: {
+            ...model,
+            people: model.people.filter(owned),
+            softwareSystems: model.softwareSystems.filter(owned).map((sys) => ({
+                ...sys,
+                containers: sys.containers.filter(owned).map((c) => ({ ...c, components: c.components.filter(owned) })),
+            })),
+            relationships: model.relationships.filter(owned),
+            groups: model.groups.filter(owned),
+            deploymentEnvironments: (model.deploymentEnvironments ?? []).filter(owned),
+        },
+        views: {
+            ...ws.views,
+            systemLandscapeViews: ws.views.systemLandscapeViews.filter(owned),
+            systemContextViews: ws.views.systemContextViews.filter(owned),
+            containerViews: ws.views.containerViews.filter(owned),
+            componentViews: ws.views.componentViews.filter(owned),
+            dynamicViews: (ws.views.dynamicViews ?? []).filter(owned),
+            deploymentViews: (ws.views.deploymentViews ?? []).filter(owned),
+        },
+    }
 }
 
 // ─── Serializer Context ─────────────────────────────────────────────
@@ -73,9 +116,11 @@ class SerializerContext {
     private componentGroups = new Map<string, GroupScope<Component>>()
     private hasNestedGroups = false
 
-    constructor(workspace: Workspace) {
+    /** `idSource` supplies the identifier maps when `workspace` is a filtered
+     *  view of a larger model, so cross-file references still resolve. */
+    constructor(workspace: Workspace, idSource: Workspace = workspace) {
         this.workspace = workspace
-        this.buildIdMaps()
+        this.buildIdMaps(idSource)
         this.topLevelGroups = this.buildGroupScope(
             [...workspace.model.people, ...workspace.model.softwareSystems],
             true,
@@ -266,8 +311,8 @@ class SerializerContext {
         return `element ${id}`
     }
 
-    private buildIdMaps(): void {
-        const model = this.workspace.model
+    private buildIdMaps(idSource: Workspace): void {
+        const model = idSource.model
 
         for (const person of model.people) {
             this.registerElement(person.id)
@@ -440,6 +485,17 @@ class SerializerContext {
     }
 
     // ─── Main Serialize ─────────────────────────────────────────────
+
+    /** Emit the model block's *contents* only, at column 0 — the shape of a
+     *  file that is `!include`d from inside `model { }`. */
+    serializeFragment(): string {
+        this.serializeModel()
+        // Drop `model {` / `}` and one level of indent.
+        const body = this.lines.slice(1, -1).map((l) => (l.startsWith('    ') ? l.slice(4) : l))
+        while (body.length > 0 && body[body.length - 1] === '') body.pop()
+        while (body.length > 0 && body[0] === '') body.shift()
+        return body.join('\n') + (body.length > 0 ? '\n' : '')
+    }
 
     serialize(): string {
         const ws = this.workspace
@@ -693,7 +749,7 @@ class SerializerContext {
         const extraTags = this.locationAwareTags(person, ['Element', 'Person'])
         const props = this.elementProperties(person)
         const hasProperties = Object.keys(props).length > 0
-        const hasBlock = !!person.url || hasProperties
+        const hasBlock = !!person.url || hasProperties || !!person.directives?.length
 
         const parts: string[] = []
         parts.push('person')
@@ -708,6 +764,7 @@ class SerializerContext {
         if (hasBlock) {
             this.emit(`${prefix}${parts.join(' ')} {`)
             this.depth++
+            for (const d of person.directives ?? []) this.emit(d)
             if (person.url) this.emit(`url "${this.escapeString(person.url)}"`)
             if (hasProperties) this.serializeProperties(props)
             this.depth--
@@ -722,7 +779,7 @@ class SerializerContext {
         const extraTags = this.locationAwareTags(sys, ['Element', 'Software System'])
         const props = this.elementProperties(sys)
         const hasProperties = Object.keys(props).length > 0
-        const hasBody = sys.containers.length > 0 || !!sys.url || hasProperties
+        const hasBody = sys.containers.length > 0 || !!sys.url || hasProperties || !!sys.directives?.length
 
         const parts: string[] = []
         parts.push('softwareSystem')
@@ -738,6 +795,7 @@ class SerializerContext {
             this.emit(`${prefix}${parts.join(' ')} {`)
             this.depth++
 
+            for (const d of sys.directives ?? []) this.emit(d)
             if (sys.url) this.emit(`url "${this.escapeString(sys.url)}"`)
             if (hasProperties) this.serializeProperties(props)
 
@@ -756,7 +814,7 @@ class SerializerContext {
         const extraTags = this.getExtraTags(container.tags, ['Element', 'Container'])
         const props = this.elementProperties(container)
         const hasProperties = Object.keys(props).length > 0
-        const hasBody = container.components.length > 0 || !!container.url || hasProperties
+        const hasBody = container.components.length > 0 || !!container.url || hasProperties || !!container.directives?.length
 
         const parts: string[] = []
         parts.push('container')
@@ -775,6 +833,7 @@ class SerializerContext {
             this.emit(`${prefix}${parts.join(' ')} {`)
             this.depth++
 
+            for (const d of container.directives ?? []) this.emit(d)
             if (container.url) this.emit(`url "${this.escapeString(container.url)}"`)
             if (hasProperties) this.serializeProperties(props)
             const scope = this.componentGroups.get(container.id)
@@ -792,7 +851,7 @@ class SerializerContext {
         const extraTags = this.getExtraTags(comp.tags, ['Element', 'Component'])
         const props = this.elementProperties(comp)
         const hasProperties = Object.keys(props).length > 0
-        const hasBlock = !!comp.url || hasProperties
+        const hasBlock = !!comp.url || hasProperties || !!comp.directives?.length
 
         const parts: string[] = []
         parts.push('component')
@@ -810,6 +869,7 @@ class SerializerContext {
         if (hasBlock) {
             this.emit(`${prefix}${parts.join(' ')} {`)
             this.depth++
+            for (const d of comp.directives ?? []) this.emit(d)
             if (comp.url) this.emit(`url "${this.escapeString(comp.url)}"`)
             if (hasProperties) this.serializeProperties(props)
             this.depth--

--- a/src/lib/fileIO.ts
+++ b/src/lib/fileIO.ts
@@ -422,6 +422,10 @@ export function isWorkspaceShape(obj: unknown): obj is Workspace {
     isRecord(d) && typeof d.raw === 'string' && ['workspace', 'model', 'views'].includes(String(d.scope))
   ))) return false
 
+  if ('includedFiles' in obj && obj.includedFiles !== undefined && (!Array.isArray(obj.includedFiles) || !obj.includedFiles.every(f =>
+    isRecord(f) && typeof f.path === 'string' && typeof f.writable === 'boolean' && (f.text === undefined || typeof f.text === 'string')
+  ))) return false
+
   const { model, views } = obj
   if (!isRecord(model) || !isRecord(views)) return false
   if (!Array.isArray(model.people) || !model.people.every(isPersonShape)) return false

--- a/src/lib/fileIO.ts
+++ b/src/lib/fileIO.ts
@@ -418,6 +418,10 @@ export function isWorkspaceShape(obj: unknown): obj is Workspace {
   if ('description' in obj && obj.description !== undefined && typeof obj.description !== 'string') return false
   if ('scope' in obj && obj.scope !== undefined && !['softwaresystem', 'landscape', 'none'].includes(String(obj.scope))) return false
 
+  if ('directives' in obj && obj.directives !== undefined && (!Array.isArray(obj.directives) || !obj.directives.every(d =>
+    isRecord(d) && typeof d.raw === 'string' && ['workspace', 'model', 'views'].includes(String(d.scope))
+  ))) return false
+
   const { model, views } = obj
   if (!isRecord(model) || !isRecord(views)) return false
   if (!Array.isArray(model.people) || !model.people.every(isPersonShape)) return false

--- a/src/lib/folderIO.ts
+++ b/src/lib/folderIO.ts
@@ -107,6 +107,49 @@ export async function readDSLFile(filename: string): Promise<{ content: string; 
   }
 }
 
+/** Walk `a/b/c.dsl` from the current directory handle. `create` makes
+ *  intermediate directories; the file itself is created only by the writer. */
+async function resolveFileHandle(relPath: string, create: boolean): Promise<FileSystemFileHandle | null> {
+  if (!currentDirHandle) return null
+  const parts = relPath.split('/').filter((p) => p !== '' && p !== '.')
+  if (parts.length === 0 || parts.some((p) => p === '..')) return null
+  let dir = currentDirHandle
+  try {
+    for (const seg of parts.slice(0, -1)) dir = await dir.getDirectoryHandle(seg, { create })
+    return await dir.getFileHandle(parts[parts.length - 1], { create })
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'NotFoundError') return null
+    throw err
+  }
+}
+
+/** Read a text file at a path relative to the open folder (for `!include`
+ *  resolution). `null` when it does not exist; throws on other failures. */
+export async function readDSLFileAt(relPath: string): Promise<string | null> {
+  const handle = await resolveFileHandle(relPath, false)
+  if (!handle) return null
+  const file = await handle.getFile()
+  return readTextFileWithLimit(file, 'Included DSL file')
+}
+
+/** Write a text file at a path relative to the open folder (include
+ *  write-back). Never creates the file: an included file that vanished is
+ *  not silently recreated. */
+export async function writeDSLFileAt(relPath: string, content: string): Promise<boolean> {
+  try {
+    const handle = await resolveFileHandle(relPath, false)
+    if (!handle) return false
+    recordSelfDslWrite(content)
+    const writable = await handle.createWritable()
+    await writable.write(content)
+    await writable.close()
+    return true
+  } catch (err) {
+    log.error('writeDSLFileAt failed', { relPath, err })
+    return false
+  }
+}
+
 /** Read a workspace file for the disk watcher. Unlike `readDSLFile` this is
  *  silent and distinguishes "gone" (`null`) from a transient failure (throws),
  *  because it runs every couple of seconds. */

--- a/src/lib/include-review-fixes.test.ts
+++ b/src/lib/include-review-fixes.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Regression tests for the review findings on the TEA-325 PR: directive
+ * placement, provenance of directives/styles/themes from included files,
+ * export paths, child provenance, read-only relationship pins.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+import { loadWorkspaceDocument } from '@/lib/workspaceDocument'
+import { planIncludedWrites, serializeRoot } from '@/lib/includeWriteback'
+import { useWorkspaceStore } from '@/store/workspace'
+
+function store() { return useWorkspaceStore.getState() }
+
+describe('directive placement (single-pass ordering)', () => {
+  it('re-emits a model-scope !include after the declaration that preceded it', () => {
+    const src = `workspace {
+    model {
+        u = person "User"
+        !include teams/identity.dsl
+        sys = softwareSystem "Sys"
+    }
+    views {}
+}`
+    const out = serializeDSL(parseDSL(src).workspace)
+    const lines = out.split('\n').map((l) => l.trim())
+    const iU = lines.indexOf('u = person "User"')
+    const iInc = lines.indexOf('!include teams/identity.dsl')
+    const iSys = lines.indexOf('sys = softwareSystem "Sys"')
+    expect(iU).toBeGreaterThan(-1)
+    expect(iInc).toBe(iU + 1)
+    expect(iSys).toBeGreaterThan(iInc)
+  })
+
+  it('keeps a directive at the top of the model block when nothing precedes it', () => {
+    const out = serializeDSL(parseDSL('workspace {\n model {\n !const X "1"\n u = person "U"\n }\n views {}\n}').workspace)
+    const lines = out.split('\n').map((l) => l.trim())
+    expect(lines.indexOf('!const X "1"')).toBeLessThan(lines.indexOf('u = person "U"'))
+  })
+
+  it('keeps a !include written inside a group inside that group, and keeps the group', () => {
+    const src = `workspace {
+    model {
+        group "Team" {
+            !include team.dsl
+        }
+        u = person "U"
+    }
+    views {}
+}`
+    const { workspace } = parseDSL(src)
+    expect(workspace.directives).toEqual([{ scope: 'model', raw: '!include team.dsl', groupId: workspace.model.groups[0]?.id ?? expect.any(String) }])
+    const out = serializeDSL(workspace)
+    expect(out).toMatch(/group "Team" \{\s*\n\s*!include team\.dsl\s*\n\s*\}/)
+  })
+
+  it('anchors a directive after an element declared inside a group, not outside it', () => {
+    const src = `workspace {
+    model {
+        a = person "A"
+        group "Team" {
+            b = person "B"
+            !include more.dsl
+        }
+    }
+    views {}
+}`
+    const out = serializeDSL(parseDSL(src).workspace)
+    const lines = out.split('\n').map((l) => l.trim())
+    expect(lines.indexOf('!include more.dsl')).toBe(lines.indexOf('b = person "B"') + 1)
+    // Round trip is stable.
+    expect(serializeDSL(parseDSL(out).workspace)).toBe(out)
+  })
+})
+
+describe('provenance of directives, styles and themes from included files', () => {
+  const ROOT = `workspace {
+    model {
+        !include teams/a.dsl
+        u = person "U"
+    }
+    views {
+        systemLandscape "Land" { include * }
+        !include styles.dsl
+    }
+}`
+  const FILES: Record<string, string> = {
+    'teams/a.dsl': '!const X "y"\na = softwareSystem "A"\n!include sub/b.dsl\n',
+    'teams/sub/b.dsl': 'b = softwareSystem "B"\n',
+    'styles.dsl': 'styles {\n  element "Person" {\n    background #ff0000\n  }\n}\nthemes "https://example.com/theme.json"\n',
+  }
+  const read = async (p: string) => FILES[p] ?? null
+
+  it('does not re-emit an included file\'s own directives, styles or themes into the root', async () => {
+    const { workspace, errors } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    expect(errors).toEqual([])
+    const root = serializeRoot(workspace)
+    expect(root).toContain('!include teams/a.dsl')
+    expect(root).toContain('!include styles.dsl')
+    expect(root).not.toContain('!const X')
+    expect(root).not.toContain('!include sub/b.dsl')
+    expect(root).not.toContain('background #ff0000')
+    expect(root).not.toContain('themes')
+    // The included file that owns them is read-only (it has directives) and untouched.
+    expect(planIncludedWrites(workspace).map((w) => w.path)).toEqual(['teams/sub/b.dsl'])
+  })
+
+  it('exports for copy / download use the same root-only form', async () => {
+    const { workspace } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    // serializeDSL with no source is the flattened form; the export paths must
+    // not use it for a multi-file workspace or the content doubles on reopen.
+    expect(serializeDSL(workspace)).toContain('softwareSystem "A"')
+    expect(serializeRoot(workspace)).not.toContain('softwareSystem "A"')
+  })
+})
+
+describe('store rules for included content', () => {
+  const ROOT = `workspace {
+    model {
+        u = person "U"
+        !include rw.dsl
+        !include ro.dsl
+    }
+    views {
+        systemLandscape "Land" { include * }
+    }
+}`
+  const read = async (p: string) => ({
+    'rw.dsl': 'pay = softwareSystem "Pay" {\n  api = container "API"\n}\n',
+    'ro.dsl': '!const X "1"\nlegacy = softwareSystem "Legacy"\nlegacy -> u "Notifies"\n',
+  })[p] ?? null
+
+  beforeEach(async () => {
+    const { workspace, errors } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    expect(errors).toEqual([])
+    store().loadWorkspace(workspace)
+  })
+
+  it('a new container under an included system is written to that system\'s file', () => {
+    store().addContainer('pay', 'Payments DB')
+    const pay = store().workspace!.model.softwareSystems.find((s) => s.id === 'pay')!
+    const db = pay.containers.find((c) => c.name === 'Payments DB')!
+    expect(db.sourcePath).toBe('rw.dsl')
+    const fragment = planIncludedWrites(store().workspace!).find((w) => w.path === 'rw.dsl')!.content
+    expect(fragment).toContain('Payments DB')
+    expect(serializeRoot(store().workspace!)).not.toContain('Payments DB')
+  })
+
+  it('refuses a new container under a read-only system', () => {
+    const before = store().workspace!
+    store().addContainer('legacy', 'Nope')
+    expect(store().workspace).toBe(before)
+  })
+
+  it('a duplicated top-level element is root-owned; a duplicated child stays in its parent\'s file', () => {
+    store().setActiveView('Land')
+    store().duplicateElements(['pay'])
+    const copy = store().workspace!.model.softwareSystems.find((s) => s.name === 'Pay copy')!
+    expect(copy.sourcePath).toBeUndefined()
+    expect(serializeRoot(store().workspace!)).toContain('Pay copy')
+    // Its cloned container follows the copy (root) rather than rw.dsl.
+    expect(copy.containers[0]?.sourcePath).toBeUndefined()
+  })
+
+  it('refuses to delete an element a read-only file still references', () => {
+    store().deleteElements(['u'])
+    expect(store().workspace!.model.people.map((p) => p.id)).toEqual(['u'])
+    expect(store().workspace!.model.relationships.some((r) => r.description === 'Notifies')).toBe(true)
+  })
+})

--- a/src/lib/includeWriteback.ts
+++ b/src/lib/includeWriteback.ts
@@ -1,0 +1,42 @@
+// Route a save across the files a workspace was assembled from (TEA-325 C-lite).
+//
+// The root document is serialized with `source: null` (its own content plus
+// the preserved `!include` lines). Each writable included file gets a bare
+// model fragment holding exactly the content it declared. Read-only files are
+// never written; edits to their content are blocked in the store instead.
+
+import type { Workspace } from '@/types/model'
+import { serializeDSL } from '@/lib/dsl'
+
+export interface PlannedWrite {
+  /** Path relative to the root file. */
+  path: string
+  content: string
+}
+
+/** True when this workspace was stitched from more than one file. */
+export function hasIncludedFiles(ws: Workspace): boolean {
+  return (ws.includedFiles?.length ?? 0) > 0
+}
+
+/** Serialize the root document: everything when the workspace is a single
+ *  file, root-owned content only when it has includes. */
+export function serializeRoot(ws: Workspace): string {
+  return hasIncludedFiles(ws) ? serializeDSL(ws, { source: null }) : serializeDSL(ws)
+}
+
+/** Fragments to write for every writable included file. */
+export function planIncludedWrites(ws: Workspace): PlannedWrite[] {
+  if (!hasIncludedFiles(ws)) return []
+  return (ws.includedFiles ?? [])
+    .filter((f) => f.writable)
+    .map((f) => ({ path: f.path, content: serializeDSL(ws, { source: f.path }) }))
+}
+
+/** Is content from `sourcePath` locked against edits? Root content
+ *  (`undefined`) never is. */
+export function isReadOnlySource(ws: Workspace, sourcePath: string | undefined): boolean {
+  if (!sourcePath) return false
+  const f = ws.includedFiles?.find((x) => x.path === sourcePath)
+  return f ? !f.writable : true
+}

--- a/src/lib/workspaceDocument.include.test.ts
+++ b/src/lib/workspaceDocument.include.test.ts
@@ -1,0 +1,173 @@
+/**
+ * TEA-325 phase B: loading a folder workspace resolves `!include`, tags every
+ * declaration with the file it came from, points errors at that file, and
+ * partitions saves so the root never swallows an included file's content.
+ */
+import { describe, it, expect } from 'vitest'
+import { loadWorkspaceDocument, parseWorkspaceDocument } from './workspaceDocument'
+import { serializeDSL } from '@/lib/dsl'
+import { planIncludedWrites, serializeRoot, isReadOnlySource } from '@/lib/includeWriteback'
+import { isWorkspaceShape } from '@/lib/fileIO'
+
+const ROOT = `workspace "Org" "Everything" {
+    model {
+        !include teams/payments.dsl
+        u = person "User"
+        !include teams/identity.dsl
+        u -> pay "Pays with"
+    }
+    views {
+        systemLandscape "Land" {
+            include *
+        }
+        !include views/extra.dsl
+    }
+}
+`
+const FILES: Record<string, string> = {
+  'teams/payments.dsl': `pay = softwareSystem "Payments" "Takes money" {
+    api = container "Payments API" "" "Go"
+}
+`,
+  // Structurizr is single-pass: a reference must follow its declaration, so
+  // the cross-team relationship lives in the file that declares `idp`.
+  'teams/identity.dsl': `idp = softwareSystem "Identity"
+pay -> idp "Verifies"
+`,
+  'views/extra.dsl': `systemContext pay "PayCtx" {
+    include *
+}
+`,
+}
+const read = async (p: string) => (p in FILES ? FILES[p] : null)
+
+describe('loadWorkspaceDocument with includes', () => {
+  it('stitches the full model and tags provenance per declaration', async () => {
+    const { workspace, errors } = await loadWorkspaceDocument({ content: ROOT, fallbackName: 'org', readInclude: read })
+    expect(errors).toEqual([])
+    expect(workspace.model.softwareSystems.map((s) => s.name).sort()).toEqual(['Identity', 'Payments'])
+    const pay = workspace.model.softwareSystems.find((s) => s.id === 'pay')!
+    expect(pay.sourcePath).toBe('teams/payments.dsl')
+    expect(pay.containers[0].sourcePath).toBe('teams/payments.dsl')
+    expect(workspace.model.softwareSystems.find((s) => s.id === 'idp')!.sourcePath).toBe('teams/identity.dsl')
+    expect(workspace.model.people[0].sourcePath).toBeUndefined()
+    const rels = workspace.model.relationships
+    expect(rels.find((r) => r.description === 'Verifies')!.sourcePath).toBe('teams/identity.dsl')
+    expect(rels.find((r) => r.description === 'Pays with')!.sourcePath).toBeUndefined()
+    expect(workspace.views.systemLandscapeViews[0].sourcePath).toBeUndefined()
+    expect(workspace.views.systemContextViews[0].sourcePath).toBe('views/extra.dsl')
+    // The include lines themselves are still preserved directives.
+    expect(workspace.directives?.map((d) => d.raw)).toEqual([
+      '!include teams/payments.dsl', '!include teams/identity.dsl', '!include views/extra.dsl',
+    ])
+  })
+
+  it('classifies which included files can be written back', async () => {
+    const { workspace } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    expect(workspace.includedFiles).toEqual([
+      { path: 'teams/payments.dsl', writable: true, text: FILES['teams/payments.dsl'] },
+      { path: 'teams/identity.dsl', writable: true, text: FILES['teams/identity.dsl'] },
+      { path: 'views/extra.dsl', writable: false, reason: 'included in the views block', text: FILES['views/extra.dsl'] },
+    ])
+    expect(isReadOnlySource(workspace, 'views/extra.dsl')).toBe(true)
+    expect(isReadOnlySource(workspace, 'teams/payments.dsl')).toBe(false)
+    expect(isReadOnlySource(workspace, undefined)).toBe(false)
+  })
+
+  it('marks fragments with their own directives, wrappers, or element scope read-only', async () => {
+    const root = `workspace {
+    model {
+        !include a.dsl
+        !include b.dsl
+        sys = softwareSystem "S" {
+            !include c.dsl
+        }
+    }
+    views {}
+}`
+    const { workspace } = await loadWorkspaceDocument({ content: root, readInclude: async (p) => ({
+      'a.dsl': '!const X "y"\nx = person "X"\n',
+      'b.dsl': 'model {\n  y = person "Y"\n}\n',
+      'c.dsl': 'web = container "Web"\n',
+    })[p] ?? null })
+    expect(workspace.includedFiles?.map(({ path, writable, reason }) => ({ path, writable, reason }))).toEqual([
+      { path: 'a.dsl', writable: false, reason: 'contains its own ! directives' },
+      { path: 'b.dsl', writable: false, reason: 'not a plain model fragment' },
+      { path: 'c.dsl', writable: false, reason: 'included inside an element block' },
+    ])
+    const sys = workspace.model.softwareSystems[0]
+    expect(sys.directives).toEqual(['!include c.dsl'])
+    expect(sys.containers[0].sourcePath).toBe('c.dsl')
+  })
+
+  it('points parse errors at the included file and line, and reports resolution failures as errors', async () => {
+    const { errors } = await loadWorkspaceDocument({ content: ROOT, readInclude: async (p) => (
+      p === 'teams/payments.dsl' ? 'pay = softwareSystem "Payments"\npay -> nope "x"\n' : read(p)
+    ) })
+    expect(errors.some((e) => e.message.startsWith('teams/payments.dsl:2:'))).toBe(true)
+
+    const missing = await loadWorkspaceDocument({ content: ROOT, readInclude: async (p) => (p === 'teams/identity.dsl' ? null : read(p)) })
+    expect(missing.errors.map((e) => e.message)).toContain('!include teams/identity.dsl: file not found')
+  })
+
+  it('drops the "preserved but not resolved" warning for includes that resolved', async () => {
+    const { warnings } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    expect(warnings).toEqual([])
+    const single = parseWorkspaceDocument({ content: ROOT })
+    expect(single.warnings).toHaveLength(3)
+  })
+
+  it('serializes the root with only root-owned content plus the include lines', async () => {
+    const { workspace } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    const root = serializeRoot(workspace)
+    expect(root).toContain('!include teams/payments.dsl')
+    expect(root).toContain('person "User"')
+    expect(root).toContain('u -> pay "Pays with"')
+    expect(root).not.toContain('softwareSystem "Payments"')
+    expect(root).not.toContain('softwareSystem "Identity"')
+    expect(root).not.toContain('pay -> idp')
+    expect(root).not.toContain('PayCtx')
+    expect(root).toContain('systemLandscape "Land"')
+  })
+
+  it('plans a bare model fragment for each writable included file', async () => {
+    const { workspace } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    const writes = planIncludedWrites(workspace)
+    expect(writes.map((w) => w.path)).toEqual(['teams/payments.dsl', 'teams/identity.dsl'])
+    const pay = writes[0].content
+    expect(pay.startsWith('pay = softwareSystem "Payments" "Takes money" {')).toBe(true)
+    expect(pay).toContain('    api = container "Payments API" "" "Go"')
+    expect(pay).not.toContain('pay -> idp')
+    expect(pay).not.toContain('model {')
+    expect(pay).not.toContain('person "User"')
+    expect(writes[1].content).toBe('idp = softwareSystem "Identity"\n\npay -> idp "Verifies"\n')
+  })
+
+  it('the written fragments re-stitch to the same model', async () => {
+    const first = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    const writes = planIncludedWrites(first.workspace)
+    const files2: Record<string, string> = { ...FILES }
+    for (const w of writes) files2[w.path] = w.content
+    const root2 = serializeRoot(first.workspace)
+    const second = await loadWorkspaceDocument({ content: root2, readInclude: async (p) => files2[p] ?? null })
+    expect(second.errors).toEqual([])
+    expect(second.workspace.model.softwareSystems.map((s) => s.name).sort()).toEqual(['Identity', 'Payments'])
+    expect(second.workspace.model.relationships).toHaveLength(2)
+    expect(serializeRoot(second.workspace)).toBe(root2)
+    expect(planIncludedWrites(second.workspace)).toEqual(writes)
+  })
+
+  it('a workspace without includes serializes exactly as before', async () => {
+    const plain = 'workspace { model { u = person "U" } views {} }'
+    const { workspace } = await loadWorkspaceDocument({ content: plain, readInclude: read })
+    expect(workspace.includedFiles).toBeUndefined()
+    expect(serializeRoot(workspace)).toBe(serializeDSL(workspace))
+    expect(planIncludedWrites(workspace)).toEqual([])
+  })
+
+  it('crash-recovery shape guard accepts includedFiles and provenance', async () => {
+    const { workspace } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    expect(isWorkspaceShape(JSON.parse(JSON.stringify(workspace)))).toBe(true)
+    expect(isWorkspaceShape({ ...JSON.parse(JSON.stringify(workspace)), includedFiles: [{ path: 1 }] })).toBe(false)
+  })
+})

--- a/src/lib/workspaceDocument.ts
+++ b/src/lib/workspaceDocument.ts
@@ -1,6 +1,10 @@
-import type { Workspace } from '@/types/model'
+import type { IncludedFile, Workspace } from '@/types/model'
 import { parseDSL, type ParseError } from '@/lib/dsl'
 import { applySidecar, parseSidecar } from '@/lib/sidecar'
+import {
+  locateLine, resolveIncludes, resolveIncludesSync,
+  type ResolveIncludesOptions, type ResolveIncludesResult,
+} from '@/lib/dsl/includeResolver'
 
 export interface WorkspaceDocumentInput {
   content: string
@@ -11,18 +15,147 @@ export interface WorkspaceDocumentInput {
 export interface WorkspaceDocumentResult {
   workspace: Workspace
   errors: ParseError[]
+  warnings: ParseError[]
 }
 
+/** Parse one document (no include resolution). Synchronous and pure: the
+ *  code pane, tests and single-file opens use this directly. */
 export function parseWorkspaceDocument({
   content,
   fallbackName,
   sidecarJson,
 }: WorkspaceDocumentInput): WorkspaceDocumentResult {
-  const { workspace, errors } = parseDSL(content)
+  const { workspace, errors, warnings } = parseDSL(content)
   if (!workspace.name && fallbackName) workspace.name = fallbackName
 
   const sidecar = sidecarJson ? parseSidecar(sidecarJson) : null
   if (sidecar) applySidecar(workspace, sidecar)
 
-  return { workspace, errors }
+  return { workspace, errors, warnings }
+}
+
+export interface LoadWorkspaceDocumentInput extends WorkspaceDocumentInput {
+  /** Read an `!include`d file by path relative to the root file; `null` when
+   *  it does not exist. Omit to load without resolving includes. */
+  readInclude?: ResolveIncludesOptions['read']
+}
+
+/** A file included from inside `model { }` that contains only plain model
+ *  content can be written back as a fragment. Anything else (a `views`
+ *  block, a `workspace` wrapper, its own `!` directives, an include inside an
+ *  element) is shown read-only. */
+function classifyIncluded(path: string, text: string, scope: string | undefined): IncludedFile {
+  if (scope !== 'model') {
+    return { path, writable: false, reason: scope === 'element' ? 'included inside an element block' : `included in the ${scope ?? 'workspace'} block`, text }
+  }
+  const code = text.replace(/"(?:[^"\\]|\\.)*"/g, '""').replace(/\/\/.*$|#.*$/gm, '')
+  if (/^\s*!/m.test(code)) return { path, writable: false, reason: 'contains its own ! directives', text }
+  if (/^\s*(workspace|model|views|configuration)\b[^\n]*\{/m.test(code)) {
+    return { path, writable: false, reason: 'not a plain model fragment', text }
+  }
+  return { path, writable: true, text }
+}
+
+/** Parse an already-resolved document and attach provenance, file
+ *  classification, and file-relative error locations. Sync and pure. */
+export function stitchWorkspaceDocument(
+  input: WorkspaceDocumentInput,
+  resolved: ResolveIncludesResult,
+  texts: Map<string, string>,
+): WorkspaceDocumentResult {
+  const { workspace, errors: rawErrors, warnings: rawWarnings, declarationLines, viewLines } = parseDSL(resolved.content)
+  if (!workspace.name && input.fallbackName) workspace.name = input.fallbackName
+
+  // Provenance: map every declaration back to the file it was read from.
+  const fileOf = (flatLine: number | undefined): string | undefined => {
+    if (flatLine === undefined) return undefined
+    const { path } = locateLine(resolved.segments, flatLine)
+    return path || undefined
+  }
+  const tag = <T extends { id: string; sourcePath?: string }>(item: T) => {
+    const p = fileOf(declarationLines.get(item.id))
+    if (p) item.sourcePath = p
+  }
+  for (const person of workspace.model.people) tag(person)
+  for (const sys of workspace.model.softwareSystems) {
+    tag(sys)
+    for (const c of sys.containers) { tag(c); for (const comp of c.components) tag(comp) }
+  }
+  for (const rel of workspace.model.relationships) tag(rel)
+  for (const g of workspace.model.groups) tag(g)
+  for (const env of workspace.model.deploymentEnvironments ?? []) tag(env)
+  for (const [view, line] of viewLines) {
+    const p = fileOf(line)
+    if (p) view.sourcePath = p
+  }
+
+  workspace.includedFiles = resolved.files.map((path) => classifyIncluded(path, texts.get(path) ?? '', resolved.scopes.get(path)))
+
+  // Errors from included files point at that file. Resolution errors
+  // (missing file, cycle, caps) are real errors: the model is incomplete.
+  const relocate = (e: ParseError): ParseError => {
+    const { path, line } = locateLine(resolved.segments, e.line)
+    return path ? { ...e, line, message: `${path}:${line}: ${e.message}` } : { ...e, line }
+  }
+  const errors: ParseError[] = [
+    ...resolved.errors.map((e) => ({ message: e.path ? `${e.path}:${e.line}: ${e.message}` : e.message, line: e.line, column: 1 })),
+    ...rawErrors.map(relocate),
+  ]
+  // The phase-A "preserved but not resolved" warning no longer applies to
+  // includes that did resolve; keep it for the ones deliberately left alone.
+  const warnings = rawWarnings
+    .map(relocate)
+    .filter((w) => {
+      const m = w.message.match(/^(?:.*?: )?!include\s+(.+?) is preserved/)
+      if (!m) return true
+      const target = m[1].replace(/^["']|["']$/g, '')
+      return !resolved.files.some((f) => f === target || f.endsWith('/' + target))
+    })
+
+  const sidecar = input.sidecarJson ? parseSidecar(input.sidecarJson) : null
+  if (sidecar) applySidecar(workspace, sidecar)
+
+  return { workspace, errors, warnings }
+}
+
+/** Parse a document loaded from a folder, resolving `!include` against
+ *  `readInclude` first (TEA-325 phase B). Elements, relationships, groups,
+ *  views and environments declared in an included file carry `sourcePath`;
+ *  errors and warnings from included files are prefixed with `path:line:`. */
+export async function loadWorkspaceDocument(input: LoadWorkspaceDocumentInput): Promise<WorkspaceDocumentResult> {
+  if (!input.readInclude || !/^\s*!include\b/m.test(input.content)) {
+    return parseWorkspaceDocument(input)
+  }
+  const texts = new Map<string, string>()
+  const resolved = await resolveIncludes(input.content, {
+    read: async (path) => {
+      const text = await input.readInclude!(path)
+      if (text !== null) texts.set(path, text)
+      return text
+    },
+  })
+  if (resolved.files.length === 0 && resolved.errors.length === 0) {
+    // Only unresolvable includes (URLs etc.): plain parse keeps the warnings.
+    return parseWorkspaceDocument(input)
+  }
+  return stitchWorkspaceDocument(input, resolved, texts)
+}
+
+/** Re-parse the root text of a multi-file workspace using the included
+ *  texts captured when it was loaded, so a code-pane edit produces the same
+ *  ids and provenance as a fresh open. An `!include` of a file that was not
+ *  loaded is reported as an error rather than read from disk. */
+export function restitchWorkspaceDocument(
+  rootText: string,
+  current: Workspace,
+  fallbackName?: string,
+): WorkspaceDocumentResult {
+  const files = new Map<string, string>()
+  for (const f of current.includedFiles ?? []) if (f.text !== undefined) files.set(f.path, f.text)
+  const resolved = resolveIncludesSync(rootText, { files })
+  const result = stitchWorkspaceDocument({ content: rootText, fallbackName }, resolved, files)
+  for (const path of resolved.needed) {
+    result.errors.push({ message: `!include ${path}: file was not loaded with this workspace — reopen it from the folder`, line: 1, column: 1 })
+  }
+  return result
 }

--- a/src/lib/workspaceDocument.ts
+++ b/src/lib/workspaceDocument.ts
@@ -63,7 +63,7 @@ export function stitchWorkspaceDocument(
   resolved: ResolveIncludesResult,
   texts: Map<string, string>,
 ): WorkspaceDocumentResult {
-  const { workspace, errors: rawErrors, warnings: rawWarnings, declarationLines, viewLines } = parseDSL(resolved.content)
+  const { workspace, errors: rawErrors, warnings: rawWarnings, declarationLines, viewLines, directiveLines, styleLines, themesLine } = parseDSL(resolved.content)
   if (!workspace.name && input.fallbackName) workspace.name = input.fallbackName
 
   // Provenance: map every declaration back to the file it was read from.
@@ -88,6 +88,18 @@ export function stitchWorkspaceDocument(
     const p = fileOf(line)
     if (p) view.sourcePath = p
   }
+  // Directives, styles and themes that live in an included file belong to
+  // it; re-emitting them into the root would duplicate (and mis-resolve) them.
+  workspace.directives?.forEach((d, i) => {
+    const p = fileOf(directiveLines[i])
+    if (p) d.sourcePath = p
+  })
+  for (const style of [...workspace.views.configuration.styles.elements, ...workspace.views.configuration.styles.relationships]) {
+    const p = fileOf(styleLines.get(style))
+    if (p) style.sourcePath = p
+  }
+  const themesPath = fileOf(themesLine)
+  if (themesPath) workspace.views.configuration.themesSourcePath = themesPath
 
   workspace.includedFiles = resolved.files.map((path) => classifyIncluded(path, texts.get(path) ?? '', resolved.scopes.get(path)))
 

--- a/src/store/included-readonly.test.ts
+++ b/src/store/included-readonly.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from './workspace'
+import { loadWorkspaceDocument } from '@/lib/workspaceDocument'
+
+const ROOT = `workspace "Org" {
+    model {
+        !include rw.dsl
+        !include ro.dsl
+        u = person "User"
+        u -> a "Uses"
+    }
+    views {
+        systemLandscape "Land" { include * }
+    }
+}`
+const read = async (p: string) => ({
+  // Has its own directive → read-only.
+  'ro.dsl': '!const X "1"\na = softwareSystem "A"\na -> b "Calls"\n',
+  'rw.dsl': 'b = softwareSystem "B"\n',
+})[p] ?? null
+
+function store() { return useWorkspaceStore.getState() }
+
+describe('read-only included content (TEA-325)', () => {
+  beforeEach(async () => {
+    const { workspace } = await loadWorkspaceDocument({ content: ROOT, readInclude: read })
+    store().loadWorkspace(workspace)
+  })
+
+  it('blocks edits to elements from a read-only file but allows writable and root ones', () => {
+    const before = store().undoStack.length
+    store().updateElement('a', { description: 'nope' })
+    expect(store().workspace!.model.softwareSystems.find((s) => s.id === 'a')!.description).toBeUndefined()
+    expect(store().undoStack.length).toBe(before)
+
+    store().updateElement('b', { description: 'yes' })
+    expect(store().workspace!.model.softwareSystems.find((s) => s.id === 'b')!.description).toBe('yes')
+    store().updateElement('u', { description: 'root' })
+    expect(store().workspace!.model.people[0].description).toBe('root')
+  })
+
+  it('never deletes read-only elements, even inside a mixed selection', () => {
+    store().deleteElements(['a', 'b'])
+    const ids = store().workspace!.model.softwareSystems.map((s) => s.id)
+    expect(ids).toEqual(['a'])
+  })
+
+  it('blocks relationship edits and deletes owned by a read-only file', () => {
+    const rel = store().workspace!.model.relationships.find((r) => r.description === 'Calls')!
+    store().updateRelationship(rel.id, { description: 'changed' })
+    expect(store().workspace!.model.relationships.find((r) => r.id === rel.id)!.description).toBe('Calls')
+    store().deleteRelationship(rel.id)
+    expect(store().workspace!.model.relationships.some((r) => r.id === rel.id)).toBe(true)
+
+    const rootRel = store().workspace!.model.relationships.find((r) => r.description === 'Uses')!
+    store().deleteRelationship(rootRel.id)
+    expect(store().workspace!.model.relationships.some((r) => r.id === rootRel.id)).toBe(false)
+  })
+
+  it('a code-pane apply of the root text keeps included content attached', () => {
+    const rootText = `workspace "Org" {
+    model {
+        !include rw.dsl
+        !include ro.dsl
+        u = person "User Renamed"
+        u -> a "Uses"
+    }
+    views {
+        systemLandscape "Land" { include * }
+    }
+}`
+    const result = store().replaceWorkspaceFromDSL(rootText)
+    expect(result.ok).toBe(true)
+    const ws = store().workspace!
+    expect(ws.model.people[0].name).toBe('User Renamed')
+    expect(ws.model.softwareSystems.map((s) => s.id).sort()).toEqual(['a', 'b'])
+    expect(ws.model.softwareSystems.find((s) => s.id === 'a')!.sourcePath).toBe('ro.dsl')
+    expect(ws.includedFiles?.map((f) => f.path)).toEqual(['rw.dsl', 'ro.dsl'])
+    expect(ws.model.relationships.map((r) => r.description).sort()).toEqual(['Calls', 'Uses'])
+  })
+})

--- a/src/store/included-readonly.test.ts
+++ b/src/store/included-readonly.test.ts
@@ -39,10 +39,12 @@ describe('read-only included content (TEA-325)', () => {
     expect(store().workspace!.model.people[0].description).toBe('root')
   })
 
-  it('never deletes read-only elements, even inside a mixed selection', () => {
+  it('never deletes read-only elements, nor elements a read-only file still references', () => {
+    // `a` is read-only; `b` is writable but ro.dsl declares `a -> b`, which
+    // would dangle if `b` went — and ro.dsl is never rewritten.
     store().deleteElements(['a', 'b'])
-    const ids = store().workspace!.model.softwareSystems.map((s) => s.id)
-    expect(ids).toEqual(['a'])
+    const ids = store().workspace!.model.softwareSystems.map((s) => s.id).sort()
+    expect(ids).toEqual(['a', 'b'])
   })
 
   it('blocks relationship edits and deletes owned by a read-only file', () => {

--- a/src/store/slices/element-slice.ts
+++ b/src/store/slices/element-slice.ts
@@ -114,7 +114,11 @@ export const createElementSlice: StateCreator<
       const tags = extraTag ? ['Element', 'Container', extraTag] : ['Element', 'Container']
       const finalName = uniqueElementName(name, ws)
       id = mintIdFor(ws, finalName)
+      // A child lives in its parent's file (TEA-325): inherit the source so
+      // the fragment write-back carries it; a read-only parent can't take it.
+      if (isReadOnlySource(ws, system.sourcePath)) { announce(`${system.name} is defined in a read-only file`); return }
       const container: Container = { id, type: 'container', idIsAuto: true, name: finalName, tags, properties: {}, components: [] }
+      if (system.sourcePath) container.sourcePath = system.sourcePath
       system.containers.push(container)
       // A container belongs ONLY in its own system's container views — never in
       // the active view if that view is scoped to a different system (that would
@@ -160,7 +164,9 @@ export const createElementSlice: StateCreator<
         pushUndoSnapshot(s)
         const finalName = uniqueElementName(name, ws)
         id = mintIdFor(ws, finalName)
+        if (isReadOnlySource(ws, container.sourcePath)) { announce(`${container.name} is defined in a read-only file`); return }
         const comp: Component = { id, type: 'component', idIsAuto: true, name: finalName, tags: ['Element', 'Component'], properties: {} }
+        if (container.sourcePath) comp.sourcePath = container.sourcePath
         container.components.push(comp)
         // A component belongs ONLY in its own container's component views (not in
         // a different container's active view). Add to every component view
@@ -264,7 +270,14 @@ export const createElementSlice: StateCreator<
       if (!s.workspace) return
       // Never delete content owned by a read-only included file (TEA-325).
       const ws = s.workspace
-      const deletable = ids.filter((id) => !isReadOnlySource(ws, findElementHelper(ws, id)?.sourcePath))
+      // …and content a read-only file still points at: deleting it would leave
+      // that file (which is never rewritten) with a dangling reference.
+      const pinnedByReadOnlyRel = new Set<string>()
+      for (const r of ws.model.relationships) {
+        if (isReadOnlySource(ws, r.sourcePath)) { pinnedByReadOnlyRel.add(r.sourceId); pinnedByReadOnlyRel.add(r.destinationId) }
+      }
+      const deletable = ids.filter((id) => !isReadOnlySource(ws, findElementHelper(ws, id)?.sourcePath) && !pinnedByReadOnlyRel.has(id))
+      if (deletable.length < ids.length) announce('Some elements are defined in, or referenced by, a read-only included file and were kept')
       if (deletable.length === 0) return
       ids = deletable
       pushUndoSnapshot(s)

--- a/src/store/slices/element-slice.ts
+++ b/src/store/slices/element-slice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand'
+import { isReadOnlySource } from '@/lib/includeWriteback'
 import type { WorkspaceState } from '../workspace-types'
 import type { Person, SoftwareSystem, Container, Component, Workspace } from '@/types/model'
 import { announce } from '@/lib/announce'
@@ -261,6 +262,11 @@ export const createElementSlice: StateCreator<
     if (ids.length === 0) return
     set((s) => {
       if (!s.workspace) return
+      // Never delete content owned by a read-only included file (TEA-325).
+      const ws = s.workspace
+      const deletable = ids.filter((id) => !isReadOnlySource(ws, findElementHelper(ws, id)?.sourcePath))
+      if (deletable.length === 0) return
+      ids = deletable
       pushUndoSnapshot(s)
       cascadeDeleteElements(s.workspace, ids)
       // If the active view was among the ones just removed, fall back to the first remaining view.

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -7,6 +7,9 @@ import { checkModelIntegrity } from '@/lib/modelIntegrity'
 import { pushUndoSnapshot } from '../internals'
 import { normalizeWorkspaceShape, allViewsOf, findViewHelper, forEachElementHelper, clearSelectionDraft } from '../workspace-helpers'
 import { getFirstViewKey } from '../workspace-selectors'
+import { hasIncludedFiles } from '@/lib/includeWriteback'
+import { restitchWorkspaceDocument } from '@/lib/workspaceDocument'
+
 
 /** Map element id -> element name for every element in the model tree. */
 function elementNamesById(ws: Workspace): Map<string, string> {
@@ -193,7 +196,12 @@ export const createLifecycleSlice: StateCreator<
     let errors: ReturnType<WorkspaceState['replaceWorkspaceFromDSL']>['errors']
     let warnings: ReturnType<WorkspaceState['replaceWorkspaceFromDSL']>['errors'] = []
     try {
-      ;({ workspace: parsed, errors, warnings } = parseDSL(text))
+      const currentWs = get().workspace!
+      // A multi-file workspace: the pane shows the root file, so re-stitch
+      // the included texts captured at load before parsing (TEA-325).
+      ;({ workspace: parsed, errors, warnings } = hasIncludedFiles(currentWs)
+        ? restitchWorkspaceDocument(text, currentWs, currentWs.name)
+        : parseDSL(text))
     } catch (err) {
       return {
         ok: false,

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -191,8 +191,9 @@ export const createLifecycleSlice: StateCreator<
     // error, never escape into the caller's timer callback.
     let parsed: Workspace
     let errors: ReturnType<WorkspaceState['replaceWorkspaceFromDSL']>['errors']
+    let warnings: ReturnType<WorkspaceState['replaceWorkspaceFromDSL']>['errors'] = []
     try {
-      ;({ workspace: parsed, errors } = parseDSL(text))
+      ;({ workspace: parsed, errors, warnings } = parseDSL(text))
     } catch (err) {
       return {
         ok: false,
@@ -245,7 +246,7 @@ export const createLifecycleSlice: StateCreator<
       clearSelectionDraft(s)
       s.scopeViolations = validateScope(parsed)
     })
-    return { ok: true, errors: [] }
+    return { ok: true, errors: [], warnings }
   },
 
   updateWorkspaceMeta: (patch) => set((s) => {

--- a/src/store/slices/relationship-slice.ts
+++ b/src/store/slices/relationship-slice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand'
+import { isReadOnlySource } from '@/lib/includeWriteback'
 import type { WorkspaceState } from '../workspace-types'
 import type { Relationship, View, Workspace } from '@/types/model'
 import { nanoid, pushUndoSnapshot } from '../internals'
@@ -97,6 +98,7 @@ export const createRelationshipSlice: StateCreator<
     if (!s.workspace) return
     const rel = s.workspace.model.relationships.find(r => r.id === id)
     if (!rel) return
+    if (isReadOnlySource(s.workspace, rel.sourcePath)) return
     // Use 'key in patch' for optional fields that the UI may legitimately clear by passing
     // undefined (e.g. empty text field → { description: undefined }). Only push undo if at
     // least one field actually changed.
@@ -165,7 +167,9 @@ export const createRelationshipSlice: StateCreator<
   deleteRelationship: (id) => set((s) => {
     if (!s.workspace) return
     const ws = s.workspace
-    if (!ws.model.relationships.some(r => r.id === id)) return
+    const target = ws.model.relationships.find(r => r.id === id)
+    if (!target) return
+    if (isReadOnlySource(ws, target.sourcePath)) return
     pushUndoSnapshot(s)
     ws.model.relationships = ws.model.relationships.filter(r => r.id !== id)
     forEachView(ws, (v) => {

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -1,3 +1,4 @@
+import { isReadOnlySource } from '@/lib/includeWriteback'
 import { current, isDraft } from 'immer'
 import type {
   Workspace, View, ModelElement, Person, SoftwareSystem, Container, Component,
@@ -110,6 +111,9 @@ export function applyElementPatch(ws: Workspace, id: string, patch: ElementPatch
   let changed = false
   forEachElementHelper(ws, (el) => {
     if (el.id !== id) return false
+    // Content from a read-only included file is shown but never edited: the
+    // edit would be dropped on save (TEA-325).
+    if (isReadOnlySource(ws, el.sourcePath)) return true
     // Use 'key in patch' for fields that can be legitimately cleared to undefined.
     // This distinguishes { status: undefined } (clear) from {} (leave unchanged),
     // which matters because the UI passes { status: undefined } when the user

--- a/src/store/workspace-helpers.ts
+++ b/src/store/workspace-helpers.ts
@@ -515,6 +515,15 @@ export function appendScopedView(
  * Returns the array of newly-created element IDs (in the order they were
  * created). Empty array means no elements were duplicated.
  */
+/** The system or container that directly holds `id` (undefined for top-level). */
+export function findParentHelper(ws: Workspace, id: string): SoftwareSystem | Container | undefined {
+  for (const sys of ws.model.softwareSystems) {
+    if (sys.containers.some((c) => c.id === id)) return sys
+    for (const c of sys.containers) if (c.components.some((x) => x.id === id)) return c
+  }
+  return undefined
+}
+
 export function duplicateElementsInTree(
   ws: Workspace,
   ids: string[],
@@ -667,6 +676,20 @@ export function duplicateElementsInTree(
   // possibly relationships); evict the stale id→element index so the next
   // reader rebuilds it against the post-mutation tree.
   invalidateElementIndex(ws)
+  // Provenance (TEA-325): a top-level copy is new root content; a nested copy
+  // lives wherever its parent lives.
+  const setSubtree = (el: ModelElement, path: string | undefined) => {
+    if (path) el.sourcePath = path
+    else delete el.sourcePath
+    if (el.type === 'softwareSystem') for (const c of el.containers) setSubtree(c, path)
+    if (el.type === 'container') for (const x of el.components) setSubtree(x, path)
+  }
+  for (const newId of newIds) {
+    const copy = findElementHelper(ws, newId)
+    if (!copy) continue
+    if (copy.type === 'person' || copy.type === 'softwareSystem') { setSubtree(copy, undefined); continue }
+    setSubtree(copy, findParentHelper(ws, newId)?.sourcePath)
+  }
   return newIds
 }
 

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -155,7 +155,7 @@ export interface WorkspaceState extends UndoState {
    *  A successful apply is ONE undo entry and carries per-view element layout
    *  (x/y/pinned/locked + view locks) over from the current workspace for every
    *  view key + element id that survives the edit. */
-  replaceWorkspaceFromDSL: (text: string) => { ok: boolean; errors: ParseError[] }
+  replaceWorkspaceFromDSL: (text: string) => { ok: boolean; errors: ParseError[]; warnings?: ParseError[] }
 
   // Navigation
   setActiveView: (key: string) => void

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -35,6 +35,13 @@ export interface BaseElement {
   url?: string
   status?: ElementStatus
   owner?: string
+  /** `!` directive lines written inside this element's block (e.g. an
+   *  `!include` of its containers). Preserved verbatim, re-emitted first. */
+  directives?: string[]
+  /** Path (relative to the root workspace file) of the included file that
+   *  declared this element. Absent for root-owned content. Never serialized
+   *  into DSL; used to route writes and to mark read-only sources (TEA-325). */
+  sourcePath?: string
 }
 
 export interface Person extends BaseElement {
@@ -67,6 +74,8 @@ export interface Group {
    *  Older c4hero workspaces omit this; strict subset membership still lets
    *  the serializer infer their hierarchy. */
   parentId?: string
+  /** See BaseElement.sourcePath. */
+  sourcePath?: string
 }
 
 export type ModelElement = Person | SoftwareSystem | Container | Component
@@ -114,6 +123,8 @@ export interface DeploymentEnvironment {
   id: string
   name: string
   deploymentNodes: DeploymentNode[]
+  /** See BaseElement.sourcePath. */
+  sourcePath?: string
 }
 
 export type DeploymentElement =
@@ -135,6 +146,8 @@ export interface Relationship {
   url?: string
   tags: string[]
   properties: Record<string, string>
+  /** See BaseElement.sourcePath. */
+  sourcePath?: string
 }
 
 // ─── Views ───────────────────────────────────────────────────────────
@@ -184,6 +197,8 @@ export interface AutoLayout {
 export interface View {
   type: ViewType
   key: string
+  /** See BaseElement.sourcePath. */
+  sourcePath?: string
   /** True when `key` was synthesised by the parser because the DSL omitted one.
    *  The serializer skips emitting auto keys so the source DSL roundtrips
    *  byte-identical for views without explicit keys. */
@@ -264,12 +279,28 @@ export interface WorkspaceDirective {
   raw: string
 }
 
+export interface IncludedFile {
+  /** Path relative to the root workspace file, as written in `!include`. */
+  path: string
+  /** True when c4hero can write this file back as a plain model fragment. */
+  writable: boolean
+  /** Why it is read-only, for the UI. */
+  reason?: string
+  /** The file's text as read at load time. Lets the code pane re-stitch the
+   *  full document without touching disk. */
+  text?: string
+}
+
 export interface Workspace {
   name?: string
   description?: string
   scope?: WorkspaceScope
   /** Preserved preprocessor directives (TEA-325 phase A). Absent when none. */
   directives?: WorkspaceDirective[]
+  /** Files pulled in through `!include` when this workspace was loaded from a
+   *  folder (TEA-325 phase B). Content from a writable file is saved back to
+   *  that file; a read-only file's content is shown but never modified. */
+  includedFiles?: IncludedFile[]
   model: Model
   views: {
     systemLandscapeViews: View[]

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -227,6 +227,8 @@ export interface View {
 
 export interface ElementStyle {
   tag: string
+  /** See BaseElement.sourcePath. */
+  sourcePath?: string
   background?: string
   color?: string
   shape?: string
@@ -240,6 +242,8 @@ export interface ElementStyle {
 
 export interface RelationshipStyle {
   tag: string
+  /** See BaseElement.sourcePath. */
+  sourcePath?: string
   color?: string
   thickness?: number
   dashed?: boolean
@@ -253,6 +257,8 @@ export interface ViewConfiguration {
     relationships: RelationshipStyle[]
   }
   themes?: string[]
+  /** File the `themes` line came from, when `!include`d. */
+  themesSourcePath?: string
 }
 
 // ─── Model ───────────────────────────────────────────────────────────
@@ -277,6 +283,16 @@ export interface WorkspaceDirective {
   scope: 'workspace' | 'model' | 'views'
   /** The whole line as written, trimmed. */
   raw: string
+  /** Model scope only: the group block the line was written in. */
+  groupId?: string
+  /** Model scope only: id of the element / environment / group declared just
+   *  before this line in the same block. The serializer re-emits the line
+   *  right after that declaration, so a `!include` that references earlier
+   *  root content keeps its single-pass ordering. Absent = top of the block. */
+  after?: string
+  /** Set when the line came from an `!include`d file; never re-emitted into
+   *  the root. See BaseElement.sourcePath. */
+  sourcePath?: string
 }
 
 export interface IncludedFile {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -254,10 +254,22 @@ export interface Model {
 
 export type WorkspaceScope = 'softwaresystem' | 'landscape' | 'none'
 
+/** A `!` preprocessor line (`!include`, `!const`, `!var`, `!identifiers`,
+ *  `!docs`, `!adrs`, …) that c4hero does not evaluate but must never lose.
+ *  Kept verbatim and re-emitted at the top of the block it came from, in
+ *  original order. */
+export interface WorkspaceDirective {
+  scope: 'workspace' | 'model' | 'views'
+  /** The whole line as written, trimmed. */
+  raw: string
+}
+
 export interface Workspace {
   name?: string
   description?: string
   scope?: WorkspaceScope
+  /** Preserved preprocessor directives (TEA-325 phase A). Absent when none. */
+  directives?: WorkspaceDirective[]
   model: Model
   views: {
     systemLandscapeViews: View[]


### PR DESCRIPTION
## Summary

[TEA-325](https://linear.app/kevnord/issue/TEA-325) phases A and B, as two commits on one branch.

### Phase A — never lose a directive (the data-loss fix)

The parser consumed every `!` preprocessor line and discarded it, so saving a workspace that used `!include` (or `!const`, `!var`, `!docs`, `!adrs`) silently deleted those lines.

- Every `!` keyword now carries the rest of its line; the parser records each as `{ scope: 'workspace' | 'model' | 'views', raw }` in source order, plus element-body directives on the element itself. The serializer re-emits them at the top of their block (or element block), ahead of generated content. A second round trip is byte-identical.
- `!identifiers` is consumed, not preserved: c4hero always writes flat identifiers, so re-emitting `hierarchical` made Structurizr reject the references we write. The real-CLI conformance suite caught this on the first run.
- New `warnings` channel on the parse result; the code pane footer shows "N directives preserved, not resolved".

### Phase B — multi-file workspaces

When a folder is open, `!include <relative path>` is resolved and the stitched model is rendered.

- **Resolver** (`src/lib/dsl/includeResolver.ts`): pure and injectable. Keeps each `!include` line (so saves still write it) and splices the file's text after it, with a source map. Recursive, relative to the including file. Cycles, missing files, depth > 10, > 50 files and > 10 MB are errors with the file and line; URLs, absolute paths and `..` escapes are left in place. Sync core + async wrapper.
- **Provenance**: the parser now records declaration lines; every element, relationship, group, view and deployment environment from an included file gets `sourcePath`. Parse errors inside an included file are prefixed `path:line:`. The inspector shows *Defined in teams/payments.dsl*.
- **Saves never flatten**: the serializer gains `source: null` (root-owned content plus the include lines) and `source: <path>` (a bare model fragment). Autosave and manual saves use the root form; each writable included file is written back as a fragment, only when its content changed.
- **Read-only sources**: a file included inside an element or the views block, one with its own `!` directives, or one wrapped in `model { }` can't be routed back yet. Its content is shown, the inspector marks it read-only, and the store refuses element/relationship edits and deletes on it rather than dropping them at save time.
- **Code pane**: applies re-stitch the included texts captured at load, so ids and provenance match a fresh open and a pane edit can't drop included content.
- Single-file opens (no folder handle) and the disk watcher's included files are out of scope; includes there stay preserved-but-unresolved with the warning.

## Test plan

- [x] `npm run check` green (2645 tests)
- [x] Full Playwright suite: 183 passed
- [x] `test:conformance` against the real Structurizr CLI passes
- [x] New: `directives-roundtrip.test.ts`, `includeResolver.test.ts` (splice + source map, nested, cycle, missing, caps, unresolved forms, element scope), `workspaceDocument.include.test.ts` (provenance, classification, error relocation, root/fragment partition, fragments re-stitch to the same model), `included-readonly.test.ts` (store guards, code-pane apply keeps included content)
- [ ] Manual: open a folder with a root `workspace.dsl` including two team files; edit a team element; confirm only that team's file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs