### PR TITLE
test(dsl): generated conformance corpus against the real Structurizr parser (TEA-63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A property with an empty value no longer makes the saved file invalid.**
+  Structurizr rejects `"key" ""` ("A property value must be specified"), so
+  an element or relationship carrying an empty property produced DSL the
+  real parser refused. Such entries are now left out on save, the same way
+  a trailing backslash is, and an element whose only properties were empty
+  no longer gets an empty block. Found by the new generated conformance
+  corpus. (TEA-63)
+
 ## [0.6.0] - 2026-09-10
 
 ### Added

--- a/src/lib/dsl/fuzz/generateWorkspace.ts
+++ b/src/lib/dsl/fuzz/generateWorkspace.ts
@@ -1,0 +1,295 @@
+// Deterministic workspace generator for the conformance corpus (TEA-63).
+//
+// Seeded, so a failing case is reproducible by seed number. Every string
+// pool below is a thing Structurizr's tokenizer or c4hero's serializer has
+// treated specially at some point: quotes, backslashes in every position,
+// newlines, tabs, commas (tag separators), comment openers, braces, arrows,
+// keywords used as names, empty and whitespace-only values, unicode.
+//
+// The generator stays inside what Structurizr accepts structurally (no
+// self-relationships, disjoint groups, unique ids, view keys limited to the
+// characters Structurizr allows — TEA-166 tracks keys that aren't). What it
+// pushes on is the *content*: the shapes c4hero's own round-trip tests never
+// think to write.
+
+import type {
+  Workspace, Person, SoftwareSystem, Container, Component, Relationship, Group, View,
+  ElementStyle, RelationshipStyle, ElementStatus, Location, InteractionStyle, LineStyle,
+} from '@/types/model'
+
+/** mulberry32 — small, fast, good enough for test data. */
+export function rng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const PLAIN = ['Payments', 'Identity', 'Web App', 'Mobile', 'Ledger', 'Notifier', 'Search', 'Gateway', 'Reporting', 'Audit']
+const HOSTILE = [
+  'Say "hi"',                       // quote
+  'C:\\Program Files',              // interior backslash
+  'Shared Folder X:\\',             // trailing backslash (unrepresentable → dropped)
+  'see "manual\\"',                 // backslash before quote (representable)
+  'literal \\n not newline',        // backslash before n (unrepresentable → dropped)
+  'two\nlines',                     // real newline
+  'tab\there',                      // real tab
+  'has,comma',                      // comma — splits tags
+  'looks like // a comment',        // comment opener inside a string
+  'hash # inside',                  // other comment opener
+  'braces { and }',                 // block delimiters
+  'arrow -> here',                  // relationship operator
+  'model',                          // keyword as a name
+  'views',
+  'group',
+  '!include evil.dsl',              // directive as a name
+  '  padded  ',                     // surrounding whitespace
+  'ünïcödé ✓ 日本語',               // non-ASCII
+  'very long name '.repeat(12).trim(),
+  "it's",                           // apostrophe
+  '"',                              // a lone quote
+  '\\',                             // a lone backslash (unrepresentable → dropped)
+  'a\\\\b',                         // two backslashes
+]
+const TECH = ['Go', 'Spring Boot', 'Node.js', 'Postgres 16', 'C++/CLI', 'F#', 'Kafka 3.x', 'HTTP/2']
+const TAGS = ['critical', 'legacy', 'team-a', 'PCI', 'has,comma', 'has"quote', 'spaced tag', 'Tag\\Back']
+const OWNERS = ['Platform Team', 'Team "Blue"', 'ops\\infra', '']
+// Structurizr validates urls (java.net.URL), so only well-formed ones here.
+// c4hero accepting any string in the url field is a product gap (TEA-169).
+const URLS = ['https://example.com/x', 'https://example.com/a?b=c&d=%22e%22', 'https://例え.jp/path']
+const COLOURS = ['#ff0000', '#08427b', '#999999', '#1168bd']
+const SHAPES = ['Box', 'RoundedBox', 'Cylinder', 'Person', 'Hexagon']
+
+export interface GenerateOptions {
+  /** Include hostile strings (default true). */
+  hostile?: boolean
+  /** Upper bounds. */
+  maxPeople?: number
+  maxSystems?: number
+  maxContainers?: number
+  maxComponents?: number
+}
+
+export function generateWorkspace(seed: number, opts: GenerateOptions = {}): Workspace {
+  const r = rng(seed)
+  const int = (max: number) => Math.floor(r() * (max + 1))
+  const pick = <T,>(xs: readonly T[]): T => xs[Math.floor(r() * xs.length)]
+  const chance = (p: number) => r() < p
+  const hostile = opts.hostile ?? true
+  const str = (plainOnly = false) => (!plainOnly && hostile && chance(0.4) ? pick(HOSTILE) : pick(PLAIN))
+  // Structurizr requires a non-empty element name, so names avoid strings
+  // that encode to nothing (a lone or trailing backslash). What c4hero should
+  // do with such a name in the inspector is TEA-169's territory.
+  const NAMEABLE = HOSTILE.filter((h) => representable(h).length > 0)
+  const nameStr = () => (hostile && chance(0.4) ? pick(NAMEABLE) : pick(PLAIN))
+  const maybe = <T,>(p: number, v: () => T): T | undefined => (chance(p) ? v() : undefined)
+  const tags = (defaults: string[]) => {
+    const extra = new Set<string>()
+    const n = int(2)
+    for (let i = 0; i < n; i++) extra.add(hostile ? pick(TAGS) : pick(TAGS.slice(0, 4)))
+    return [...defaults, ...extra]
+  }
+  const props = (): Record<string, string> => {
+    const out: Record<string, string> = {}
+    const n = int(2)
+    for (let i = 0; i < n; i++) out[chance(0.3) && hostile ? pick(['key with space', 'key"q', 'k.dotted', 'key,comma']) : `k${i}`] = str()
+    return out
+  }
+  let seq = 0
+  const id = (prefix: string) => `${prefix}${++seq}`
+  // Structurizr requires unique names among siblings (people + systems at the
+  // top level, containers within a system, components within a container).
+  const uniqueName = (taken: Set<string>) => {
+    let name = nameStr()
+    let n = 2
+    while (taken.has(name)) name = `${nameStr()} ${n++}`
+    taken.add(name)
+    return name
+  }
+  const topNames = new Set<string>()
+
+  const base = (prefix: string, defaults: string[], taken: Set<string>) => ({
+    id: id(prefix),
+    name: uniqueName(taken),
+    description: maybe(0.7, () => str()),
+    tags: tags(defaults),
+    properties: props(),
+    url: maybe(0.2, () => pick(URLS)),
+    status: maybe(0.3, () => pick(['Live', 'Planned', 'Deprecated', 'Removed'] as ElementStatus[])),
+    owner: maybe(0.3, () => pick(OWNERS)),
+  })
+
+  const people: Person[] = []
+  for (let i = 0, n = int(opts.maxPeople ?? 3); i < n; i++) {
+    people.push({ ...base('p', ['Element', 'Person'], topNames), type: 'person', location: maybe(0.3, () => pick(['Internal', 'External', 'Unspecified'] as Location[])) })
+  }
+  const systems: SoftwareSystem[] = []
+  for (let i = 0, n = 1 + int((opts.maxSystems ?? 4) - 1); i < n; i++) {
+    const external = chance(0.2)
+    const containers: Container[] = []
+    const containerNames = new Set<string>()
+    // External systems may not have containers (integrity rule).
+    if (!external) {
+      for (let j = 0, m = int(opts.maxContainers ?? 3); j < m; j++) {
+        const components: Component[] = []
+        const componentNames = new Set<string>()
+        for (let k = 0, o = int(opts.maxComponents ?? 2); k < o; k++) {
+          components.push({ ...base('comp', ['Element', 'Component'], componentNames), type: 'component', technology: maybe(0.6, () => pick(TECH)) })
+        }
+        containers.push({ ...base('c', ['Element', 'Container'], containerNames), type: 'container', technology: maybe(0.7, () => pick(TECH)), components })
+      }
+    }
+    systems.push({
+      ...base('sys', ['Element', 'Software System'], topNames),
+      type: 'softwareSystem',
+      location: external ? 'External' : maybe(0.3, () => pick(['Internal', 'Unspecified'] as Location[])),
+      containers,
+    })
+  }
+
+  // Every element, for relationships and views.
+  const all: { id: string; kind: 'person' | 'softwareSystem' | 'container' | 'component'; parent?: string }[] = []
+  for (const p of people) all.push({ id: p.id, kind: 'person' })
+  for (const s of systems) {
+    all.push({ id: s.id, kind: 'softwareSystem' })
+    for (const c of s.containers) {
+      all.push({ id: c.id, kind: 'container', parent: s.id })
+      for (const comp of c.components) all.push({ id: comp.id, kind: 'component', parent: c.id })
+    }
+  }
+
+  const relationships: Relationship[] = []
+  const seenPairs = new Set<string>()
+  for (let i = 0, n = int(Math.min(6, all.length * 2)); i < n && all.length > 1; i++) {
+    const a = pick(all), b = pick(all)
+    if (a.id === b.id) continue
+    // Structurizr rejects a relationship between an element and any of its
+    // ancestors or descendants ("Relationships cannot be added between
+    // parents and children").
+    const ancestors = (e: typeof a) => {
+      const out = new Set<string>()
+      let cur = e.parent
+      while (cur) { out.add(cur); cur = all.find((x) => x.id === cur)?.parent }
+      return out
+    }
+    if (ancestors(a).has(b.id) || ancestors(b).has(a.id)) continue
+    // Structurizr (impliedRelationships on by default) derives a relationship
+    // between every ancestor pair of a relationship's ends, and then rejects
+    // an explicit duplicate of one ("already exists"). Reserve the whole
+    // ancestor lattice of each pair so no later pick collides with an
+    // implied one.
+    const key = `${a.id}->${b.id}`
+    if (seenPairs.has(key)) continue
+    for (const A of [a.id, ...ancestors(a)]) for (const B of [b.id, ...ancestors(b)]) seenPairs.add(`${A}->${B}`)
+    relationships.push({
+      id: id('rel'),
+      sourceId: a.id,
+      destinationId: b.id,
+      description: maybe(0.8, () => str()),
+      technology: maybe(0.5, () => pick(TECH)),
+      tags: tags(['Relationship']),
+      properties: props(),
+      interactionStyle: maybe(0.3, () => pick(['Synchronous', 'Asynchronous'] as InteractionStyle[])),
+      lineStyle: maybe(0.3, () => pick(['Curved', 'Straight', 'Orthogonal'] as LineStyle[])),
+      url: maybe(0.15, () => pick(URLS)),
+    })
+  }
+
+  // Disjoint top-level groups over people + systems.
+  const groups: Group[] = []
+  if (chance(0.5) && people.length + systems.length >= 2) {
+    const pool = [...people.map((p) => p.id), ...systems.map((s) => s.id)]
+    const n = 1 + int(1)
+    for (let g = 0; g < n && pool.length > 0; g++) {
+      const take = 1 + int(Math.max(0, pool.length - 1))
+      const members = pool.splice(0, take)
+      groups.push({ id: id('grp'), name: str(), elementIds: members })
+    }
+  }
+
+  // Views: landscape always; context + container per system (sometimes);
+  // component per container (sometimes). Keys stay within Structurizr's
+  // allowed characters.
+  const views: Workspace['views'] = {
+    systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [],
+    dynamicViews: [], deploymentViews: [],
+    configuration: { styles: { elements: [], relationships: [] } },
+  }
+  const viewCommon = (key: string): Pick<View, 'key' | 'title' | 'description' | 'autoLayout' | 'relationships'> => ({
+    key,
+    title: maybe(0.5, () => str()),
+    description: maybe(0.3, () => str()),
+    autoLayout: maybe(0.5, () => ({ direction: pick(['TB', 'BT', 'LR', 'RL'] as const) })),
+    relationships: [],
+  })
+  const explicitOrStar = (ids: string[]) => (chance(0.5) ? [{ id: '*' }] : ids.filter(() => chance(0.7)).map((i) => ({ id: i })))
+  views.systemLandscapeViews.push({
+    ...viewCommon('Landscape'),
+    type: 'systemLandscape',
+    elements: explicitOrStar(all.filter((e) => e.kind === 'person' || e.kind === 'softwareSystem').map((e) => e.id)),
+  })
+  for (const s of systems) {
+    if (chance(0.6)) {
+      views.systemContextViews.push({
+        ...viewCommon(`Ctx-${s.id}`), type: 'systemContext', softwareSystemId: s.id,
+        elements: explicitOrStar(all.filter((e) => e.kind !== 'container' && e.kind !== 'component').map((e) => e.id)),
+      })
+    }
+    if (s.containers.length > 0 && chance(0.7)) {
+      views.containerViews.push({
+        ...viewCommon(`Cont-${s.id}`), type: 'container', softwareSystemId: s.id,
+        elements: explicitOrStar(s.containers.map((c) => c.id)),
+      })
+      for (const c of s.containers) {
+        if (c.components.length > 0 && chance(0.5)) {
+          views.componentViews.push({
+            ...viewCommon(`Comp-${c.id}`), type: 'component', containerId: c.id,
+            elements: explicitOrStar(c.components.map((x) => x.id)),
+          })
+        }
+      }
+    }
+  }
+
+  // Styles keyed on a mix of built-in and generated tags.
+  const styleTags = ['Person', 'Software System', 'Container', 'Component', ...TAGS]
+  for (let i = 0, n = int(3); i < n; i++) {
+    const style: ElementStyle = { tag: pick(styleTags) }
+    if (chance(0.7)) style.background = pick(COLOURS)
+    if (chance(0.5)) style.color = pick(COLOURS)
+    if (chance(0.5)) style.shape = pick(SHAPES)
+    if (chance(0.3)) style.fontSize = 10 + int(20)
+    if (chance(0.2)) style.opacity = int(100)
+    views.configuration.styles.elements.push(style)
+  }
+  for (let i = 0, n = int(2); i < n; i++) {
+    const style: RelationshipStyle = { tag: pick(['Relationship', ...TAGS]) }
+    if (chance(0.7)) style.color = pick(COLOURS)
+    if (chance(0.5)) style.thickness = 1 + int(4)
+    if (chance(0.5)) style.dashed = chance(0.5)
+    views.configuration.styles.relationships.push(style)
+  }
+
+  return {
+    name: chance(0.15) && hostile ? pick(HOSTILE) : `Generated ${seed}`,
+    description: maybe(0.5, () => str()),
+    model: { people, softwareSystems: systems, relationships, groups, deploymentEnvironments: [] },
+    views,
+  }
+}
+
+/** What a string becomes after the serializer's unrepresentable-backslash
+ *  rules: a backslash before `n` or at the end of the value is dropped. Every
+ *  other character survives Structurizr byte-for-byte. */
+export function representable(s: string): string {
+  return s.replace(/\\+(?=n)/g, '').replace(/\\+$/, '')
+}
+
+/** A tag after the serializer's comma stripping and backslash rules. */
+export function representableTag(t: string): string {
+  return representable(t.replace(/,/g, ''))
+}

--- a/src/lib/dsl/generated-roundtrip.test.ts
+++ b/src/lib/dsl/generated-roundtrip.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Secondary invariant for TEA-63: c4hero agrees with itself across a
+ * generated corpus. `parse(serialize(x))` must have no errors, re-serialize
+ * byte-identically, and keep every value the serializer can represent.
+ *
+ * This is deliberately NOT the conformance gate — both sides are c4hero.
+ * structurizr-conformance.test.ts runs the same corpus through the real
+ * Structurizr CLI. This file exists so a regression in c4hero's own
+ * round-trip shows up on a bare checkout, with a seed to reproduce it.
+ */
+import { describe, it, expect } from 'vitest'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+import { generateWorkspace, representable, representableTag } from './fuzz/generateWorkspace'
+import type { Workspace } from '@/types/model'
+
+const SEEDS = Number(process.env.ROUNDTRIP_SEEDS ?? 200)
+
+interface Flat {
+  kind: string
+  name: string
+  description: string
+  technology: string
+  status: string
+  owner: string
+  external: boolean
+  tags: string[]
+  properties: Record<string, string>
+  url: string
+}
+
+/** Every element flattened to the values the serializer promises to keep,
+ *  normalised for the documented unrepresentable cases. */
+function flatten(ws: Workspace, normalise: boolean): Flat[] {
+  const norm = (s: string | undefined) => (normalise ? representable(s ?? '') : (s ?? ''))
+  const normTags = (tags: string[], defaults: string[]) =>
+    tags.filter((t) => !defaults.includes(t)).map((t) => (normalise ? representableTag(t) : t)).filter(Boolean).sort()
+  // Empty keys/values are unrepresentable in Structurizr and dropped on save.
+  const normProps = (p: Record<string, string>) =>
+    Object.fromEntries(Object.entries(p).map(([k, v]) => [norm(k), norm(v)]).filter(([k, v]) => !normalise || (k && v)))
+  const out: Flat[] = []
+  const push = (kind: string, el: { name: string; description?: string; technology?: string; status?: string; owner?: string; location?: string; tags: string[]; properties: Record<string, string>; url?: string }, defaults: string[]) => {
+    out.push({
+      kind, name: norm(el.name), description: norm(el.description), technology: norm(el.technology),
+      status: el.status ?? '', owner: norm(el.owner), external: el.location === 'External',
+      tags: normTags(el.tags, defaults), properties: normProps(el.properties), url: norm(el.url),
+    })
+  }
+  for (const p of ws.model.people) push('person', p, ['Element', 'Person'])
+  for (const s of ws.model.softwareSystems) {
+    push('softwareSystem', s, ['Element', 'Software System'])
+    for (const c of s.containers) {
+      push('container', c, ['Element', 'Container'])
+      for (const comp of c.components) push('component', comp, ['Element', 'Component'])
+    }
+  }
+  return out.sort((a, b) => `${a.kind}:${a.name}:${a.description}`.localeCompare(`${b.kind}:${b.name}:${b.description}`))
+}
+
+function flattenRelationships(ws: Workspace, normalise: boolean) {
+  const norm = (s: string | undefined) => (normalise ? representable(s ?? '') : (s ?? ''))
+  return ws.model.relationships
+    .map((r) => ({
+      description: norm(r.description), technology: norm(r.technology),
+      interactionStyle: r.interactionStyle ?? '', lineStyle: r.lineStyle ?? '', url: norm(r.url),
+      tags: r.tags.filter((t) => t !== 'Relationship').map((t) => (normalise ? representableTag(t) : t)).filter(Boolean).sort(),
+      properties: Object.fromEntries(Object.entries(r.properties).map(([k, v]) => [norm(k), norm(v)]).filter(([k, v]) => !normalise || (k && v))),
+    }))
+    .sort((a, b) => `${a.description}:${a.technology}`.localeCompare(`${b.description}:${b.technology}`))
+}
+
+describe('generated corpus round-trips through c4hero (TEA-63)', () => {
+  const seeds = Array.from({ length: SEEDS }, (_, i) => i + 1)
+
+  it.each(seeds)('seed %i: parse(serialize(x)) is clean, idempotent and value-preserving', (seed) => {
+    const ws = generateWorkspace(seed)
+    const dsl = serializeDSL(ws)
+    const { workspace: parsed, errors } = parseDSL(dsl)
+    expect(errors, `seed ${seed} parse errors:\n${dsl}`).toEqual([])
+
+    // Idempotent from the second pass on. The first parse expands `include *`
+    // into an explicit list (keeping the expression is TEA-326), so compare
+    // serialize(parse(serialize(parse(dsl)))) with serialize(parse(dsl)).
+    const once = serializeDSL(parsed)
+    const { workspace: reparsed, errors: errors2 } = parseDSL(once)
+    expect(errors2, `seed ${seed} second-pass parse errors`).toEqual([])
+    expect(serializeDSL(reparsed), `seed ${seed} not idempotent`).toBe(once)
+
+    // Value fidelity, modulo the documented unrepresentable cases.
+    expect(flatten(parsed, false), `seed ${seed} element values drifted`).toEqual(flatten(ws, true))
+    expect(flattenRelationships(parsed, false), `seed ${seed} relationship values drifted`).toEqual(flattenRelationships(ws, true))
+
+    // Structure.
+    expect(parsed.model.relationships.length).toBe(ws.model.relationships.length)
+    expect(parsed.model.groups.map((g) => g.elementIds.length).sort()).toEqual(ws.model.groups.map((g) => g.elementIds.length).sort())
+    const keys = (w: Workspace) => [
+      ...w.views.systemLandscapeViews, ...w.views.systemContextViews, ...w.views.containerViews, ...w.views.componentViews,
+    ].map((v) => v.key).sort()
+    expect(keys(parsed)).toEqual(keys(ws))
+  })
+
+  it('the generator is deterministic per seed', () => {
+    expect(serializeDSL(generateWorkspace(42))).toBe(serializeDSL(generateWorkspace(42)))
+    expect(serializeDSL(generateWorkspace(42))).not.toBe(serializeDSL(generateWorkspace(43)))
+  })
+})

--- a/src/lib/dsl/serializer.ts
+++ b/src/lib/dsl/serializer.ts
@@ -423,17 +423,35 @@ class SerializerContext {
         for (const [key, val] of Object.entries(user)) {
             if (!(key in props)) props[key] = val
         }
-        return props
+        return this.emittableProperties(props)
+    }
+
+    /** Drop entries whose key or value encodes to nothing: Structurizr rejects
+     *  `"key" ""` and a nameless property, so they are unrepresentable. Applied
+     *  before any `hasProperties` check so an element with only such entries
+     *  gets no empty block. Found by the generated conformance corpus (TEA-63). */
+    private emittableProperties(props: Record<string, string>): Record<string, string> {
+        const out: Record<string, string> = Object.create(null)
+        for (const [key, val] of Object.entries(props)) {
+            if (this.escapeString(key).length > 0 && this.escapeString(val).length > 0) out[key] = val
+        }
+        return out
     }
 
     /** Emit a `properties { }` block for any user-defined key/value pairs. */
     private serializeProperties(props: Record<string, string>): void {
+        // Structurizr rejects `"key" ""` ("A property value must be specified")
+        // and a nameless property, so entries that encode to nothing are
+        // unrepresentable and skipped — the same rule as trailing backslashes.
+        // Found by the generated conformance corpus (TEA-63).
         const entries = Object.entries(props)
+            .map(([key, val]) => [this.escapeString(key), this.escapeString(val)] as const)
+            .filter(([key, val]) => key.length > 0 && val.length > 0)
         if (entries.length === 0) return
         this.emit('properties {')
         this.depth++
         for (const [key, val] of entries) {
-            this.emit(`"${this.escapeString(key)}" "${this.escapeString(val)}"`)
+            this.emit(`"${key}" "${val}"`)
         }
         this.depth--
         this.emit('}')
@@ -653,6 +671,7 @@ class SerializerContext {
         const varName = this.idToVar.get(id)
         const ref = this.idToVar.get(referencedId) ?? referencedId
         const extraTags = this.getExtraTags(tags, defaultTags)
+        properties = this.emittableProperties(properties)
         const hasProperties = Object.keys(properties).length > 0
         const hasBlock = !!url || hasProperties
 

--- a/src/lib/dsl/structurizr-conformance.test.ts
+++ b/src/lib/dsl/structurizr-conformance.test.ts
@@ -34,6 +34,7 @@ import { createMicroservicesTemplate } from '@/lib/templates/microservices'
 import { createMonolithTemplate } from '@/lib/templates/monolith'
 import { createEventDrivenTemplate } from '@/lib/templates/eventDriven'
 import type { Workspace } from '@/types/model'
+import { generateWorkspace, representable } from './fuzz/generateWorkspace'
 
 const CLI = process.env.STRUCTURIZR_CLI ?? join(process.cwd(), '.structurizr-cli', 'structurizr.sh')
 const CLI_AVAILABLE = existsSync(CLI)
@@ -552,6 +553,78 @@ workspace "Grouped" {
 // which is the same false-confidence failure this whole file exists to prevent.
 // The CI job sets STRUCTURIZR_CONFORMANCE=1, so a broken CLI download turns
 // into a red build instead of a green skip.
+// ─── Generated corpus (TEA-63) ─────────────────────────────────────────
+//
+// The fixtures above are a handful of hand-picked shapes. This runs a seeded
+// generator over many workspaces full of hostile strings, tags, groups,
+// views and styles, and asks the real parser two questions: does it accept
+// what c4hero wrote, and did it store the values c4hero meant? A failure
+// names the seed, so `generateWorkspace(seed)` reproduces it exactly.
+//
+// Each case is one JVM start, so the count is capped; raise
+// CONFORMANCE_SEEDS locally to sweep further.
+describe.skipIf(!CLI_AVAILABLE)('Structurizr conformance: generated corpus', () => {
+    const validateSeeds = Array.from({ length: Number(process.env.CONFORMANCE_SEEDS ?? 24) }, (_, i) => i + 1)
+    const fidelitySeeds = validateSeeds.slice(0, Number(process.env.CONFORMANCE_FIDELITY_SEEDS ?? 8))
+
+    it.each(validateSeeds)('seed %i serializes to DSL Structurizr accepts', (seed) => {
+        const dsl = serializeDSL(generateWorkspace(seed))
+        expect(validate(dsl), `seed ${seed}:\n${dsl}`).toBeNull()
+    })
+
+    /** Names the real parser stored for people, systems, containers and components. */
+    function storedNames(model: Record<string, unknown>): Record<string, string[]> {
+        const m = model.model as {
+            people?: { name: string }[]
+            softwareSystems?: { name: string; containers?: { name: string; components?: { name: string }[] }[] }[]
+        } | undefined
+        const systems = m?.softwareSystems ?? []
+        return {
+            person: (m?.people ?? []).map(p => p.name).sort(),
+            softwareSystem: systems.map(s => s.name).sort(),
+            container: systems.flatMap(s => (s.containers ?? []).map(c => c.name)).sort(),
+            component: systems.flatMap(s => (s.containers ?? []).flatMap(c => (c.components ?? []).map(x => x.name))).sort(),
+        }
+    }
+
+    /** What c4hero meant, after the documented unrepresentable-backslash rule. */
+    function intendedNames(ws: Workspace): Record<string, string[]> {
+        return {
+            person: ws.model.people.map(p => representable(p.name)).sort(),
+            softwareSystem: ws.model.softwareSystems.map(s => representable(s.name)).sort(),
+            container: ws.model.softwareSystems.flatMap(s => s.containers.map(c => representable(c.name))).sort(),
+            component: ws.model.softwareSystems.flatMap(s => s.containers.flatMap(c => c.components.map(x => representable(x.name)))).sort(),
+        }
+    }
+
+    /** Relationships the real parser stored, from every nesting level, minus
+     *  the ones it *implied* between ancestors (those carry linkedRelationshipId). */
+    function authoredRelationships(model: Record<string, unknown>): ExportedRelationship[] {
+        type Rel = ExportedRelationship & { linkedRelationshipId?: string }
+        type El = { relationships?: Rel[]; containers?: El[]; components?: El[] }
+        const m = model.model as { people?: El[]; softwareSystems?: El[] } | undefined
+        const out: Rel[] = []
+        const walk = (el: El) => {
+            out.push(...(el.relationships ?? []))
+            for (const c of el.containers ?? []) walk(c)
+            for (const c of el.components ?? []) walk(c)
+        }
+        for (const p of m?.people ?? []) walk(p)
+        for (const s of m?.softwareSystems ?? []) walk(s)
+        return out.filter(r => !r.linkedRelationshipId)
+    }
+
+    it.each(fidelitySeeds)('seed %i: the real parser stores the values c4hero meant', (seed) => {
+        const ws = generateWorkspace(seed)
+        const model = exportModel(serializeDSL(ws))
+        expect(storedNames(model), `seed ${seed}`).toEqual(intendedNames(ws))
+
+        const wantRels = ws.model.relationships.map(r => representable(r.description ?? '')).sort()
+        const gotRels = authoredRelationships(model).map(r => r.description ?? '').sort()
+        expect(gotRels, `seed ${seed} relationship descriptions`).toEqual(wantRels)
+    })
+})
+
 describe('Structurizr conformance harness', () => {
     it('has the CLI installed when conformance is required', () => {
         if (process.env.STRUCTURIZR_CONFORMANCE !== '1') return

--- a/src/lib/dsl/structurizr-encoding.test.ts
+++ b/src/lib/dsl/structurizr-encoding.test.ts
@@ -188,9 +188,12 @@ workspace {
     expect(reparsed.workspace.model.softwareSystems[0].location).not.toBe('External')
   })
 
-  it('leaves an empty owner property as a property, so it survives round-trip', () => {
-    // The serializer only re-emits a truthy owner field; hoisting "" would
-    // drop the property on the next save.
+  it('parses an empty owner property without hoisting it, and drops it on save', () => {
+    // Hoisting "" onto the owner field would be wrong (the field is truthy-
+    // gated), so it stays a property on parse. It cannot be written back,
+    // though: the real parser rejects `"owner" ""` with "A property value
+    // must be specified" — found by the generated conformance corpus
+    // (TEA-63) — so the serializer skips empty-valued properties.
     const source = `
 workspace {
   model {
@@ -210,7 +213,8 @@ workspace {
     expect(sys.properties.owner).toBe('')
 
     const dsl1 = serializeDSL(workspace)
-    expect(dsl1).toContain('"owner" ""')
+    expect(dsl1).not.toContain('"owner" ""')
+    expect(dsl1).not.toContain('properties')
     const reparsed = parseDSL(dsl1)
     expect(serializeDSL(reparsed.workspace)).toBe(dsl1)
   })


### PR DESCRIPTION
## Summary

[TEA-63](https://linear.app/kevnord/issue/TEA-63). Generalises the hand-picked conformance fixtures into a seeded corpus, and puts the real Structurizr CLI in charge of the verdict.

- **Generator** (`src/lib/dsl/fuzz/generateWorkspace.ts`): deterministic per seed. People, systems, containers, components, relationships, disjoint groups, all four static view types with `include *` or explicit lists, element and relationship styles. String pools cover quotes, backslashes in every position, newlines, tabs, commas, comment openers, braces, arrows, keywords used as names, whitespace padding, unicode and long values.
- **Conformance gate** (real CLI, CI's `dsl-conformance` job): 24 seeds must validate; 8 must export exactly the element names and authored relationship descriptions c4hero meant (implied relationships excluded, the documented unrepresentable-backslash rule applied). `CONFORMANCE_SEEDS` / `CONFORMANCE_FIDELITY_SEEDS` widen the sweep locally. A failure names the seed.
- **Secondary invariant** (no CLI): 200 seeds parse clean, re-serialize idempotently from the second pass (the first expands `include *`, TEA-326), and keep every representable value.

### What the first sweep found

One serializer bug, fixed here: Structurizr rejects `"key" ""` ("A property value must be specified"), so any element or relationship with an empty property produced DSL the real parser refused. Empty-encoding entries are now dropped before block decisions. The encoding test that asserted the opposite was pinning invalid output and is corrected.

Four product validation gaps where the store accepts a state Structurizr rejects. The generator is constrained around them and they are filed as a follow-up ticket: empty element names, invalid URLs, duplicate sibling names, relationships to an ancestor or duplicating an implied one.

## Test plan

- [x] `npm run check` green (2845 tests)
- [x] Real CLI: 24 validate + 8 fidelity seeds pass; local sweep of 60 validate + 20 fidelity seeds clean
- [x] Self round-trip: 200 seeds pass; local sweep of 1000 seeds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs