### PR TITLE
chore(deps): bump js-yaml to 4.3.2 for GHSA-2883-xcg3-v3hh (audit gate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c4hero",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c4hero",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
@@ -6680,9 +6680,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Lockfile-only bump of a dev transitive (eslint > @eslint/eslintrc > js-yaml 4.3.1 → 4.3.2). The repo-wide audit gate was failing the `security` job on every open PR (#174, #175, #176). `npm run audit` and `npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs