### PR TITLE
feat(import): import C4-PlantUML and Mermaid C4 files (TEA-255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Import C4-PlantUML and Mermaid C4 files.** The largest population of
+  existing C4 diagrams lives in `.puml` files and Mermaid `C4Context` /
+  `C4Container` / `C4Component` blocks. Paste or drop one into the new
+  *Import PlantUML / Mermaid* dialog (welcome screen, app menu, or command
+  palette) and get a live, editable canvas plus clean Structurizr DSL. The
+  dialog auto-detects the format, previews what it found (people, systems,
+  containers, components, relationships) and lists every skipped line with
+  its line number, so nothing is dropped silently. People, systems,
+  containers and components map with their `_Ext`, `Db` and `Queue`
+  variants (external location, Cylinder and Pipe shapes); `System_Boundary`
+  / `Container_Boundary` become nesting; `Boundary` / `Enterprise_Boundary`
+  become groups; `Rel` in every direction variant and `BiRel` (split in two)
+  become relationships; `$named` arguments work. Every import is pushed
+  through the Structurizr DSL round trip before it loads, so what you get can
+  always be saved. Nothing is fetched: `!include` lines are reported, not
+  followed. Out of scope for now: sprites and styling macros, deployment
+  nodes, dynamic steps, exporting back. (TEA-255)
+
 ## [0.6.0] - 2026-09-10
 
 ### Added

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -21,6 +21,7 @@ A more detailed reference for what c4hero ships. The README is the elevator pitc
 
 ## File workflows
 
+- **Import C4-PlantUML and Mermaid C4.** Paste or drop a `.puml` file or a Mermaid `C4Context` / `C4Container` / `C4Component` block; the dialog auto-detects the format, previews the counts, lists every skipped line with its number, and loads an editable canvas that saves as Structurizr DSL. Boundaries become nesting or groups; `_Ext` / `Db` / `Queue` variants map to location, tags and shapes. Styling macros, sprites, deployment nodes and dynamic steps are reported and skipped.
 - **Folder collections** (Chromium browsers): open a folder of `.dsl` files, pick a workspace, and edit. Saves write back to disk via the File System Access API.
 - **Single-file mode** (all browsers): open a `.dsl` file directly. Saves either go back to the source handle (where supported) or trigger a download.
 - **Recent collections / files** are remembered in `localStorage` and re-openable from the welcome screen.

--- a/e2e/welcome/import-foreign.spec.ts
+++ b/e2e/welcome/import-foreign.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '../fixtures/workspace'
+
+const PUML = `@startuml
+title Shop
+Person(shopper, "Shopper", "Buys things")
+System_Boundary(shop, "Shop") {
+  Container(web, "Web App", "React", "The storefront")
+  ContainerDb(db, "Shop DB", "Postgres")
+}
+System_Ext(payments, "Payment Provider")
+Rel(shopper, web, "Uses", "HTTPS")
+Rel(web, db, "Reads and writes")
+Rel(web, payments, "Charges cards")
+@enduml`
+
+test.describe('Import PlantUML / Mermaid (TEA-255)', () => {
+  test('pastes a C4-PlantUML snippet on the welcome screen and lands on an editable canvas', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.goto()
+    await page.getByRole('button', { name: 'Import PlantUML or Mermaid' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Import PlantUML or Mermaid' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.locator('[data-import-confirm]')).toBeDisabled()
+
+    await dialog.locator('[data-import-source]').fill(PUML)
+    const summary = dialog.locator('[data-import-summary]')
+    await expect(summary).toContainText('Shop')
+    await expect(summary).toContainText('C4-PlantUML')
+    await expect(summary).toContainText('1 person, 2 systems, 2 containers, 0 components, 3 relationships')
+    await expect(dialog.locator('[data-import-warnings]')).toHaveCount(0)
+
+    await dialog.locator('[data-import-confirm]').click()
+    await expect(dialog).toBeHidden()
+
+    // The container diagram is the source type, so the container view opens.
+    await expect(await workspace.getNodeByName('Web App')).toBeVisible({ timeout: 10000 })
+    await expect(await workspace.getNodeByName('Shop DB')).toBeVisible()
+    const ws = await workspace.getWorkspace()
+    expect(ws?.name).toBe('Shop')
+    expect(ws?.model.softwareSystems.map((s) => s.name).sort()).toEqual(['Payment Provider', 'Shop'])
+
+    // Unsaved single-file flow: nothing linked yet, the save control offers to save to a .dsl.
+    await expect(page.getByRole('button', { name: /No file linked|Click to download \.dsl/ })).toBeVisible()
+  })
+
+  test('shows warnings for skipped lines and a clear error for unrecognised text', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.goto()
+    await page.getByRole('button', { name: 'Import PlantUML or Mermaid' }).click()
+    const dialog = page.getByRole('dialog', { name: 'Import PlantUML or Mermaid' })
+
+    await dialog.locator('[data-import-source]').fill('just some prose')
+    await expect(dialog.locator('[data-import-error]')).toContainText('Not recognised')
+    await expect(dialog.locator('[data-import-confirm]')).toBeDisabled()
+
+    await dialog.locator('[data-import-source]').fill(`C4Context
+  title Ctx
+  Person(a, "A")
+  System(s, "S")
+  Rel(a, s, "uses")
+  UpdateLayoutConfig($c4ShapeInRow="3")`)
+    await expect(dialog.locator('[data-import-summary]')).toContainText('Mermaid C4')
+    const warnings = dialog.locator('[data-import-warnings]')
+    await expect(warnings).toContainText('1 line skipped or adjusted')
+    await warnings.locator('summary').click()
+    await expect(warnings).toContainText('6: UpdateLayoutConfig')
+  })
+
+  test('asks before replacing an open workspace, from the command palette', async ({ workspace }) => {
+    const page = workspace.page
+    await workspace.loadSample()
+    await workspace.runCommand('Import', 'Import PlantUML / Mermaid')
+    const dialog = page.getByRole('dialog', { name: 'Import PlantUML or Mermaid' })
+    await dialog.locator('[data-import-source]').fill(PUML)
+    await dialog.locator('[data-import-confirm]').click()
+    await expect(dialog.locator('[data-import-replace]')).toContainText('Replace')
+    await expect(dialog.locator('[data-import-confirm]')).toHaveText('Replace and import')
+    await dialog.locator('[data-import-confirm]').click()
+    await expect(dialog).toBeHidden()
+    const ws = await workspace.getWorkspace()
+    expect(ws?.name).toBe('Shop')
+  })
+})

--- a/src/components/dialogs/ImportDialog.tsx
+++ b/src/components/dialogs/ImportDialog.tsx
@@ -1,0 +1,182 @@
+import { useMemo, useRef, useState } from 'react'
+import { FileInput, Upload, AlertTriangle, Check } from 'lucide-react'
+import DialogShell from '@/components/shared/DialogShell'
+import { useWorkspaceStore } from '@/store/workspace'
+import { readTextFileWithLimit } from '@/lib/fileIO'
+import { importForeign, ImportError, type ForeignImport } from '@/lib/import'
+import { announce } from '@/lib/announce'
+
+const ACCEPT = '.puml,.plantuml,.iuml,.wsd,.pu,.mmd,.mermaid,.md,.txt'
+
+interface ImportDialogProps {
+  onClose: () => void
+  /** Called with the normalised workspace once the user confirms. The caller
+   *  loads it into the store and takes the unsaved single-file flow. */
+  onImport: (result: ForeignImport) => void
+  /** Anchor under the top pill ("shade") or centre on the welcome screen. */
+  position?: 'shade' | 'center'
+}
+
+type Outcome = { ok: true; result: ForeignImport } | { ok: false; error: string; line?: number } | null
+
+/** Paste or drop a C4-PlantUML / Mermaid C4 file, see what it would become,
+ *  and load it as a new unsaved workspace (TEA-255). */
+export default function ImportDialog({ onClose, onImport, position = 'center' }: ImportDialogProps) {
+  const [text, setText] = useState('')
+  const [fileName, setFileName] = useState<string | null>(null)
+  const [readError, setReadError] = useState<string | null>(null)
+  const [confirmReplace, setConfirmReplace] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const hasWorkspace = useWorkspaceStore((s) => !!s.workspace)
+  const workspaceName = useWorkspaceStore((s) => s.workspace?.name)
+  const isDirty = useWorkspaceStore((s) => s.undoStack.length !== s.lastSavedUndoLength)
+
+  // Re-run the importer on every change; it is pure and fast.
+  const outcome = useMemo<Outcome>(() => {
+    if (text.trim() === '') return null
+    try {
+      return { ok: true, result: importForeign(text) }
+    } catch (err) {
+      if (err instanceof ImportError) return { ok: false, error: err.message, line: err.line }
+      return { ok: false, error: err instanceof Error ? err.message : 'Import failed' }
+    }
+  }, [text])
+
+  async function readFile(file: File) {
+    setReadError(null)
+    try {
+      setText(await readTextFileWithLimit(file, 'Diagram file'))
+      setFileName(file.name)
+      setConfirmReplace(false)
+    } catch (err) {
+      setReadError(err instanceof Error ? err.message : 'Could not read the file')
+    }
+  }
+
+  function commit() {
+    if (!outcome?.ok) return
+    if (hasWorkspace && !confirmReplace) { setConfirmReplace(true); return }
+    onImport(outcome.result)
+    announce(`Imported ${outcome.result.workspace.name}`)
+    onClose()
+  }
+
+  const summary = outcome?.ok ? outcome.result.summary : null
+  const formatLabel = outcome?.ok ? (outcome.result.format === 'mermaid-c4' ? 'Mermaid C4' : 'C4-PlantUML') : null
+
+  return (
+    <DialogShell onClose={onClose} ariaLabel="Import PlantUML or Mermaid" position={position} style={{ width: 'min(640px, calc(100vw - 32px))' }}>
+      <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--color-border)', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <FileInput size={16} color="var(--color-accent)" aria-hidden="true" />
+        <span style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: 'var(--color-text-primary)' }}>Import PlantUML / Mermaid</span>
+      </div>
+
+      <div style={{ padding: '12px 16px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <p style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', lineHeight: 1.5 }}>
+          Paste a C4-PlantUML file (<code>@startuml</code> with <code>Person</code>, <code>System</code>, <code>Container</code>… macros) or a Mermaid
+          <code> C4Context</code> / <code>C4Container</code> / <code>C4Component</code> block. Nothing leaves your browser; includes are not fetched.
+        </p>
+
+        <div
+          onDragOver={(e) => { e.preventDefault() }}
+          onDrop={(e) => { e.preventDefault(); const f = e.dataTransfer.files?.[0]; if (f) void readFile(f) }}
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="hover-subtle"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 10px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface-2)', color: 'var(--color-text-secondary)', fontSize: 'var(--text-xs)', cursor: 'pointer' }}
+          >
+            <Upload size={12} aria-hidden="true" /> Choose file
+          </button>
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
+            {fileName ? fileName : 'or drop a file here, or paste below'}
+          </span>
+          <input ref={inputRef} type="file" accept={ACCEPT} hidden onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ''; if (f) void readFile(f) }} />
+        </div>
+
+        <textarea
+          aria-label="Diagram source"
+          data-import-source
+          value={text}
+          onChange={(e) => { setText(e.target.value); setFileName(null); setConfirmReplace(false) }}
+          placeholder={'@startuml\nPerson(user, "User")\nSystem(sys, "System")\nRel(user, sys, "Uses")\n@enduml'}
+          spellCheck={false}
+          style={{ width: '100%', minHeight: 160, resize: 'vertical', boxSizing: 'border-box', padding: 8, borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-bg-primary)', color: 'var(--color-text-primary)', fontFamily: 'ui-monospace, monospace', fontSize: 'var(--text-xs)' }}
+        />
+
+        {readError && <Note tone="error">{readError}</Note>}
+
+        {outcome && !outcome.ok && (
+          <Note tone="error" data-import-error>{outcome.line ? `Line ${outcome.line}: ` : ''}{outcome.error}</Note>
+        )}
+
+        {outcome?.ok && summary && (
+          <div data-import-summary style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '8px 10px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface-2)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 'var(--text-xs)', color: 'var(--color-text-primary)' }}>
+              <Check size={12} color="var(--color-success)" aria-hidden="true" />
+              <b>{outcome.result.workspace.name}</b>
+              <span style={{ color: 'var(--color-text-muted)' }}>· {formatLabel}</span>
+            </div>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-secondary)' }}>
+              {summary.people} {summary.people === 1 ? 'person' : 'people'}, {summary.systems} {summary.systems === 1 ? 'system' : 'systems'}, {summary.containers} {summary.containers === 1 ? 'container' : 'containers'}, {summary.components} {summary.components === 1 ? 'component' : 'components'}, {summary.relationships} {summary.relationships === 1 ? 'relationship' : 'relationships'}
+            </div>
+            {outcome.result.warnings.length > 0 && (
+              <details data-import-warnings style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-secondary)' }}>
+                <summary style={{ cursor: 'pointer', color: 'var(--color-warning)' }}>
+                  <AlertTriangle size={11} aria-hidden="true" style={{ verticalAlign: '-1px', marginRight: 4 }} />
+                  {outcome.result.warnings.length} {outcome.result.warnings.length === 1 ? 'line' : 'lines'} skipped or adjusted
+                </summary>
+                <ul style={{ margin: '6px 0 0', paddingLeft: 18, maxHeight: 140, overflowY: 'auto' }}>
+                  {outcome.result.warnings.map((w, i) => (
+                    <li key={i}><span style={{ color: 'var(--color-text-muted)', fontFamily: 'ui-monospace, monospace' }}>{w.line}:</span> {w.message}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </div>
+        )}
+
+        {confirmReplace && (
+          <Note tone="warn" data-import-replace>
+            <b>Replace {workspaceName || 'the current workspace'}?</b>{' '}
+            {isDirty ? 'It has unsaved changes — importing discards them.' : 'Importing replaces the open diagram with the imported one.'}
+          </Note>
+        )}
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button type="button" onClick={onClose} className="hover-subtle" style={BTN}>Cancel</button>
+          <button
+            type="button"
+            onClick={commit}
+            disabled={!outcome?.ok}
+            data-import-confirm
+            style={{ ...BTN, border: '1px solid var(--color-accent)', color: outcome?.ok ? 'var(--color-text-primary)' : 'var(--color-text-muted)', cursor: outcome?.ok ? 'pointer' : 'not-allowed' }}
+          >
+            {confirmReplace ? 'Replace and import' : 'Import'}
+          </button>
+        </div>
+      </div>
+    </DialogShell>
+  )
+}
+
+function Note({ tone, children, ...rest }: { tone: 'error' | 'warn'; children: React.ReactNode } & Record<string, unknown>) {
+  const color = tone === 'error' ? 'var(--color-error)' : 'var(--color-warning)'
+  return (
+    <div role={tone === 'error' ? 'alert' : 'status'} {...rest} style={{ fontSize: 'var(--text-xs)', color, padding: '6px 10px', borderRadius: 'var(--radius-sm)', border: `1px solid ${color}`, lineHeight: 1.45 }}>
+      {children}
+    </div>
+  )
+}
+
+const BTN: React.CSSProperties = {
+  padding: '6px 12px',
+  borderRadius: 'var(--radius-sm)',
+  border: '1px solid var(--color-border)',
+  background: 'transparent',
+  color: 'var(--color-text-primary)',
+  fontSize: 'var(--text-xs)',
+  cursor: 'pointer',
+}

--- a/src/components/layout/FloatingTopPill.tsx
+++ b/src/components/layout/FloatingTopPill.tsx
@@ -22,6 +22,7 @@ import {
   LayoutGrid,
   Sparkles,
   Code,
+  FileInput,
 } from 'lucide-react'
 import { useSettingsStore } from '@/store/settings'
 import { THEMES, THEME_CANVAS_BACKGROUNDS } from '@/lib/themes'
@@ -41,6 +42,7 @@ interface WsEntry {
 }
 
 const ExportDialog = lazy(() => import('@/components/dialogs/ExportDialog'))
+const ImportDialog = lazy(() => import('@/components/dialogs/ImportDialog'))
 const CommandPalette = lazy(() => import('@/components/command-palette/CommandPalette'))
 const CreateViewDialog = lazy(() => import('@/components/views/CreateViewDialog'))
 const ScopePickerDialog = lazy(() => import('@/components/shared/ScopePickerDialog'))
@@ -73,6 +75,7 @@ export default function FloatingTopPill() {
   const navigate = useNavigate()
   const loadWorkspace = useWorkspaceStore((s) => s.loadWorkspace)
   const activeFilename = useWorkspaceStore((s) => s.activeWorkspaceFilename)
+  const importDialogOpen = useWorkspaceStore((s) => s.importDialogOpen)
 
   const openWsPicker = useCallback(async () => {
     const filenames = await listDSLFiles()
@@ -434,6 +437,7 @@ export default function FloatingTopPill() {
             <MenuItemRow icon={Code} label="DSL code…" onClick={() => { setHamburgerOpen(false); useWorkspaceStore.getState().setCodePanelOpen(true) }} />
             <div style={{ borderTop: '1px solid var(--color-border)', margin: '4px 0' }} />
             <MenuItemRow icon={Download} label="Export…" onClick={() => { setHamburgerOpen(false); setExportDialogOpen(true); setWsPickerOpen(false); useWorkspaceStore.getState().setCommandPaletteOpen(false) }} />
+            <MenuItemRow icon={FileInput} label="Import PlantUML / Mermaid…" onClick={() => { setHamburgerOpen(false); setExportDialogOpen(false); setWsPickerOpen(false); useWorkspaceStore.getState().setImportDialogOpen(true) }} />
             <div style={{ borderTop: '1px solid var(--color-border)', margin: '4px 0' }} />
             <MenuItemRow
               icon={Command}
@@ -487,6 +491,22 @@ export default function FloatingTopPill() {
             onExport={handleExport}
             onCopy={handleCopy}
             onClose={() => setExportDialogOpen(false)}
+          />
+        </Suspense>
+      )}
+      {importDialogOpen && (
+        <Suspense fallback={<LoadingDot />}>
+          <ImportDialog
+            position="shade"
+            onClose={() => useWorkspaceStore.getState().setImportDialogOpen(false)}
+            onImport={(result) => {
+              // Same as instantiating a template without a folder file: an
+              // unsaved single-file workspace whose Save As suggests <name>.dsl.
+              const s = useWorkspaceStore.getState()
+              s.loadWorkspace(result.workspace)
+              s.setActiveWorkspaceFilename(null)
+              if (result.initialViewKey) s.setActiveView(result.initialViewKey)
+            }}
           />
         </Suspense>
       )}

--- a/src/components/welcome/StartupView.test.tsx
+++ b/src/components/welcome/StartupView.test.tsx
@@ -8,6 +8,7 @@ vi.mock('lucide-react', () => ({
   Plus: () => null,
   ChevronRight: () => null,
   X: () => null,
+  FileInput: () => null,
   MoreHorizontal: () => null,
 }))
 
@@ -32,6 +33,7 @@ function makeCallbacks(): Callbacks {
     onOpenRecent: vi.fn(),
     onRemoveRecent: vi.fn(),
     onOpenFile: vi.fn(),
+  onImportForeign: vi.fn(),
   }
 }
 

--- a/src/components/welcome/StartupView.tsx
+++ b/src/components/welcome/StartupView.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, FileText, Plus, ChevronRight, X } from 'lucide-react'
+import { FolderOpen, FileText, Plus, ChevronRight, X, FileInput } from 'lucide-react'
 import { hasFolderAccess } from '@/lib/folderIO'
 import RowMenu from './RowMenu'
 import {
@@ -17,6 +17,7 @@ export default function StartupView({
   onOpenRecent,
   onRemoveRecent,
   onOpenFile,
+  onImportForeign,
   recentFolders,
 }: {
   onCreateCollection: () => void
@@ -24,6 +25,8 @@ export default function StartupView({
   onOpenRecent: (path: string) => void
   onRemoveRecent: (name: string) => void
   onOpenFile: () => void
+  /** Import a C4-PlantUML or Mermaid C4 file (TEA-255). */
+  onImportForeign: () => void
   recentFolders: RecentFolder[]
 }) {
   const canUseCollections = hasFolderAccess()
@@ -53,6 +56,10 @@ export default function StartupView({
                   <LifecycleButton onClick={onOpenCollection}>
                     <FolderOpen size={14} />
                     Open collection
+                  </LifecycleButton>
+                  <LifecycleButton onClick={onImportForeign} ariaLabel="Import PlantUML or Mermaid">
+                    <FileInput size={14} />
+                    Import PlantUML / Mermaid
                   </LifecycleButton>
                 </>
               ) : (
@@ -108,6 +115,10 @@ export default function StartupView({
                 <FolderOpen size={14} />
                 Open collection
               </LifecycleButton>
+              <LifecycleButton onClick={onImportForeign} ariaLabel="Import PlantUML or Mermaid">
+                <FileInput size={14} />
+                Import PlantUML / Mermaid
+              </LifecycleButton>
             </div>
           ) : (
             <div className="welcome-fallback">
@@ -115,6 +126,10 @@ export default function StartupView({
               <LifecycleButton variant="primary" onClick={onOpenFile}>
                 <FileText size={14} />
                 Open .dsl file
+              </LifecycleButton>
+              <LifecycleButton onClick={onImportForeign} ariaLabel="Import PlantUML or Mermaid">
+                <FileInput size={14} />
+                Import PlantUML / Mermaid
               </LifecycleButton>
             </div>
           )}

--- a/src/components/welcome/WelcomeScreen.test.tsx
+++ b/src/components/welcome/WelcomeScreen.test.tsx
@@ -5,6 +5,7 @@ import WelcomeScreen from './WelcomeScreen'
 // Mock lucide-react to avoid SVG issues
 vi.mock('lucide-react', () => ({
   FileText: () => null,
+  FileInput: () => null,
   Play: () => null,
   LayoutTemplate: () => null,
   Sparkles: () => null,

--- a/src/components/welcome/WelcomeScreen.tsx
+++ b/src/components/welcome/WelcomeScreen.tsx
@@ -33,6 +33,7 @@ import StartupView from './StartupView'
 import CollectionView from './CollectionView'
 
 const ScopePickerDialog = lazy(() => import('@/components/shared/ScopePickerDialog'))
+const ImportDialog = lazy(() => import('@/components/dialogs/ImportDialog'))
 
 const log = createLogger('WelcomeScreen')
 
@@ -100,6 +101,7 @@ export default function WelcomeScreen({ initialView }: { initialView?: 'startup'
 
   const [showScopePicker, setShowScopePicker] = useState(false)
   const [showTemplates, setShowTemplates] = useState(false)
+  const [showImport, setShowImport] = useState(false)
   const [showNewCollection, setShowNewCollection] = useState(false)
   const [newCollectionName, setNewCollectionName] = useState('My Architecture')
   const [renameCollection, setRenameCollection] = useState<{ slug: string; name: string } | null>(null)
@@ -523,6 +525,7 @@ export default function WelcomeScreen({ initialView }: { initialView?: 'startup'
             onOpenRecent={handleOpenRecent}
             onRemoveRecent={handleRemoveRecent}
             onOpenFile={handleOpenFile}
+            onImportForeign={() => setShowImport(true)}
             recentFolders={recentFolders}
           />
         ) : (
@@ -594,6 +597,21 @@ export default function WelcomeScreen({ initialView }: { initialView?: 'startup'
           <ScopePickerDialog
             onConfirm={handleBlankWorkspaceFromPicker}
             onCancel={() => setShowScopePicker(false)}
+          />
+        </Suspense>
+      )}
+      {showImport && (
+        <Suspense fallback={null}>
+          <ImportDialog
+            position="center"
+            onClose={() => setShowImport(false)}
+            onImport={(result) => {
+              // Unsaved single-file flow, like a template without a folder:
+              // no filename until the user saves.
+              loadWorkspace(result.workspace)
+              useWorkspaceStore.getState().setActiveWorkspaceFilename(null)
+              if (result.initialViewKey) useWorkspaceStore.getState().setActiveView(result.initialViewKey)
+            }}
           />
         </Suspense>
       )}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -4,7 +4,7 @@ import {
   MousePointer, LayoutDashboard, Maximize2, ZoomIn, ZoomOut,
   LayoutGrid, Search, Save, Settings, Monitor,
   Presentation, FolderOpen, Image, FileCode, Copy, Plus,
-  Highlighter, MousePointerClick, RotateCcw, CircleHelp, Sparkles, Radar, Eye, EyeOff,
+  Highlighter, MousePointerClick, RotateCcw, CircleHelp, Sparkles, Radar, Eye, EyeOff, FileInput,
 } from 'lucide-react'
 import { useWorkspaceStore, getCreatableTypes, getActiveView, getAllViews, isFocalScopeElement } from '@/store/workspace'
 import { computeCascadeImpact } from '@/store/workspace-helpers'
@@ -38,6 +38,15 @@ export function getCommands(reactFlow: ReactFlowInstance | null): Command[] {
 
   const commands: Command[] = [
     // ─── Create ──────────────────────────────────────────
+    {
+      id: 'import-foreign',
+      label: 'Import PlantUML / Mermaid',
+      category: 'create',
+      icon: FileInput,
+      keywords: ['import', 'plantuml', 'puml', 'mermaid', 'c4', 'convert'],
+      when: () => !!store().workspace,
+      execute: () => { store().setImportDialogOpen(true) },
+    },
     {
       id: 'add-person',
       label: 'Add Person',

--- a/src/lib/import/__fixtures__/context.golden.dsl
+++ b/src/lib/import/__fixtures__/context.golden.dsl
@@ -1,0 +1,52 @@
+workspace "System Context diagram for Internet Banking System" {
+
+    model {
+        properties {
+            "structurizr.groupSeparator" "/"
+        }
+
+        group "BankBoundary0" {
+            group "BankBoundary" {
+                group "BankBoundary2" {
+                    SystemA = softwareSystem "Banking System A"
+                    SystemB = softwareSystem "Banking System B" "A system of the bank, with personal bank accounts. next line."
+                }
+
+                group "BankBoundary3" {
+                    SystemF = softwareSystem "Banking System F Queue" "A system of the bank." "Queue"
+                    SystemG = softwareSystem "Banking System G Queue" "A system of the bank, with personal bank accounts." "Queue,External"
+                }
+
+                SystemE = softwareSystem "Mainframe Banking System" "Stores all of the core banking information about customers, accounts, transactions, etc." "Database,External"
+                SystemC = softwareSystem "E-mail system" "The internal Microsoft Exchange e-mail system." "External"
+                SystemD = softwareSystem "Banking System D Database" "A system of the bank, with personal bank accounts." "Database"
+            }
+
+            customerA = person "Banking Customer A" "A customer of the bank, with personal bank accounts."
+            customerB = person "Banking Customer B"
+            customerC = person "Banking Customer C" "desc" "External"
+            customerD = person "Banking Customer D" "A customer of the bank, <br/> with personal bank accounts."
+            SystemAA = softwareSystem "Internet Banking System" "Allows customers to view information about their bank accounts, and make payments."
+        }
+
+        customerA -> SystemAA "Uses"
+        SystemAA -> customerA "Uses"
+        SystemAA -> SystemE "Uses"
+        SystemE -> SystemAA "Uses"
+        SystemAA -> SystemC "Sends e-mails" "SMTP"
+        SystemC -> customerA "Sends e-mails to"
+    }
+
+    views {
+        styles {
+            element "Database" {
+                shape Cylinder
+            }
+
+            element "Queue" {
+                shape Pipe
+            }
+        }
+    }
+
+}

--- a/src/lib/import/__fixtures__/context.mmd
+++ b/src/lib/import/__fixtures__/context.mmd
@@ -1,0 +1,41 @@
+```mermaid
+C4Context
+  title System Context diagram for Internet Banking System
+  %% In the shape of the Mermaid docs sample, rewritten by hand for the golden test.
+  Enterprise_Boundary(b0, "BankBoundary0") {
+    Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")
+    Person(customerB, "Banking Customer B")
+    Person_Ext(customerC, "Banking Customer C", "desc")
+
+    Person(customerD, "Banking Customer D", "A customer of the bank, <br/> with personal bank accounts.")
+
+    System(SystemAA, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")
+
+    Enterprise_Boundary(b1, "BankBoundary") {
+
+      SystemDb_Ext(SystemE, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
+
+      System_Boundary(b2, "BankBoundary2") {
+        System(SystemA, "Banking System A")
+        System(SystemB, "Banking System B", "A system of the bank, with personal bank accounts. next line.")
+      }
+
+      System_Ext(SystemC, "E-mail system", "The internal Microsoft Exchange e-mail system.")
+      SystemDb(SystemD, "Banking System D Database", "A system of the bank, with personal bank accounts.")
+
+      Boundary(b3, "BankBoundary3", "boundary") {
+        SystemQueue(SystemF, "Banking System F Queue", "A system of the bank.")
+        SystemQueue_Ext(SystemG, "Banking System G Queue", "A system of the bank, with personal bank accounts.")
+      }
+    }
+  }
+
+  BiRel(customerA, SystemAA, "Uses")
+  BiRel(SystemAA, SystemE, "Uses")
+  Rel(SystemAA, SystemC, "Sends e-mails", "SMTP")
+  Rel(SystemC, customerA, "Sends e-mails to")
+
+  UpdateElementStyle(customerA, $fontColor="red", $bgColor="grey", $borderColor="red")
+  UpdateRelStyle(customerA, SystemAA, $textColor="blue", $lineColor="blue", $offsetX="5")
+  UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```

--- a/src/lib/import/__fixtures__/internet-banking.golden.dsl
+++ b/src/lib/import/__fixtures__/internet-banking.golden.dsl
@@ -1,0 +1,35 @@
+workspace "Container diagram for Internet Banking System" {
+
+    model {
+        customer = person "Personal Banking Customer" "A customer of the bank, with personal bank accounts."
+        email_system = softwareSystem "E-Mail System" "The internal Microsoft Exchange system." "External"
+        banking_system = softwareSystem "Mainframe Banking System" "Stores all of the core banking information about customers, accounts, transactions, etc." "External"
+        c1 = softwareSystem "Internet Banking" {
+            web_app = container "Web Application" "Delivers the static content and the Internet banking SPA" "Java, Spring MVC"
+            spa = container "Single-Page App" "Provides all the Internet banking functionality to customers via their web browser" "JavaScript, Angular"
+            mobile_app = container "Mobile App" "Provides a limited subset of the Internet banking functionality to customers via their mobile device" "C#, Xamarin"
+            database = container "Database" "Stores user registration information, hashed auth credentials, access logs, etc." "SQL Database" "Database"
+            backend_api = container "API Application" "Provides Internet banking functionality via API" "Java, Docker Container"
+        }
+
+        customer -> web_app "Uses" "HTTPS"
+        customer -> spa "Uses" "HTTPS"
+        customer -> mobile_app "Uses"
+        web_app -> spa "Delivers"
+        spa -> backend_api "Uses" "async, JSON/HTTPS"
+        mobile_app -> backend_api "Uses" "async, JSON/HTTPS"
+        database -> backend_api "Reads from and writes to" "sync, JDBC"
+        customer -> email_system "Sends e-mails to"
+        email_system -> backend_api "Sends e-mails using" "sync, SMTP"
+        backend_api -> banking_system "Uses" "sync/async, XML/HTTPS"
+    }
+
+    views {
+        styles {
+            element "Database" {
+                shape Cylinder
+            }
+        }
+    }
+
+}

--- a/src/lib/import/__fixtures__/internet-banking.puml
+++ b/src/lib/import/__fixtures__/internet-banking.puml
@@ -1,0 +1,35 @@
+@startuml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+' A container diagram in the shape of the C4-PlantUML README sample,
+' rewritten by hand for the importer's golden test.
+
+LAYOUT_WITH_LEGEND()
+
+title Container diagram for Internet Banking System
+
+Person(customer, "Personal Banking Customer", "A customer of the bank, with personal bank accounts.")
+System_Ext(email_system, "E-Mail System", "The internal Microsoft Exchange system.")
+System_Ext(banking_system, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
+
+System_Boundary(c1, "Internet Banking") {
+    Container(web_app, "Web Application", "Java, Spring MVC", "Delivers the static content and the Internet banking SPA")
+    Container(spa, "Single-Page App", "JavaScript, Angular", "Provides all the Internet banking functionality to customers via their web browser")
+    Container(mobile_app, "Mobile App", "C#, Xamarin", "Provides a limited subset of the Internet banking functionality to customers via their mobile device")
+    ContainerDb(database, "Database", "SQL Database", "Stores user registration information, hashed auth credentials, access logs, etc.")
+    Container(backend_api, "API Application", "Java, Docker Container", "Provides Internet banking functionality via API")
+}
+
+Rel(customer, web_app, "Uses", "HTTPS")
+Rel(customer, spa, "Uses", "HTTPS")
+Rel(customer, mobile_app, "Uses")
+
+Rel_Neighbor(web_app, spa, "Delivers")
+Rel(spa, backend_api, "Uses", "async, JSON/HTTPS")
+Rel(mobile_app, backend_api, "Uses", "async, JSON/HTTPS")
+Rel_Back_Neighbor(database, backend_api, "Reads from and writes to", "sync, JDBC")
+
+Rel_Back(customer, email_system, "Sends e-mails to")
+Rel_Back_Neighbor(email_system, backend_api, "Sends e-mails using", "sync, SMTP")
+Rel_Neighbor(backend_api, banking_system, "Uses", "sync/async, XML/HTTPS")
+@enduml

--- a/src/lib/import/c4plantuml.test.ts
+++ b/src/lib/import/c4plantuml.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseC4PlantUML } from './c4plantuml'
+import { importForeign, detectFormat, ImportError } from './index'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+
+const fixture = (name: string) => readFileSync(join(__dirname, '__fixtures__', name), 'utf8')
+
+describe('parseC4PlantUML', () => {
+  it('maps every element macro, variants, boundaries and relationships', () => {
+    const r = parseC4PlantUML(`@startuml
+title Shop
+Person(user, "Shopper", "Buys things")
+Person_Ext(courier, "Courier")
+System_Ext(payments, "Payment Provider", "Takes cards")
+SystemDb(warehouse, "Warehouse DB")
+SystemQueue_Ext(events, "Event Bus")
+System_Boundary(shop, "Shop") {
+  Container(web, "Web App", "React", "The storefront")
+  ContainerDb(db, "Shop DB", "Postgres")
+  ContainerQueue(q, "Orders Queue", "Kafka")
+  Container_Ext(cdn, "CDN")
+  Container_Boundary(api, "API") {
+    Component(orders, "Orders", "Go", "Order handling")
+    Component_Ext(auth, "Auth Lib")
+  }
+}
+Rel(user, web, "Uses", "HTTPS")
+Rel_R(web, db, "Reads")
+BiRel(web, payments, "Charges")
+Rel_Back(courier, web, "Gets jobs from")
+@enduml`)
+    const ws = r.workspace
+    expect(ws.name).toBe('Shop')
+    expect(ws.model.people.map((p) => [p.id, p.name, p.location])).toEqual([
+      ['user', 'Shopper', undefined], ['courier', 'Courier', 'External'],
+    ])
+    expect(ws.model.softwareSystems.map((s) => [s.id, s.location, s.tags.filter((t) => t !== 'Element' && t !== 'Software System')])).toEqual([
+      ['payments', 'External', []], ['warehouse', undefined, ['Database']], ['events', 'External', ['Queue']], ['shop', undefined, []],
+    ])
+    const shop = ws.model.softwareSystems.find((s) => s.id === 'shop')!
+    expect(shop.containers.map((c) => c.id)).toEqual(['web', 'db', 'q', 'cdn', 'api'])
+    expect(shop.containers[0].technology).toBe('React')
+    expect(shop.containers[0].description).toBe('The storefront')
+    expect(shop.containers[1].tags).toContain('Database')
+    expect(shop.containers[2].tags).toContain('Queue')
+    expect(shop.containers[3].tags).toContain('External')
+    const api = shop.containers[4]
+    expect(api.components.map((c) => [c.id, c.technology])).toEqual([['orders', 'Go'], ['auth', undefined]])
+    expect(api.components[1].tags).toContain('External')
+    expect(ws.model.relationships.map((r) => `${r.sourceId}->${r.destinationId}:${r.description ?? ''}:${r.technology ?? ''}`)).toEqual([
+      'user->web:Uses:HTTPS', 'web->db:Reads:', 'web->payments:Charges:', 'payments->web:Charges:', 'courier->web:Gets jobs from:',
+    ])
+    expect(ws.views.configuration.styles.elements).toEqual([{ tag: 'Database', shape: 'Cylinder' }, { tag: 'Queue', shape: 'Pipe' }])
+    expect(r.warnings.map((w) => w.message)).toEqual(['BiRel: bidirectional relationship split into two one-way relationships'])
+    expect(r.viewHint).toBe('component')
+  })
+
+  it('supports $named arguments in any order', () => {
+    const r = parseC4PlantUML(`Person($label="Someone", $alias=p1, $descr="d")
+System($alias="s", $label="Sys")
+Rel($to="s", $from="p1", $label="uses", $techn="HTTP")`)
+    expect(r.workspace.model.people[0]).toMatchObject({ id: 'p1', name: 'Someone', description: 'd' })
+    expect(r.workspace.model.relationships[0]).toMatchObject({ sourceId: 'p1', destinationId: 's', description: 'uses', technology: 'HTTP' })
+  })
+
+  it('turns Boundary / Enterprise_Boundary into groups over the elements inside', () => {
+    const r = parseC4PlantUML(`Enterprise_Boundary(ent, "Acme") {
+  Person(a, "A")
+  Boundary(team, "Team X", "team") {
+    System(s1, "S1")
+    System(s2, "S2")
+  }
+}
+System(outside, "Outside")`)
+    // A parent group contains everything its child groups contain — the
+    // serializer's nesting rule.
+    expect(r.workspace.model.groups.map((g) => [g.name, g.elementIds, g.parentId])).toEqual([
+      ['Acme', ['a', 's1', 's2'], undefined],
+      ['Team X', ['s1', 's2'], 'ent'],
+    ])
+  })
+
+  it('warns, with line numbers, for everything it skips', () => {
+    const r = parseC4PlantUML(`@startuml
+!include <C4/C4_Context>
+!includeurl https://example.com/x.puml
+LAYOUT_LEFT_RIGHT()
+SHOW_LEGEND()
+AddElementTag("x", $bgColor="red")
+skinparam backgroundColor white
+Person(u, "U", $sprite="person2")
+note right of u
+  a note
+end note
+Deployment_Node(n, "Node") {
+  Container(c, "C")
+}
+Lay_D(u, u)
+Frobnicate(u)
+@enduml`)
+    expect(r.warnings.map((w) => `${w.line}: ${w.message}`)).toEqual([
+      '2: !include skipped — includes are not resolved (no file or network access)',
+      '3: !includeurl skipped — includes are not resolved (no file or network access)',
+      '4: LAYOUT_LEFT_RIGHT(…): layout directive skipped',
+      '5: SHOW_LEGEND(…): display directive skipped',
+      '6: AddElementTag(…): styling macro (not imported yet) skipped',
+      '7: skinparam skipped',
+      '8: Person(u): sprite "person2" not imported',
+      '9: note block skipped',
+      '12: Deployment_Node(…): deployment node (deployment import is a follow-up) skipped',
+      '15: Lay_D(…): manual layout hint skipped',
+      '16: Unrecognised macro Frobnicate(…) skipped',
+    ])
+    // The container inside the skipped deployment node was skipped with it.
+    expect(r.workspace.model.softwareSystems).toEqual([])
+    expect(r.workspace.model.people).toHaveLength(1)
+  })
+
+  it('gives orphan containers and components a synthesised parent instead of dropping them', () => {
+    const r = parseC4PlantUML(`title Orphans
+Container(web, "Web", "React")
+Component(comp, "Comp", "Go")`)
+    const sys = r.workspace.model.softwareSystems[0]
+    expect(sys.name).toBe('Orphans')
+    expect(sys.containers.map((c) => c.name)).toEqual(['Web', 'Orphans components'])
+    expect(sys.containers[1].components[0].name).toBe('Comp')
+    expect(r.warnings.map((w) => w.message)).toEqual([
+      'Container "Web" declared outside a System_Boundary — placed in a synthesised software system "Orphans"',
+      'Component "Comp" declared outside a Container_Boundary — placed in a synthesised container "Orphans components"',
+      'No @startuml found — imported as a bare macro list',
+    ])
+  })
+
+  it('reports unknown relationship ends, missing aliases and unclosed boundaries rather than crashing', () => {
+    const r = parseC4PlantUML(`Person(a, "A")
+Rel(a, ghost, "Haunts")
+Person("", "Nameless")
+System_Boundary(open, "Open") {`)
+    expect(r.warnings.map((w) => `${w.line}: ${w.message}`)).toEqual([
+      '2: Rel: unknown element "ghost" — skipped',
+      '3: Person: missing alias — skipped',
+      '1: No @startuml found — imported as a bare macro list',
+      '4: Boundary never closed — closed at end of input',
+    ])
+  })
+
+  it('makes aliases DSL-safe and unique', () => {
+    const r = parseC4PlantUML(`Person(1st-user, "One")
+Person(1st-user, "Two")
+System(a.b, "Dotted")`)
+    expect(r.workspace.model.people.map((p) => p.id)).toEqual(['e_1st_user', 'e_1st_user2'])
+    expect(r.workspace.model.softwareSystems[0].id).toBe('a_b')
+  })
+})
+
+describe('golden: internet-banking.puml', () => {
+  it('imports to the checked-in DSL, which parses clean and round-trips', () => {
+    const result = importForeign(fixture('internet-banking.puml'))
+    const dsl = serializeDSL(result.workspace)
+    expect(dsl).toBe(fixture('internet-banking.golden.dsl'))
+    const { errors, workspace } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    expect(workspace.model.softwareSystems.length).toBe(result.workspace.model.softwareSystems.length)
+    expect(workspace.model.relationships.length).toBe(result.workspace.model.relationships.length)
+    expect(result.summary).toEqual({ people: 1, systems: 3, containers: 5, components: 0, relationships: 10 })
+    expect(result.viewHint).toBe('container')
+    expect(result.initialViewKey).toBeDefined()
+    expect(result.workspace.views.containerViews.some((v) => v.key === result.initialViewKey)).toBe(true)
+    expect(result.warnings.map((w) => w.line)).toEqual([2, 7])
+  })
+})
+
+describe('detectFormat / importForeign', () => {
+  it('detects each format', () => {
+    expect(detectFormat('@startuml\nPerson(a, "A")\n@enduml')).toBe('c4plantuml')
+    expect(detectFormat('!include <C4/C4_Context>\nPerson(a,"A")')).toBe('c4plantuml')
+    expect(detectFormat('Person(a, "A")')).toBe('c4plantuml')
+    expect(detectFormat('C4Context\n  Person(a, "A")')).toBe('mermaid-c4')
+    expect(detectFormat('```mermaid\nC4Container\n```')).toBe('mermaid-c4')
+    expect(detectFormat('workspace "x" {\n model {} }')).toBe('structurizr')
+    expect(detectFormat('hello world')).toBe('unknown')
+  })
+
+  it('refuses empty, unknown and Structurizr input with a clear error', () => {
+    expect(() => importForeign('   ')).toThrow(ImportError)
+    expect(() => importForeign('just prose')).toThrow(/Not recognised/)
+    expect(() => importForeign('workspace { model { } }')).toThrow(/already Structurizr DSL/)
+    expect(() => importForeign('@startuml\nLAYOUT_TOP_DOWN()\n@enduml')).toThrow(/No people or software systems/)
+  })
+})

--- a/src/lib/import/c4plantuml.test.ts
+++ b/src/lib/import/c4plantuml.test.ts
@@ -126,6 +126,7 @@ Component(comp, "Comp", "Go")`)
     expect(sys.name).toBe('Orphans')
     expect(sys.containers.map((c) => c.name)).toEqual(['Web', 'Orphans components'])
     expect(sys.containers[1].components[0].name).toBe('Comp')
+    expect(sys.containers[1].properties).toEqual({}) // no internal marker leaks into the DSL
     expect(r.warnings.map((w) => w.message)).toEqual([
       'Container "Web" declared outside a System_Boundary — placed in a synthesised software system "Orphans"',
       'Component "Comp" declared outside a Container_Boundary — placed in a synthesised container "Orphans components"',

--- a/src/lib/import/c4plantuml.ts
+++ b/src/lib/import/c4plantuml.ts
@@ -1,0 +1,92 @@
+// C4-PlantUML importer: `@startuml` files using the C4_Context / C4_Container /
+// C4_Component macro sets. Line-oriented; no PlantUML preprocessing.
+
+import { tokenizeMacroLines, type MacroLine } from './macroCall'
+import { ModelBuilder, elementVariant, relationshipVariant, boundaryVariant } from './modelBuilder'
+import { summarize, type ImportResult } from './importTypes'
+
+/** Macros and directives that are recognised only to be reported. */
+const SKIPPED_CALLS: Array<[RegExp, string]> = [
+  [/^LAYOUT_/i, 'layout directive'],
+  [/^SHOW_/i, 'display directive'],
+  [/^HIDE_/i, 'display directive'],
+  [/^Lay_/i, 'manual layout hint'],
+  [/^(AddElementTag|AddRelTag|AddBoundaryTag|UpdateElementStyle|UpdateRelStyle|UpdateBoundaryStyle|SetDefaultLegendEntries)$/, 'styling macro (not imported yet)'],
+  [/^(Deployment_Node|Node|Node_L|Node_R|Deployment_Node_L|Deployment_Node_R)$/, 'deployment node (deployment import is a follow-up)'],
+  [/^(ContainerDb|ContainerQueue)_Boundary$/, 'boundary variant'],
+]
+
+export function parseC4PlantUML(content: string): ImportResult {
+  const b = new ModelBuilder()
+  const lines = tokenizeMacroLines(content)
+  // Mutable through the bare-line handler's callbacks, hence an object.
+  const state = { skipUntil: null as RegExp | null, sawStart: false }
+  let depthOfSkippedBlock = 0
+
+  for (const l of lines) {
+    if (state.skipUntil) {
+      if (l.kind === 'bare' && state.skipUntil.test(l.text)) state.skipUntil = null
+      continue
+    }
+    if (depthOfSkippedBlock > 0) {
+      if (l.kind === 'close') depthOfSkippedBlock--
+      else if (l.kind === 'call' && l.opensBlock) depthOfSkippedBlock++
+      continue
+    }
+    if (l.kind === 'close') { b.closeBoundary(l.line); continue }
+    if (l.kind === 'bare') { handleBare(l, b, (re) => { state.skipUntil = re }, () => { state.sawStart = true }); continue }
+
+    const ev = elementVariant(l.name)
+    if (ev) { b.addElement(l, ev); continue }
+    const rv = relationshipVariant(l.name)
+    if (rv) { b.addRelationship(l, rv.bidirectional); continue }
+    const bv = boundaryVariant(l.name)
+    if (bv) {
+      b.openBoundary(l, bv)
+      if (!l.opensBlock) b.closeBoundary(l.line) // one-line boundary with no body
+      continue
+    }
+    const skipped = SKIPPED_CALLS.find(([re]) => re.test(l.name))
+    if (skipped) {
+      b.warn(l.line, `${l.name}(…): ${skipped[1]} skipped`)
+      if (l.opensBlock) depthOfSkippedBlock = 1
+      continue
+    }
+    b.warn(l.line, `Unrecognised macro ${l.name}(…) skipped`)
+    if (l.opensBlock) depthOfSkippedBlock = 1
+  }
+
+  if (!state.sawStart) b.warn(1, 'No @startuml found — imported as a bare macro list')
+  const workspace = b.build()
+  return { workspace, warnings: b.warnings, viewHint: b.viewHint(), summary: summarize(workspace) }
+}
+
+function handleBare(
+  l: Extract<MacroLine, { kind: 'bare' }>,
+  b: ModelBuilder,
+  skipBlock: (until: RegExp) => void,
+  markStart: () => void,
+): void {
+  const t = l.text
+  const start = t.match(/^@startuml(?:\s+(.+))?$/i)
+  if (start) { markStart(); if (start[1] && !b.name) b.name = start[1].trim(); return }
+  if (/^@enduml$/i.test(t)) return
+  const title = t.match(/^title\s+(.+)$/i)
+  if (title) { b.name = title[1].trim().replace(/^"(.*)"$/, '$1'); return }
+  if (/^!include(url)?\b/i.test(t)) { b.warn(l.line, `${t.split(/\s+/)[0]} skipped — includes are not resolved (no file or network access)`); return }
+  if (/^!(define|procedure|function|unquoted|theme|pragma|\$)/i.test(t) || /^!/.test(t)) { b.warn(l.line, `Preprocessor line "${t.slice(0, 40)}" skipped`); return }
+  if (/^skinparam\b/i.test(t)) { b.warn(l.line, 'skinparam skipped'); return }
+  if (/^(note|legend|caption|header|footer)\b/i.test(t)) {
+    const kw = t.split(/\s+/)[0].toLowerCase()
+    // Single-line `note ... : text` has no end marker.
+    if (/:/.test(t) && kw === 'note') { b.warn(l.line, 'note skipped'); return }
+    b.warn(l.line, `${kw} block skipped`)
+    skipBlock(new RegExp(`^end\\s*${kw}\\b`, 'i'))
+    return
+  }
+  if (/^(left to right direction|top to bottom direction|scale\b|hide\b|show\b|allowmixing)/i.test(t)) {
+    b.warn(l.line, `"${t.slice(0, 40)}" skipped`)
+    return
+  }
+  b.warn(l.line, `Unrecognised line "${t.slice(0, 50)}" skipped`)
+}

--- a/src/lib/import/importTypes.ts
+++ b/src/lib/import/importTypes.ts
@@ -1,0 +1,44 @@
+import type { ViewType, Workspace } from '@/types/model'
+
+export type ForeignFormat = 'c4plantuml' | 'mermaid-c4' | 'structurizr' | 'unknown'
+
+export interface ImportWarning {
+  /** 1-based line in the source text. */
+  line: number
+  message: string
+}
+
+export interface ImportResult {
+  workspace: Workspace
+  warnings: ImportWarning[]
+  /** Which view type the source diagram was, so the canvas can open on the
+   *  matching generated view instead of the first one. */
+  viewHint?: ViewType
+  /** Counts for the dialog summary. */
+  summary: { people: number; systems: number; containers: number; components: number; relationships: number }
+}
+
+export class ImportError extends Error {
+  readonly line?: number
+  constructor(message: string, line?: number) {
+    super(message)
+    this.name = 'ImportError'
+    this.line = line
+  }
+}
+
+export function summarize(ws: Workspace): ImportResult['summary'] {
+  let containers = 0
+  let components = 0
+  for (const s of ws.model.softwareSystems) {
+    containers += s.containers.length
+    for (const c of s.containers) components += c.components.length
+  }
+  return {
+    people: ws.model.people.length,
+    systems: ws.model.softwareSystems.length,
+    containers,
+    components,
+    relationships: ws.model.relationships.length,
+  }
+}

--- a/src/lib/import/index.ts
+++ b/src/lib/import/index.ts
@@ -1,0 +1,77 @@
+// Import foreign C4 formats into a c4hero workspace (TEA-255).
+//
+// Every importer builds a Workspace, then the result is pushed through
+// `parseDSL(serializeDSL(ws))`. That round trip is the safety net: it proves
+// the imported model is fully representable in Structurizr DSL, reuses the
+// serializer's escaping, and synthesises default views. If it fails, the
+// import fails loudly with the parser's errors rather than loading a model
+// that could never be saved.
+
+import type { View, ViewType, Workspace } from '@/types/model'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+import { parseC4PlantUML } from './c4plantuml'
+import { parseMermaidC4, stripMermaidFence } from './mermaidC4'
+import { ImportError, summarize, type ForeignFormat, type ImportResult } from './importTypes'
+
+export type { ForeignFormat, ImportResult, ImportWarning } from './importTypes'
+export { ImportError } from './importTypes'
+
+export function detectFormat(content: string): ForeignFormat {
+  const text = stripMermaidFence(content)
+  if (/^\s*(C4Context|C4Container|C4Component|C4Dynamic|C4Deployment)\b/m.test(text)) return 'mermaid-c4'
+  if (/^\s*@startuml\b/m.test(text) || /^\s*!include(url)?\s+.*C4/m.test(text)) return 'c4plantuml'
+  if (/^\s*workspace\b[^\n]*\{/m.test(text)) return 'structurizr'
+  // A bare list of C4 macros with no header is still importable.
+  if (/^\s*(Person|System|Container|Component)(Db|Queue)?(_Ext)?\s*\(/m.test(text)) return 'c4plantuml'
+  return 'unknown'
+}
+
+export interface ForeignImport extends ImportResult {
+  format: 'c4plantuml' | 'mermaid-c4'
+  /** Key of the generated view matching the source diagram type, if any. */
+  initialViewKey?: string
+}
+
+function pickInitialView(ws: Workspace, hint: ViewType | undefined): string | undefined {
+  const all: View[] = [
+    ...ws.views.systemLandscapeViews, ...ws.views.systemContextViews,
+    ...ws.views.containerViews, ...ws.views.componentViews,
+  ]
+  const match = hint ? all.find((v) => v.type === hint) : undefined
+  return (match ?? all[0])?.key
+}
+
+/** Parse, then normalise through the DSL round trip. Throws ImportError
+ *  when the text isn't a supported format or the result can't be expressed
+ *  in Structurizr DSL. */
+export function importForeign(content: string): ForeignImport {
+  if (content.length === 0 || content.trim() === '') throw new ImportError('Nothing to import')
+  const format = detectFormat(content)
+  if (format === 'structurizr') throw new ImportError('This is already Structurizr DSL — open it with "Open .dsl file" instead')
+  if (format === 'unknown') throw new ImportError('Not recognised as C4-PlantUML (@startuml with C4 macros) or Mermaid C4 (C4Context / C4Container / C4Component)')
+
+  const raw = format === 'mermaid-c4' ? parseMermaidC4(content) : parseC4PlantUML(content)
+  if (raw.summary.people + raw.summary.systems === 0) {
+    throw new ImportError('No people or software systems found — check the warnings for what was skipped')
+  }
+
+  let dsl: string
+  try {
+    dsl = serializeDSL(raw.workspace)
+  } catch (err) {
+    throw new ImportError(`The imported model cannot be written as Structurizr DSL: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  const { workspace, errors } = parseDSL(dsl)
+  if (errors.length > 0) {
+    throw new ImportError(`The imported model did not round-trip through Structurizr DSL: ${errors.map((e) => `${e.line}:${e.column} ${e.message}`).join('; ')}`)
+  }
+  if (!workspace.name) workspace.name = raw.workspace.name
+  return {
+    format,
+    workspace,
+    warnings: raw.warnings,
+    viewHint: raw.viewHint,
+    summary: summarize(workspace),
+    initialViewKey: pickInitialView(workspace, raw.viewHint),
+  }
+}

--- a/src/lib/import/macroCall.test.ts
+++ b/src/lib/import/macroCall.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { splitArgs, unquote, tokenizeMacroLines, args } from './macroCall'
+
+describe('splitArgs', () => {
+  it('splits on top-level commas only', () => {
+    expect(splitArgs('a, "b, c", d(e, f), \'g,h\'')).toEqual(['a', '"b, c"', 'd(e, f)', "'g,h'"])
+  })
+  it('keeps an escaped quote inside a string', () => {
+    expect(splitArgs('"say \\"hi\\", ok", 2')).toEqual(['"say \\"hi\\", ok"', '2'])
+  })
+  it('returns [] for an empty list', () => {
+    expect(splitArgs('')).toEqual([])
+  })
+})
+
+describe('unquote', () => {
+  it('strips matching quotes and decodes \\n and \\"', () => {
+    expect(unquote('"a\\nb \\"c\\""')).toBe('a\nb "c"')
+    expect(unquote("'x'")).toBe('x')
+    expect(unquote('bare')).toBe('bare')
+    expect(unquote('"unterminated')).toBe('"unterminated')
+  })
+})
+
+describe('tokenizeMacroLines', () => {
+  it('recognises calls, blocks, bare lines and skips comments', () => {
+    const lines = tokenizeMacroLines(`@startuml
+' a comment
+%% another
+System_Boundary(c1, "Bank") {
+  Container(web, "Web App", "Java", "Serves pages")
+}
+Rel(a, b, "Uses")
+`)
+    expect(lines.map((l) => l.kind)).toEqual(['bare', 'call', 'call', 'close', 'call'])
+    const boundary = lines[1]
+    expect(boundary.kind === 'call' && boundary.name).toBe('System_Boundary')
+    expect(boundary.kind === 'call' && boundary.opensBlock).toBe(true)
+    expect(boundary.line).toBe(4)
+    const web = lines[2]
+    expect(web.kind === 'call' && web.positional).toEqual(['web', 'Web App', 'Java', 'Serves pages'])
+  })
+
+  it('parses $named arguments and lets them override positional order', () => {
+    const [l] = tokenizeMacroLines('Person($alias="p1", $label="Someone", $descr="d")')
+    expect(l.kind === 'call' && l.named).toEqual({ alias: 'p1', label: 'Someone', descr: 'd' })
+    const a = args(l as Extract<typeof l, { kind: 'call' }>, ['alias', 'label', 'descr'])
+    expect(a).toEqual({ alias: 'p1', label: 'Someone', descr: 'd' })
+  })
+
+  it('treats empty strings as not given', () => {
+    const [l] = tokenizeMacroLines('Container(c, "C", "", "desc")')
+    const a = args(l as Extract<typeof l, { kind: 'call' }>, ['alias', 'label', 'techn', 'descr'])
+    expect(a.techn).toBeUndefined()
+    expect(a.descr).toBe('desc')
+  })
+})

--- a/src/lib/import/macroCall.ts
+++ b/src/lib/import/macroCall.ts
@@ -1,0 +1,100 @@
+// Line-oriented tokenizer for the C4-PlantUML macro syntax that Mermaid's C4
+// diagrams deliberately mirror: `Name(arg, "quoted arg", $key=value) {`.
+//
+// This is not a PlantUML grammar. It recognises one macro call per line,
+// block open/close braces, and the handful of bare directives both importers
+// care about; everything else is reported to the caller as an "other" line
+// so it can warn with a line number instead of dropping it silently.
+
+export interface MacroCall {
+  kind: 'call'
+  line: number
+  name: string
+  /** Positional args, quotes stripped, in order. */
+  positional: string[]
+  /** `$key=value` args, quotes stripped, keys without the `$`. */
+  named: Record<string, string>
+  /** The line ended with `{` — a block follows. */
+  opensBlock: boolean
+}
+
+export interface BlockClose { kind: 'close'; line: number }
+export interface BareLine { kind: 'bare'; line: number; text: string }
+export type MacroLine = MacroCall | BlockClose | BareLine
+
+const CALL = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*(\{)?\s*$/
+
+/** Split a macro argument list on top-level commas, respecting quotes and
+ *  nested parentheses. `"a, b", c(d, e)` → ['"a, b"', 'c(d, e)']. */
+export function splitArgs(text: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let depth = 0
+  let quote: '"' | "'" | null = null
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (quote) {
+      cur += ch
+      if (ch === '\\' && i + 1 < text.length) { cur += text[++i]; continue }
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'") { quote = ch; cur += ch; continue }
+    if (ch === '(') depth++
+    if (ch === ')') depth--
+    if (ch === ',' && depth === 0) { out.push(cur); cur = ''; continue }
+    cur += ch
+  }
+  if (cur.trim() !== '' || out.length > 0) out.push(cur)
+  return out.map((a) => a.trim())
+}
+
+/** Strip one layer of matching quotes and decode the escapes PlantUML and
+ *  Mermaid both accept inside them (`\"`, `\n`). */
+export function unquote(raw: string): string {
+  const t = raw.trim()
+  if (t.length >= 2 && ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'")))) {
+    return t.slice(1, -1).replace(/\\n/g, '\n').replace(/\\(["'\\])/g, '$1')
+  }
+  return t
+}
+
+/** Tokenise every line. Comments (`'` in PlantUML, `%%` in Mermaid, `//`)
+ *  and blank lines are dropped. */
+export function tokenizeMacroLines(content: string): MacroLine[] {
+  const out: MacroLine[] = []
+  const lines = content.split(/\r?\n/)
+  for (let i = 0; i < lines.length; i++) {
+    const lineNo = i + 1
+    const raw = lines[i]
+    const text = raw.trim()
+    if (text === '' || text.startsWith("'") || text.startsWith('%%') || text.startsWith('//')) continue
+    if (text === '}') { out.push({ kind: 'close', line: lineNo }); continue }
+    const m = text.match(CALL)
+    if (m) {
+      const positional: string[] = []
+      const named: Record<string, string> = {}
+      for (const arg of splitArgs(m[2])) {
+        const nm = arg.match(/^\$([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([\s\S]*)$/)
+        if (nm) named[nm[1]] = unquote(nm[2])
+        else positional.push(unquote(arg))
+      }
+      out.push({ kind: 'call', line: lineNo, name: m[1], positional, named, opensBlock: m[3] === '{' })
+      continue
+    }
+    out.push({ kind: 'bare', line: lineNo, text })
+  }
+  return out
+}
+
+/** Resolve a macro's arguments by the documented positional order, letting
+ *  `$name=` forms override. Missing args are `undefined`; empty strings are
+ *  kept as `undefined` too, since both tools treat `""` as "not given". */
+export function args(call: MacroCall, order: string[]): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {}
+  order.forEach((key, i) => {
+    const v = call.named[key] ?? call.positional[i]
+    out[key] = v === undefined || v === '' ? undefined : v
+  })
+  return out
+}

--- a/src/lib/import/mermaidC4.test.ts
+++ b/src/lib/import/mermaidC4.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseMermaidC4, stripMermaidFence } from './mermaidC4'
+import { importForeign } from './index'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+
+const fixture = (name: string) => readFileSync(join(__dirname, '__fixtures__', name), 'utf8')
+
+describe('parseMermaidC4', () => {
+  it('strips a markdown fence', () => {
+    expect(stripMermaidFence('intro\n```mermaid\nC4Context\n  Person(a, "A")\n```\nafter')).toBe('C4Context\n  Person(a, "A")\n')
+    expect(stripMermaidFence('C4Context')).toBe('C4Context')
+  })
+
+  it('imports a C4Container block with boundaries, variants and styling directives skipped', () => {
+    const r = parseMermaidC4(`C4Container
+    title Container diagram for Internet Banking System
+    Person(customer, Customer, "A customer of the bank.")
+    Container_Boundary(c1, "Internet Banking") {
+        Container(spa, "Single-Page App", "JavaScript, Angular", "Provides all the Internet banking functionality")
+        ContainerDb(database, "Database", "SQL Database", "Stores user registration information")
+        Container(backend_api, "API Application", "Java, Docker Container", "Provides Internet banking functionality via API")
+    }
+    System_Ext(email_system, "E-Mail System", "The internal Microsoft Exchange system.")
+    Rel(customer, spa, "Uses", "HTTPS")
+    Rel(spa, backend_api, "Uses", "async, JSON/HTTPS")
+    Rel_Back(database, backend_api, "Reads from and writes to", "sync, JDBC")
+    UpdateRelStyle(customer, spa, $offsetY="60", $offsetX="90")
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")`)
+    const ws = r.workspace
+    expect(ws.name).toBe('Container diagram for Internet Banking System')
+    expect(ws.model.people[0]).toMatchObject({ id: 'customer', name: 'Customer' })
+    // A Container_Boundary at the top of a C4Container diagram wraps containers
+    // (Mermaid's idiom, where PlantUML uses System_Boundary) — so it becomes
+    // the software system that owns them.
+    const sys = ws.model.softwareSystems.find((s) => s.containers.length > 0)!
+    expect(sys.name).toBe('Internet Banking')
+    expect(sys.id).toBe('c1')
+    expect(sys.containers.map((c) => c.id)).toEqual(['spa', 'database', 'backend_api'])
+    expect(ws.model.softwareSystems.find((s) => s.id === 'email_system')?.location).toBe('External')
+    expect(ws.model.relationships).toHaveLength(3)
+    expect(r.viewHint).toBe('container')
+    expect(r.warnings.map((w) => `${w.line}: ${w.message}`)).toEqual([
+      '13: UpdateRelStyle(…): styling/layout directive (not imported yet) skipped',
+      '14: UpdateLayoutConfig(…): styling/layout directive (not imported yet) skipped',
+    ])
+  })
+
+  it('imports only the first block and says so', () => {
+    const r = parseMermaidC4(`C4Context
+  Person(a, "A")
+C4Container
+  Person(b, "B")`)
+    expect(r.workspace.model.people.map((p) => p.id)).toEqual(['a'])
+    expect(r.warnings.map((w) => w.message)).toEqual(['Second diagram "C4Container" ignored — only the first block is imported'])
+  })
+
+  it('imports C4Dynamic as a static model with a warning', () => {
+    const r = parseMermaidC4(`C4Dynamic
+  Person(a, "A")
+  System(s, "S")
+  Rel(a, s, "calls")`)
+    expect(r.workspace.model.relationships).toHaveLength(1)
+    expect(r.warnings.some((w) => /C4Dynamic imported as a static model/.test(w.message))).toBe(true)
+  })
+
+  it('warns when there is no C4 block at all', () => {
+    const r = parseMermaidC4('flowchart TD\n  A --> B')
+    expect(r.warnings.some((w) => /No C4Context/.test(w.message))).toBe(true)
+  })
+})
+
+describe('golden: context.mmd', () => {
+  it('imports to the checked-in DSL, which parses clean and round-trips', () => {
+    const result = importForeign(fixture('context.mmd'))
+    expect(result.format).toBe('mermaid-c4')
+    const dsl = serializeDSL(result.workspace)
+    expect(dsl).toBe(fixture('context.golden.dsl'))
+    const { errors } = parseDSL(dsl)
+    expect(errors).toEqual([])
+    expect(result.summary).toEqual({ people: 4, systems: 8, containers: 0, components: 0, relationships: 6 })
+    expect(result.viewHint).toBe('systemContext')
+    // Every boundary in a C4Context diagram wraps people/systems, so each
+    // became a group; parents contain their children's members. (Order is
+    // the parser's — innermost group blocks close first.)
+    expect(result.workspace.model.groups.map((g) => [g.name, g.elementIds.length, !!g.parentId])).toEqual([
+      ['BankBoundary2', 2, true], ['BankBoundary3', 2, true], ['BankBoundary', 7, true], ['BankBoundary0', 12, false],
+    ])
+    const messages = result.warnings.map((w) => w.message)
+    expect(messages.filter((m) => /BiRel/.test(m))).toHaveLength(2)
+    expect(messages.filter((m) => /Update(Element|Rel)Style|UpdateLayoutConfig/.test(m))).toHaveLength(3)
+    const lines = result.warnings.map((w) => w.line)
+    expect([...lines].sort((a, b) => a - b)).toEqual(lines)
+  })
+})

--- a/src/lib/import/mermaidC4.ts
+++ b/src/lib/import/mermaidC4.ts
@@ -1,0 +1,87 @@
+// Mermaid C4 importer: `C4Context` / `C4Container` / `C4Component` /
+// `C4Dynamic` / `C4Deployment` blocks, whose syntax mirrors C4-PlantUML's.
+
+import type { ViewType } from '@/types/model'
+import { tokenizeMacroLines } from './macroCall'
+import { ModelBuilder, elementVariant, relationshipVariant, boundaryVariant } from './modelBuilder'
+import { summarize, type ImportResult } from './importTypes'
+
+const BLOCK_KINDS: Record<string, ViewType | 'dynamic' | 'deployment'> = {
+  C4Context: 'systemContext',
+  C4Container: 'container',
+  C4Component: 'component',
+  C4Dynamic: 'dynamic',
+  C4Deployment: 'deployment',
+}
+
+/** Strip a ```` ```mermaid ```` fence when the text is a markdown snippet. */
+export function stripMermaidFence(content: string): string {
+  const m = content.match(/```\s*mermaid\s*\r?\n([\s\S]*?)```/i)
+  return m ? m[1] : content
+}
+
+const SKIPPED_CALLS: Array<[RegExp, string]> = [
+  [/^(UpdateElementStyle|UpdateRelStyle|UpdateBoundaryStyle|UpdateLayoutConfig)$/, 'styling/layout directive (not imported yet)'],
+  [/^(Deployment_Node|Node|Node_L|Node_R)$/, 'deployment node (deployment import is a follow-up)'],
+]
+
+export function parseMermaidC4(input: string): ImportResult {
+  const content = stripMermaidFence(input)
+  const b = new ModelBuilder()
+  const lines = tokenizeMacroLines(content)
+  let blockKind: string | null = null
+  let blocksSeen = 0
+  let depthOfSkippedBlock = 0
+
+  for (const l of lines) {
+    if (depthOfSkippedBlock > 0) {
+      if (l.kind === 'close') depthOfSkippedBlock--
+      else if (l.kind === 'call' && l.opensBlock) depthOfSkippedBlock++
+      continue
+    }
+    if (l.kind === 'bare') {
+      const head = l.text.match(/^(C4Context|C4Container|C4Component|C4Dynamic|C4Deployment)\b/)
+      if (head) {
+        blocksSeen++
+        if (blocksSeen === 1) blockKind = head[1]
+        else b.warn(l.line, `Second diagram "${head[1]}" ignored — only the first block is imported`)
+        continue
+      }
+      if (blocksSeen > 1) continue
+      const title = l.text.match(/^title\s+(.+)$/i)
+      if (title) { b.name = title[1].trim().replace(/^"(.*)"$/, '$1'); continue }
+      if (/^accTitle\b|^accDescr\b/i.test(l.text)) continue
+      if (!blockKind) { b.warn(l.line, `Line before the C4 block skipped: "${l.text.slice(0, 40)}"`); continue }
+      b.warn(l.line, `Unrecognised line "${l.text.slice(0, 50)}" skipped`)
+      continue
+    }
+    if (blocksSeen > 1) continue
+    if (l.kind === 'close') { b.closeBoundary(l.line); continue }
+
+    const ev = elementVariant(l.name)
+    if (ev) { b.addElement(l, ev); continue }
+    const rv = relationshipVariant(l.name)
+    if (rv) { b.addRelationship(l, rv.bidirectional); continue }
+    const bv = boundaryVariant(l.name)
+    if (bv) {
+      b.openBoundary(l, bv)
+      if (!l.opensBlock) b.closeBoundary(l.line)
+      continue
+    }
+    const skipped = SKIPPED_CALLS.find(([re]) => re.test(l.name))
+    if (skipped) {
+      b.warn(l.line, `${l.name}(…): ${skipped[1]} skipped`)
+      if (l.opensBlock) depthOfSkippedBlock = 1
+      continue
+    }
+    b.warn(l.line, `Unrecognised macro ${l.name}(…) skipped`)
+    if (l.opensBlock) depthOfSkippedBlock = 1
+  }
+
+  if (!blockKind) b.warn(1, 'No C4Context / C4Container / C4Component block found')
+  const workspace = b.build()
+  const kind = blockKind ? BLOCK_KINDS[blockKind] : undefined
+  const viewHint: ViewType = kind === 'systemContext' || kind === 'container' || kind === 'component' ? kind : b.viewHint()
+  if (kind === 'dynamic' || kind === 'deployment') b.warn(1, `${blockKind} imported as a static model — steps and nodes are not imported yet`)
+  return { workspace, warnings: b.warnings, viewHint, summary: summarize(workspace) }
+}

--- a/src/lib/import/modelBuilder.ts
+++ b/src/lib/import/modelBuilder.ts
@@ -1,0 +1,352 @@
+// Shared model construction for the C4-PlantUML and Mermaid C4 importers.
+//
+// Both syntaxes describe the same things with the same macro names, so the
+// mapping from macro → c4hero element lives here once: element kinds and
+// their Db/Queue/Ext variants, boundaries, relationships with their
+// direction suffixes, and the id policy.
+//
+// Boundaries are the subtle part. The two ecosystems use them differently:
+// C4-PlantUML wraps containers in `System_Boundary` and components in
+// `Container_Boundary`; Mermaid's C4Container diagrams wrap containers in
+// `Container_Boundary`, and C4Context diagrams wrap *systems* in
+// `System_Boundary`. So a boundary is materialised lazily from its first
+// child: a Person/System child makes it a group, a Container child makes it
+// a system (or a container group inside an enclosing system), a Component
+// child makes it a container.
+
+import type {
+  Workspace, Person, SoftwareSystem, Container, Component, Group, Relationship, ElementStyle, ViewType,
+} from '@/types/model'
+import type { ImportWarning } from './importTypes'
+import type { MacroCall } from './macroCall'
+import { args } from './macroCall'
+
+type Kind = 'person' | 'system' | 'container' | 'component'
+type Variant = { kind: Kind; ext: boolean; db: boolean; queue: boolean }
+
+/** Person / Person_Ext / System / SystemDb_Ext / ContainerQueue / Component… */
+export function elementVariant(name: string): Variant | null {
+  const m = name.match(/^(Person|System|Container|Component)(Db|Queue)?(_Ext)?$/)
+  if (!m) return null
+  const kind = m[1].toLowerCase() as Kind
+  return { kind, db: m[2] === 'Db', queue: m[2] === 'Queue', ext: m[3] === '_Ext' }
+}
+
+/** Rel, Rel_D/U/L/R, Rel_Down/Up/Left/Right, Rel_Back, Rel_Neighbor, BiRel… */
+export function relationshipVariant(name: string): { bidirectional: boolean } | null {
+  if (/^Rel(_(D|U|L|R|Down|Up|Left|Right|Back|Neighbor|Neighbour|Back_Neighbor|Back_Neighbour))?$/.test(name)) return { bidirectional: false }
+  if (/^BiRel(_(D|U|L|R|Down|Up|Left|Right|Neighbor|Neighbour))?$/.test(name)) return { bidirectional: true }
+  return null
+}
+
+export type BoundaryKind = 'system' | 'container' | 'group'
+
+export function boundaryVariant(name: string): BoundaryKind | null {
+  if (name === 'System_Boundary') return 'system'
+  if (name === 'Container_Boundary') return 'container'
+  if (name === 'Boundary' || name === 'Enterprise_Boundary') return 'group'
+  return null
+}
+
+interface Scope {
+  kind: BoundaryKind
+  alias?: string
+  label: string
+  descr?: string
+  line: number
+  /** What the boundary became, once its first child arrived. */
+  as?: { system: SoftwareSystem } | { container: Container } | { group: Group }
+}
+
+export class ModelBuilder {
+  readonly warnings: ImportWarning[] = []
+  readonly people: Person[] = []
+  readonly systems: SoftwareSystem[] = []
+  readonly relationships: Relationship[] = []
+  readonly groups: Group[] = []
+  name = ''
+  private readonly ids = new Set<string>()
+  private readonly byAlias = new Map<string, { id: string; kind: Kind }>()
+  private readonly scopes: Scope[] = []
+  private relSeq = 0
+  private needsDbStyle = false
+  private needsQueueStyle = false
+  private orphanSystem: SoftwareSystem | null = null
+
+  warn(line: number, message: string) {
+    this.warnings.push({ line, message })
+  }
+
+  /** Turn a source alias into a DSL-safe, unique identifier. The alias is
+   *  kept when it already is one so the emitted DSL diffs against the source. */
+  private idFor(alias: string | undefined, fallback: string): string {
+    let base = (alias ?? fallback).replace(/[^A-Za-z0-9_]/g, '_')
+    if (!/^[A-Za-z_]/.test(base)) base = `e_${base}`
+    if (base === '') base = 'element'
+    let id = base
+    let n = 2
+    while (this.ids.has(id)) id = `${base}${n++}`
+    this.ids.add(id)
+    return id
+  }
+
+  // ─── Scope resolution ────────────────────────────────────────────
+
+  private enclosingSystem(): SoftwareSystem | undefined {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      const as = this.scopes[i].as
+      if (as && 'system' in as) return as.system
+    }
+    return undefined
+  }
+  private enclosingContainer(): Container | undefined {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      const as = this.scopes[i].as
+      if (as && 'container' in as) return as.container
+    }
+    return undefined
+  }
+  private enclosingGroup(): Group | undefined {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      const as = this.scopes[i].as
+      if (as && 'group' in as) return as.group
+    }
+    return undefined
+  }
+
+  /** Record `id` in the nearest group and every group above it — the
+   *  serializer requires a parent group to contain its children's members. */
+  private joinGroups(id: string) {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      const as = this.scopes[i].as
+      if (as && 'group' in as && !as.group.elementIds.includes(id)) as.group.elementIds.push(id)
+    }
+  }
+
+  private materialiseAsGroup(scope: Scope): Group {
+    const group: Group = { id: this.idFor(scope.alias, 'group'), name: scope.label, elementIds: [] }
+    // Only the nearest already-materialised group above is a parent; a
+    // pending boundary above becomes a group too the moment it needs to.
+    for (let i = this.scopes.indexOf(scope) - 1; i >= 0; i--) {
+      const above = this.scopes[i]
+      if (!above.as) above.as = { group: this.materialiseAsGroup(above) }
+      if ('group' in above.as) { group.parentId = above.as.group.id; break }
+    }
+    this.groups.push(group)
+    scope.as = { group }
+    return group
+  }
+
+  private materialiseAsSystem(scope: Scope): SoftwareSystem {
+    const known = scope.alias ? this.byAlias.get(scope.alias) : undefined
+    let sys = known?.kind === 'system' ? this.systems.find((s) => s.id === known.id) : undefined
+    if (!sys) {
+      sys = { id: this.idFor(scope.alias, scope.label), type: 'softwareSystem', name: scope.label, description: scope.descr, tags: ['Element', 'Software System'], properties: {}, containers: [] }
+      this.systems.push(sys)
+      if (scope.alias) this.byAlias.set(scope.alias, { id: sys.id, kind: 'system' })
+      this.joinGroups(sys.id)
+    }
+    scope.as = { system: sys }
+    return sys
+  }
+
+  private materialiseAsContainer(scope: Scope): Container {
+    const known = scope.alias ? this.byAlias.get(scope.alias) : undefined
+    let container: Container | undefined
+    if (known?.kind === 'container') for (const s of this.systems) container = container ?? s.containers.find((c) => c.id === known.id)
+    if (!container) {
+      const sys = this.enclosingSystem() ?? this.orphanParent(scope.line, `Container boundary "${scope.label}"`)
+      container = { id: this.idFor(scope.alias, scope.label), type: 'container', name: scope.label, description: scope.descr, tags: ['Element', 'Container'], properties: {}, components: [] }
+      sys.containers.push(container)
+      if (scope.alias) this.byAlias.set(scope.alias, { id: container.id, kind: 'container' })
+      this.joinGroups(container.id)
+    }
+    scope.as = { container }
+    return container
+  }
+
+  /** Decide what the innermost pending boundary is, given what is being
+   *  declared inside it. Returns after every pending ancestor that matters
+   *  has been materialised. */
+  private settleScopeFor(childKind: Kind) {
+    const scope = this.scopes[this.scopes.length - 1]
+    if (!scope || scope.as) return
+    if (childKind === 'person' || childKind === 'system' || scope.kind === 'group') {
+      this.materialiseAsGroup(scope)
+      return
+    }
+    if (childKind === 'container') {
+      // Inside an already-materialised system, a further boundary is a
+      // container group; at the top it is the system itself.
+      if (this.enclosingSystem()) this.materialiseAsGroup(scope)
+      else this.materialiseAsSystem(scope)
+      return
+    }
+    // component
+    if (this.enclosingContainer()) this.materialiseAsGroup(scope)
+    else this.materialiseAsContainer(scope)
+  }
+
+  /** A container declared outside any boundary needs a parent; make one
+   *  named after the diagram so nothing is dropped. */
+  private orphanParent(line: number, what: string): SoftwareSystem {
+    if (!this.orphanSystem) {
+      const label = this.name || 'Imported System'
+      this.orphanSystem = {
+        id: this.idFor(undefined, 'importedSystem'), type: 'softwareSystem', name: label, tags: ['Element', 'Software System'], properties: {}, containers: [],
+      }
+      this.systems.push(this.orphanSystem)
+      this.warn(line, `${what} declared outside a System_Boundary — placed in a synthesised software system "${label}"`)
+    }
+    return this.orphanSystem
+  }
+
+  private orphanContainer(line: number, what: string): Container {
+    const sys = this.enclosingSystem() ?? this.orphanParent(line, what)
+    let holder = sys.containers.find((c) => c.properties['c4hero.import.synthesised'] === 'true')
+    if (!holder) {
+      holder = {
+        id: this.idFor(undefined, `${sys.id}Components`), type: 'container', name: `${sys.name} components`, tags: ['Element', 'Container'],
+        properties: { 'c4hero.import.synthesised': 'true' }, components: [],
+      }
+      sys.containers.push(holder)
+      this.warn(line, `${what} declared outside a Container_Boundary — placed in a synthesised container "${holder.name}"`)
+    }
+    return holder
+  }
+
+  // ─── Declarations ───────────────────────────────────────────────
+
+  addElement(call: MacroCall, variant: Variant): void {
+    const isContainerLike = variant.kind === 'container' || variant.kind === 'component'
+    const a = isContainerLike
+      ? args(call, ['alias', 'label', 'techn', 'descr', 'sprite', 'tags', 'link'])
+      : args(call, ['alias', 'label', 'descr', 'sprite', 'tags', 'link'])
+    if (!a.alias) { this.warn(call.line, `${call.name}: missing alias — skipped`); return }
+    this.settleScopeFor(variant.kind)
+    const name = a.label ?? a.alias
+    const id = this.idFor(a.alias, name)
+    const tags: string[] = []
+    if (variant.db) { tags.push('Database'); this.needsDbStyle = true }
+    if (variant.queue) { tags.push('Queue'); this.needsQueueStyle = true }
+    for (const t of (a.tags ?? '').split(/[+,]/)) { const tt = t.trim(); if (tt) tags.push(tt) }
+    if (a.sprite) this.warn(call.line, `${call.name}(${a.alias}): sprite "${a.sprite}" not imported`)
+
+    const common = { id, name, description: a.descr, properties: {} as Record<string, string>, url: a.link }
+    switch (variant.kind) {
+      case 'person': {
+        const p: Person = { ...common, type: 'person', tags: ['Element', 'Person', ...tags] }
+        if (variant.ext) p.location = 'External'
+        this.people.push(p)
+        this.attachTop(p, call.line)
+        break
+      }
+      case 'system': {
+        const s: SoftwareSystem = { ...common, type: 'softwareSystem', tags: ['Element', 'Software System', ...tags], containers: [] }
+        if (variant.ext) s.location = 'External'
+        this.systems.push(s)
+        this.attachTop(s, call.line)
+        break
+      }
+      case 'container': {
+        const c: Container = { ...common, type: 'container', technology: a.techn, tags: ['Element', 'Container', ...tags], components: [] }
+        if (variant.ext) c.tags.push('External')
+        const sys = this.enclosingSystem() ?? this.orphanParent(call.line, `Container "${name}"`)
+        sys.containers.push(c)
+        this.joinGroups(c.id)
+        break
+      }
+      case 'component': {
+        const comp: Component = { ...common, type: 'component', technology: a.techn, tags: ['Element', 'Component', ...tags] }
+        if (variant.ext) comp.tags.push('External')
+        const holder = this.enclosingContainer() ?? this.orphanContainer(call.line, `Component "${name}"`)
+        holder.components.push(comp)
+        this.joinGroups(comp.id)
+        break
+      }
+    }
+    this.byAlias.set(a.alias, { id, kind: variant.kind })
+    if (a.alias !== id) this.byAlias.set(id, { id, kind: variant.kind })
+  }
+
+  /** People and systems are top-level in c4hero; a boundary around them is
+   *  group membership, and a system/container boundary is only a warning. */
+  private attachTop(el: Person | SoftwareSystem, line: number) {
+    this.joinGroups(el.id)
+    if (this.enclosingGroup()) return
+    if (this.enclosingSystem() || this.enclosingContainer()) {
+      this.warn(line, `${el.type === 'person' ? 'Person' : 'System'} "${el.name}" declared inside a ${this.enclosingContainer() ? 'container' : 'system'} boundary — kept at the top level`)
+    }
+  }
+
+  openBoundary(call: MacroCall, kind: BoundaryKind): void {
+    const a = args(call, ['alias', 'label', 'type', 'descr', 'tags', 'link'])
+    this.scopes.push({ kind, alias: a.alias, label: a.label ?? a.alias ?? 'Boundary', descr: a.descr, line: call.line })
+  }
+
+  closeBoundary(line: number): void {
+    const scope = this.scopes.pop()
+    if (!scope) { this.warn(line, 'Unmatched "}"'); return }
+    // An empty boundary declared nothing; a system/container boundary with a
+    // known alias still deserves its element so relationships can target it.
+    if (!scope.as && scope.kind === 'system') this.materialiseAsSystem(scope)
+    else if (!scope.as && scope.kind === 'container') this.materialiseAsContainer(scope)
+  }
+
+  addRelationship(call: MacroCall, bidirectional: boolean): void {
+    const a = args(call, ['from', 'to', 'label', 'techn', 'descr', 'sprite', 'tags', 'link'])
+    if (!a.from || !a.to) { this.warn(call.line, `${call.name}: needs a source and a destination — skipped`); return }
+    const from = this.byAlias.get(a.from)
+    const to = this.byAlias.get(a.to)
+    if (!from || !to) {
+      this.warn(call.line, `${call.name}: unknown element "${!from ? a.from : a.to}" — skipped`)
+      return
+    }
+    const tags = ['Relationship']
+    for (const t of (a.tags ?? '').split(/[+,]/)) { const tt = t.trim(); if (tt) tags.push(tt) }
+    const make = (s: string, d: string): Relationship => ({
+      id: `rel${++this.relSeq}`, sourceId: s, destinationId: d,
+      description: a.label, technology: a.techn, tags: [...tags], properties: {}, url: a.link,
+    })
+    this.relationships.push(make(from.id, to.id))
+    if (bidirectional) {
+      this.relationships.push(make(to.id, from.id))
+      this.warn(call.line, `${call.name}: bidirectional relationship split into two one-way relationships`)
+    }
+  }
+
+  /** Guess the view type from what was declared, for the initial canvas. */
+  viewHint(): ViewType {
+    const hasComponents = this.systems.some((s) => s.containers.some((c) => c.components.length > 0))
+    const hasContainers = this.systems.some((s) => s.containers.length > 0)
+    if (hasComponents) return 'component'
+    if (hasContainers) return 'container'
+    return this.systems.length === 1 ? 'systemContext' : 'systemLandscape'
+  }
+
+  build(): Workspace {
+    while (this.scopes.length > 0) {
+      const s = this.scopes[this.scopes.length - 1]
+      this.warn(s.line, 'Boundary never closed — closed at end of input')
+      this.closeBoundary(s.line)
+    }
+    const styles: ElementStyle[] = []
+    if (this.needsDbStyle) styles.push({ tag: 'Database', shape: 'Cylinder' })
+    if (this.needsQueueStyle) styles.push({ tag: 'Queue', shape: 'Pipe' })
+    return {
+      name: this.name || 'Imported workspace',
+      model: {
+        people: this.people,
+        softwareSystems: this.systems,
+        relationships: this.relationships,
+        groups: this.groups.filter((g) => g.elementIds.length > 0),
+        deploymentEnvironments: [],
+      },
+      views: {
+        systemLandscapeViews: [], systemContextViews: [], containerViews: [], componentViews: [],
+        dynamicViews: [], deploymentViews: [],
+        configuration: { styles: { elements: styles, relationships: [] } },
+      },
+    }
+  }
+}

--- a/src/lib/import/modelBuilder.ts
+++ b/src/lib/import/modelBuilder.ts
@@ -201,14 +201,20 @@ export class ModelBuilder {
     return this.orphanSystem
   }
 
+  /** Synthesised holder container per system, so repeated orphan components
+   *  share one. Tracked here rather than as a property so nothing internal
+   *  leaks into the user's DSL. */
+  private readonly orphanHolders = new Map<string, Container>()
+
   private orphanContainer(line: number, what: string): Container {
     const sys = this.enclosingSystem() ?? this.orphanParent(line, what)
-    let holder = sys.containers.find((c) => c.properties['c4hero.import.synthesised'] === 'true')
+    let holder = this.orphanHolders.get(sys.id)
     if (!holder) {
       holder = {
         id: this.idFor(undefined, `${sys.id}Components`), type: 'container', name: `${sys.name} components`, tags: ['Element', 'Container'],
-        properties: { 'c4hero.import.synthesised': 'true' }, components: [],
+        properties: {}, components: [],
       }
+      this.orphanHolders.set(sys.id, holder)
       sys.containers.push(holder)
       this.warn(line, `${what} declared outside a Container_Boundary — placed in a synthesised container "${holder.name}"`)
     }

--- a/src/store/slices/lifecycle-slice.ts
+++ b/src/store/slices/lifecycle-slice.ts
@@ -106,6 +106,7 @@ export const createLifecycleSlice: StateCreator<
       pendingZoomConfirm: null,
       createViewDefaults: null,
       impactTargetIds: null,
+      importDialogOpen: false,
       diskConflict: null,
       diskFileMissing: false,
       undoStack: [],

--- a/src/store/slices/ui-slice.ts
+++ b/src/store/slices/ui-slice.ts
@@ -18,6 +18,7 @@ export type UiSlice = Pick<WorkspaceState,
   | 'searchOpen' | 'commandPaletteOpen'
   | 'canvasSettingsOpen' | 'canvasGuideOpen' | 'addElementPanelOpen' | 'highlighterOpenFacet'
   | 'viewsPanelOpen' | 'createViewDialogOpen'
+  | 'importDialogOpen' | 'setImportDialogOpen'
   | 'codePanelOpen' | 'setCodePanelOpen' | 'toggleCodePanel'
   | 'watchDisk' | 'setWatchDisk' | 'toggleWatchDisk'
   | 'diskConflict' | 'setDiskConflict' | 'diskFileMissing' | 'setDiskFileMissing'
@@ -62,6 +63,7 @@ export const createUiSlice: StateCreator<
   highlighterOpenFacet: null,
   viewsPanelOpen: false,
   createViewDialogOpen: false,
+  importDialogOpen: false,
   codePanelOpen: false,
   watchDisk: readString(WATCH_DISK_KEY) !== '0',
   diskConflict: null,
@@ -140,6 +142,7 @@ export const createUiSlice: StateCreator<
     if (s.codePanelOpen) s.commandPaletteOpen = false
   }),
   setCreateViewDialogOpen: (open) => set({ createViewDialogOpen: open, commandPaletteOpen: false }),
+  setImportDialogOpen: (open) => set({ importDialogOpen: open, commandPaletteOpen: false }),
 
   setWatchDisk: (on) => {
     writeString(WATCH_DISK_KEY, on ? '1' : '0')

--- a/src/store/workspace-types.ts
+++ b/src/store/workspace-types.ts
@@ -346,6 +346,9 @@ export interface WorkspaceState extends UndoState {
   setTechFilterMode: (mode: 'any' | 'all') => void
   setTeamFilterMode: (mode: 'any' | 'all') => void
   createViewDialogOpen: boolean
+  /** Import PlantUML / Mermaid dialog (TEA-255), opened from the menu or palette. */
+  importDialogOpen: boolean
+  setImportDialogOpen: (open: boolean) => void
   setCreateViewDialogOpen: (open: boolean) => void
   /** Elements the impact panel is analysing, snapshotted when it opened.
    *  Null when the panel is closed. */


### PR DESCRIPTION
## Summary

[TEA-255](https://linear.app/kevnord/issue/TEA-255). Drop a `.puml` file or a Mermaid `C4Context` / `C4Container` / `C4Component` block into c4hero and get a live, editable canvas plus clean Structurizr DSL.

### Library (`src/lib/import/`)

- **`macroCall.ts`** — tokenizer for the `Name(arg, "quoted", $key=value) {` syntax both ecosystems share. Quote- and paren-aware argument splitting, `$named` args overriding positional order, comments (`'`, `%%`, `//`) dropped, empty strings treated as "not given".
- **`modelBuilder.ts`** — one mapping for both formats. `Person` / `System` / `Container` / `Component` with `_Ext` (External location), `Db` (Database tag + Cylinder style) and `Queue` (Queue tag + Pipe style). `Rel` in every direction variant; `BiRel` split into two with a warning. DSL-safe unique ids that keep the source alias, so the emitted DSL diffs against the source.
- **Boundaries** are the subtle part: C4-PlantUML wraps containers in `System_Boundary` and components in `Container_Boundary`; Mermaid wraps containers in `Container_Boundary` and systems in `System_Boundary`. A boundary therefore materialises from its first child: a person/system child makes it a group, a container child makes it a system (or a container group inside an enclosing system), a component child makes it a container. Nested groups contain their children's members, as the serializer requires. Orphan containers/components get a synthesised parent rather than being dropped.
- **`c4plantuml.ts` / `mermaidC4.ts`** — the two front ends. `title` → workspace name; `!include`, `LAYOUT_*`, `SHOW_*`, `AddElementTag`/`Update*Style`, `Lay_*`, sprites, notes/legends, `Deployment_Node`, `skinparam`, unknown macros → one warning each with its line number. Mermaid: fence stripped, first block only (rest warned), `C4Dynamic`/`C4Deployment` imported as static models with a warning.
- **`index.ts`** — `detectFormat` and `importForeign`. Every import is pushed through `parseDSL(serializeDSL(ws))` before it loads. If that fails the import fails loudly; that is the round-trip contract enforced at the door. Structurizr DSL pasted here is redirected to the normal open flow.

### UI

- `ImportDialog`: choose file / drop / paste, live format detection, summary counts, collapsible warning list with line numbers, first error inline. If a workspace is open, a Replace confirmation (same wording pattern as the AI "Load diagram" flow) stands between the click and the load.
- Entry points: welcome screen button (both CTA layouts and the non-Chromium fallback), the mobile menu, and the `Import PlantUML / Mermaid` command in the palette (desktop path).
- The result loads as an unsaved single-file workspace: no filename, Save As suggests `<name>.dsl`, and the canvas opens on the view type matching the source diagram.

### Out of scope (per ticket)
Exporting back, PlantUML preprocessing, sprites/themes/styling macros, deployment nodes, dynamic steps, remote includes.

## Test plan

- [x] `npm run check` green (2635 tests)
- [x] Full Playwright suite: 186 passed, including the new `e2e/welcome/import-foreign.spec.ts` (welcome-screen paste → canvas with the container view open and Save As offered; warnings and error states; palette entry with replace confirmation)
- [x] Golden tests: `internet-banking.puml` and `context.mmd` import to the checked-in DSL, which parses clean and round-trips
- [x] Unit: every macro form incl. `$named`, variants, boundary idioms of both tools, groups nesting, BiRel split, all skipped directives with line numbers, orphan synthesis, unknown refs / missing alias / unclosed boundary, id sanitising, format detection, error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs