### PR TITLE
fix(dsl): decode legacy pre-TEA-163 escape sequences on load, migrate on save (TEA-167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Files saved by an older c4hero no longer load with drifted strings.**
+  Before v0.3 c4hero wrote JSON-style escapes (`\\` for a backslash, `\t`
+  for a tab); since the lexer started mirroring Structurizr, where only `\"`
+  and `\n` are escapes, those files read back with doubled backslashes and a
+  literal `\t`, and the next autosave could write the misread values back.
+  Old files are now recognised by the keyword lines only that serializer
+  produced (`status`, `owner`, `location`, `lineStyle`, `interactionStyle`),
+  decoded with the old rule, and migrated to Structurizr's format on the
+  next save, with a note in the code pane. A file that has `\\` or `\t` in
+  a string but no such marker is read by Structurizr's rule and flagged with
+  a warning instead of being changed silently. (TEA-167)
 - **Saving no longer deletes `!include`, `!const`, `!var`, `!docs` or `!adrs`
   lines.** The parser used to consume every `!` preprocessor directive and
   drop it, so opening a real Structurizr workspace whose model is split across

--- a/src/lib/dsl/legacy-escapes.test.ts
+++ b/src/lib/dsl/legacy-escapes.test.ts
@@ -1,0 +1,127 @@
+/**
+ * TEA-167: files saved by c4hero before TEA-163 used JSON-style escapes
+ * (`\\` for a backslash, `\t` for a tab). The modern lexer mirrors
+ * Structurizr, where only `\"` and `\n` are escapes, so such files read back
+ * drifted. They are detected by the keyword lines only that old serializer
+ * wrote, decoded with the old rule, and migrated on the next save.
+ */
+import { describe, it, expect } from 'vitest'
+import { parseDSL, serializeDSL } from '@/lib/dsl'
+import { lex } from './lexer'
+
+// What pre-TEA-163 c4hero actually wrote for a container named `C:\Program Files`
+// with a tab in its description and a status.
+const LEGACY = `workspace "Old" {
+    model {
+        sys = softwareSystem "Sys" {
+            c1 = container "C:\\\\Program Files" "col1\\tcol2" "Win" {
+                status Live
+            }
+        }
+    }
+    views {
+    }
+}
+`
+
+describe('legacy detection', () => {
+  it.each([
+    ['status', 'status Live'],
+    ['location', 'location External'],
+    ['owner', 'owner "Team Payments"'],
+  ])('recognises a bare %s line in an element body', (_k, line) => {
+    const { legacyEscapes } = parseDSL(`workspace {\n  model {\n    a = person "A" {\n      ${line}\n    }\n  }\n}`)
+    expect(legacyEscapes).toBe(true)
+  })
+
+  it.each([
+    ['lineStyle', 'lineStyle Curved'],
+    ['interactionStyle', 'interactionStyle Synchronous'],
+  ])('recognises a bare %s line in a relationship body', (_k, line) => {
+    const { legacyEscapes } = parseDSL(`workspace {\n  model {\n    a = person "A"\n    b = person "B"\n    a -> b "x" {\n      ${line}\n    }\n  }\n}`)
+    expect(legacyEscapes).toBe(true)
+  })
+
+  it('is not fooled by the same words as property keys, inside strings, in comments, or as identifiers', () => {
+    // Structurizr accepts unquoted property keys, so these are all legal
+    // hand-written files that must keep the Structurizr escape rule.
+    for (const src of [
+      'workspace { model { a = softwareSystem "C:\\\\x" { properties { owner "Team" } } } }',
+      'workspace { model { a = person "A"\n b = person "B"\n a -> b "x" { properties { lineStyle Curved } } } }',
+      'workspace { model { a = person "status Live" } views { properties { status Live } } }',
+      'workspace {\n // status Live\n model { } }',
+      'workspace {\n model {\n statusPage = softwareSystem "S"\n } }',
+    ]) {
+      const { legacyEscapes, workspace } = parseDSL(src)
+      expect(legacyEscapes, src).toBe(false)
+      const sys = workspace.model.softwareSystems[0]
+      if (sys?.name.startsWith('C:')) expect(sys.name).toBe('C:\\\\x') // two literal backslashes, as Structurizr reads it
+    }
+  })
+
+  it('is false for modern c4hero output', () => {
+    const { workspace } = parseDSL(LEGACY)
+    expect(parseDSL(serializeDSL(workspace)).legacyEscapes).toBe(false)
+  })
+})
+
+describe('legacy decoding', () => {
+  it('decodes \\\\ and \\t in legacy mode and leaves them literal otherwise', () => {
+    const src = '"a\\\\b\\tc\\"d\\ne"'
+    const legacy = lex(src, { legacyEscapes: true }).tokens[0].value
+    const modern = lex(src).tokens[0].value
+    expect(legacy).toBe('a\\b\tc"d\ne')
+    expect(modern).toBe('a\\\\b\\tc"d\ne')
+  })
+
+  it('a legacy file loads with the values the user originally typed', () => {
+    const { workspace, legacyEscapes, warnings, errors } = parseDSL(LEGACY)
+    expect(errors).toEqual([])
+    expect(legacyEscapes).toBe(true)
+    const c1 = workspace.model.softwareSystems[0].containers[0]
+    expect(c1.name).toBe('C:\\Program Files')
+    expect(c1.description).toBe('col1\tcol2')
+    expect(c1.status).toBe('Live')
+    expect(warnings[0].message).toMatch(/Saved by an older c4hero/)
+  })
+
+  it('saving migrates the file: modern output reads back identically and is no longer legacy', () => {
+    const first = parseDSL(LEGACY)
+    const migrated = serializeDSL(first.workspace)
+    expect(migrated).toContain('"C:\\Program Files"')     // one literal backslash
+    expect(migrated).not.toContain('status Live')          // emitted as a tag/property now
+    const second = parseDSL(migrated)
+    expect(second.legacyEscapes).toBe(false)
+    expect(second.warnings.some((w) => /older c4hero/.test(w.message))).toBe(false)
+    const c1 = second.workspace.model.softwareSystems[0].containers[0]
+    expect(c1.name).toBe('C:\\Program Files')
+    expect(c1.description).toBe('col1\tcol2')
+    expect(c1.status).toBe('Live')
+  })
+
+  it('the modern rule is untouched for files without a legacy marker', () => {
+    const { workspace, legacyEscapes } = parseDSL('workspace { model { a = person "C:\\\\x" } }')
+    expect(legacyEscapes).toBe(false)
+    expect(workspace.model.people[0].name).toBe('C:\\\\x')
+  })
+})
+
+describe('the residual gap is surfaced, not silent', () => {
+  it('warns when \\\\ or \\t appear in strings but no legacy marker is present', () => {
+    const looks = (src: string) => parseDSL(src).warnings.some((w) => /Structurizr reads literally/.test(w.message))
+    expect(looks('workspace { model { a = person "C:\\\\x" } }')).toBe(true)
+    expect(looks('workspace { model { a = person "a\\tb" } }')).toBe(true)
+    expect(looks('workspace { model { a = person "C:\\x" } }')).toBe(false)
+    expect(looks('workspace { // "\\\\" in a comment\n model { } }')).toBe(false)
+
+    const { warnings, legacyEscapes } = parseDSL('workspace { model { a = person "C:\\\\x" } }')
+    expect(legacyEscapes).toBe(false)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toMatch(/Structurizr reads literally/)
+  })
+
+  it('does not warn about a plain modern file', () => {
+    const { warnings } = parseDSL('workspace { model { a = person "C:\\x" "say \\"hi\\"" } }')
+    expect(warnings).toEqual([])
+  })
+})

--- a/src/lib/dsl/lexer.ts
+++ b/src/lib/dsl/lexer.ts
@@ -108,11 +108,24 @@ export interface LexResult {
  * The consume-one escape rule in one place: the step length at position `i`
  * inside a quoted string is 2 when a backslash begins one of the two real
  * escapes (`\"` or `\n`), else 1 — a backslash before anything else is a
- * literal consumed alone. readString and scanQuotedString both step with
- * this, so the tokenizer and boundary scanner cannot drift apart.
+ * literal consumed alone. readString (in modern mode) and scanQuotedString
+ * both step with this. Legacy mode (TEA-167) uses escapeStepLegacy in
+ * readString only; scanQuotedString always applies the Structurizr rule.
  */
 export function escapeStep(input: string, i: number): 1 | 2 {
     return input[i] === '\\' && (input[i + 1] === '"' || input[i + 1] === 'n') ? 2 : 1
+}
+
+/** The JSON-style rule c4hero used before TEA-163: `\\`, `\"`, `\n` and `\t`
+ *  are all two-character escapes. Only applied to files detected as legacy. */
+function escapeStepLegacy(input: string, i: number): 1 | 2 {
+    const n = input[i + 1]
+    return input[i] === '\\' && (n === '\\' || n === '"' || n === 'n' || n === 't') ? 2 : 1
+}
+
+export interface LexOptions {
+    /** Decode `\\` and `\t` as well (files saved by pre-TEA-163 c4hero). */
+    legacyEscapes?: boolean
 }
 
 /**
@@ -129,7 +142,9 @@ export function scanQuotedString(input: string, start: number): number {
     return i < input.length ? i + 1 : input.length
 }
 
-export function lex(input: string): LexResult {
+export function lex(input: string, opts: LexOptions = {}): LexResult {
+    const legacy = opts.legacyEscapes === true
+    const step = legacy ? escapeStepLegacy : escapeStep
     const tokens: Token[] = []
     const errors: LexerError[] = []
     let pos = 0
@@ -179,17 +194,17 @@ export function lex(input: string): LexResult {
             // `\t` is not an escape. On a miss, only the backslash itself is
             // consumed — the next char is re-examined, because it may start
             // an escape of its own (`a\\"b` is literal-\ then \" → `a\"b`).
-            // escapeStep (above) is the single home of that rule; consuming
-            // two chars here is what made c4hero disagree with every other
-            // Structurizr tool on backslash-heavy values.
-            // Known consequence: files saved by pre-TEA-163 c4hero used
-            // JSON-style `\\`/`\t` escapes and now read back literally;
-            // detecting and migrating those legacy files is TEA-167.
-            if (escapeStep(input, pos) === 2) {
+            // escapeStep is the single home of that rule; consuming two chars
+            // here is what made c4hero disagree with every other Structurizr
+            // tool on backslash-heavy values. Files saved by pre-TEA-163
+            // c4hero (`\\`, `\t`) are decoded when `legacy` is set; see
+            // escapeStepLegacy.
+            if (step(input, pos) === 2) {
                 const escaped = peekAt(1)
                 advance()
                 advance()
-                value += escaped === 'n' ? '\n' : '"'
+                // `\"` and `\\` decode to themselves; only n and t change.
+                value += escaped === 'n' ? '\n' : escaped === 't' ? '\t' : escaped
             } else {
                 value += advance()
             }

--- a/src/lib/dsl/parser-model.ts
+++ b/src/lib/dsl/parser-model.ts
@@ -638,6 +638,7 @@ function parseElementPropertyOnElement(p: ContextAwareParser, element: Element, 
         const val = p.readOptionalString()
         if (val !== undefined) element.url = val
     } else if (keyword === 'status') {
+        p.sawLegacyKeyword = true
         const val = p.peek()
         if (val.type === 'IDENTIFIER' || val.type === 'KEYWORD' || val.type === 'STRING') {
             const s = p.advance().value
@@ -646,9 +647,11 @@ function parseElementPropertyOnElement(p: ContextAwareParser, element: Element, 
             }
         }
     } else if (keyword === 'owner') {
+        p.sawLegacyKeyword = true
         const val = p.readOptionalString()
         if (val !== undefined) element.owner = val
     } else if (keyword === 'location') {
+        p.sawLegacyKeyword = true
         const val = p.peek()
         if (val.type === 'IDENTIFIER' || val.type === 'KEYWORD') {
             const loc = p.advance().value

--- a/src/lib/dsl/parser-relationship.ts
+++ b/src/lib/dsl/parser-relationship.ts
@@ -109,6 +109,7 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
             // 'interactionStyle' is not a reserved keyword so it arrives as IDENTIFIER
             if ((p.peekType() === 'IDENTIFIER' || p.peekType() === 'KEYWORD') &&
                 p.peekValue().toLowerCase() === 'interactionstyle') {
+                p.sawLegacyKeyword = true
                 p.advance()
                 const valTok = p.peek()
                 if (valTok.type === 'IDENTIFIER' || valTok.type === 'KEYWORD') {
@@ -143,6 +144,7 @@ export function parseRelationship(p: ContextAwareParser): Relationship | null {
             // 'lineStyle' in relationship body (Curved | Straight | Orthogonal)
             if ((p.peekType() === 'IDENTIFIER' || p.peekType() === 'KEYWORD') &&
                 p.peekValue().toLowerCase() === 'linestyle') {
+                p.sawLegacyKeyword = true
                 p.advance()
                 const valTok = p.peek()
                 if (valTok.type === 'IDENTIFIER' || valTok.type === 'KEYWORD') {

--- a/src/lib/dsl/parser.ts
+++ b/src/lib/dsl/parser.ts
@@ -124,6 +124,9 @@ export interface ParseError {
 export interface ParseResult {
     workspace: Workspace
     errors: ParseError[]
+    /** The input was recognised as saved by a pre-TEA-163 c4hero and its
+     *  `\\` / `\t` escapes were decoded (TEA-167). Saving migrates it. */
+    legacyEscapes: boolean
     /** Source line (1-based) where each element / relationship / group /
      *  deployment environment id was declared. Lets a caller that flattened
      *  `!include`s map ids back to their file (TEA-325 B). */
@@ -182,6 +185,13 @@ export class ContextAwareParser {
     lastModelDeclId: string | undefined
     /** Group body currently being parsed, for directive placement. */
     currentGroupId: string | undefined
+    /** Set when a bare `status` / `owner` / `location` / `lineStyle` /
+     *  `interactionStyle` keyword was consumed in an element or relationship
+     *  body. Only the pre-TEA-163 c4hero serializer wrote those lines (real
+     *  Structurizr rejects them), so this is the sound "saved by an old
+     *  c4hero" signal — and unlike a text scan it cannot be fooled by the same
+     *  word used as a property key or inside a string (TEA-167). */
+    sawLegacyKeyword = false
 
     /** Line of the most recently consumed token — the declaration line for
      *  whatever was just parsed. */
@@ -515,7 +525,9 @@ export class ContextAwareParser {
 
     // ─── Main Parse ──────────────────────────────────────────────────
 
-    parse(): ParseResult {
+    /** The document-level decision (`legacyEscapes`) belongs to the outer
+     *  parse(), which owns the lexer; this method never sets it. */
+    parse(): Omit<ParseResult, 'legacyEscapes'> {
         const workspace = this.createEmptyWorkspace()
 
         this.skipNewlines()
@@ -661,14 +673,45 @@ export class ContextAwareParser {
 // ─── Public API ─────────────────────────────────────────────────────
 
 export function parse(input: string): ParseResult {
-    globalIdCounter = 0 // Reset per parse call to avoid growing IDs across invocations
-    const lexResult = lex(input)
-    const parser = new ContextAwareParser(lexResult.tokens)
-    const result = parser.parse()
+    // Files saved by c4hero before TEA-163 used JSON-style escapes (`\\`,
+    // `\t`). Parse with the Structurizr rule first; if the parser met one of
+    // the element-body keywords only that old serializer wrote, the file is
+    // legacy — re-lex and re-parse with the old rule. (Re-decoding tokens
+    // isn't enough: the two rules place string boundaries differently.)
+    globalIdCounter = 0
+    let lexResult = lex(input)
+    let parser = new ContextAwareParser(lexResult.tokens)
+    let result = parser.parse()
+    const legacyEscapes = parser.sawLegacyKeyword
+    if (legacyEscapes) {
+        globalIdCounter = 0 // Reset per parse call to avoid growing IDs across invocations
+        lexResult = lex(input, { legacyEscapes: true })
+        parser = new ContextAwareParser(lexResult.tokens)
+        result = parser.parse()
+    }
 
     // Combine lexer and parser errors
     const errors = [...lexResult.errors, ...result.errors]
     const warnings = result.warnings
+    // Under the modern rule a string body still containing `\\` or `\t` is
+    // the ambiguous case: legal Structurizr, but also what an old c4hero file
+    // with no keyword marker looks like. Surface it, don't guess.
+    const legacyLookingEscapes = !legacyEscapes && lexResult.tokens.some(
+        (t) => t.type === 'STRING' && /\\\\|\\t/.test(t.value),
+    )
+    if (legacyEscapes) {
+        warnings.unshift({
+            message: 'Saved by an older c4hero: \\\\ and \\t escape sequences were converted. Saving writes the file in Structurizr\'s format.',
+            line: 1,
+            column: 1,
+        })
+    } else if (legacyLookingEscapes) {
+        warnings.unshift({
+            message: 'Strings contain \\\\ or \\t, which Structurizr reads literally (two backslashes; backslash + t). If this file was saved by c4hero before v0.3, those were escapes — check the affected values.',
+            line: 1,
+            column: 1,
+        })
+    }
 
     // Implied instance relationships are NOT materialized here — the canvas
     // derives them per deployment view via deriveInstanceRelationships(), so
@@ -731,6 +774,7 @@ export function parse(input: string): ParseResult {
         workspace: ws,
         errors,
         warnings,
+        legacyEscapes,
         declarationLines: result.declarationLines,
         viewLines: result.viewLines,
         directiveLines: result.directiveLines,


### PR DESCRIPTION
## Summary

[TEA-167](https://linear.app/kevnord/issue/TEA-167). Supersedes #175, which GitHub auto-closed when its stacked base branch was deleted at the #174 merge. Same change, rebuilt on `main`, with both rounds of review findings applied.

Files saved by c4hero before TEA-163 wrote JSON-style escapes (`\\` for a backslash, `\t` for a tab). The lexer now mirrors Structurizr, where only `\"` and `\n` are escapes, so those files loaded drifted and autosave could write the misread values back.

### How detection works (and why not a text scan)

The parser sets a flag when it consumes a bare `status`, `owner`, `location`, `lineStyle` or `interactionStyle` keyword in an element or relationship body. Only the pre-TEA-163 serializer ever wrote those lines; real Structurizr rejects them, and modern c4hero emits tags and quoted properties instead. A first review round proposed a regex over the raw text; the second round showed it was unsound, since Structurizr accepts unquoted property keys, so `properties { owner "Team" }` in a hand-written file would have flipped it into legacy decoding. Parser-level detection cannot be fooled that way.

A detected file is re-lexed and re-parsed with the old rule (re-decoding tokens is not enough: the two rules place string boundaries differently) and gets a warning saying escapes were converted and saving will migrate it. A file with `\\` or `\t` in a string but no marker keeps the Structurizr rule and gets an ambiguity warning instead of a silent guess. The modern write path is unchanged.

## Test plan

- [x] `npm run check` green
- [x] `legacy-escapes.test.ts`: each marker keyword in element and relationship bodies; the same words as property keys, inside strings, in comments and as identifiers do not trigger; modern output never triggers; legacy vs modern decoding; legacy file loads with original values; migration round trip; ambiguity warning present/absent
- [x] Full DSL suite including the real-CLI conformance test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs