### PR TITLE
fix(import): give the centred import dialog its own panel surface (TEA-332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Included content is not loaded yet; the code pane says so with a
   "preserved, not resolved" note rather than pretending the model is
   complete. (TEA-325, phase A)
+- **The import dialog is readable again on the welcome screen.** Opening
+  *Import PlantUML / Mermaid* from the welcome screen drew the dialog with no
+  background of its own, so the page behind it — the heading, the recent
+  collection rows — showed straight through the panel and its own text. The
+  same dialog opened from the app menu was fine, because that variant takes
+  its surface from the slide-down panel style. The centred variant now
+  carries the same panel background, border and shadow as every other centred
+  dialog. (TEA-332)
 
 ## [0.6.0] - 2026-09-10
 

--- a/src/components/dialogs/ImportDialog.test.tsx
+++ b/src/components/dialogs/ImportDialog.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ImportDialog from './ImportDialog'
+
+function renderDialog(position: 'center' | 'shade') {
+  render(<ImportDialog position={position} onClose={vi.fn()} onImport={vi.fn()} />)
+  return screen.getByRole('dialog', { name: 'Import PlantUML or Mermaid' })
+}
+
+describe('ImportDialog', () => {
+  // Regression (TEA-332): DialogShell ships no default surface, so the centred variant
+  // rendered transparent over the welcome screen — the page text showed
+  // straight through the dialog body.
+  it('gives the centred panel its own opaque surface', () => {
+    const dialog = renderDialog('center')
+    const style = dialog.getAttribute('style') ?? ''
+    expect(style).toContain('background')
+    expect(style).toContain('--color-bg-panel')
+    expect(style).toContain('border')
+  })
+
+  it('leaves the shade variant to the .shade-panel class background', () => {
+    const dialog = renderDialog('shade')
+    expect(dialog.className).toContain('shade-panel')
+    expect(dialog.getAttribute('style') ?? '').not.toContain('--color-bg-panel')
+  })
+})

--- a/src/components/dialogs/ImportDialog.tsx
+++ b/src/components/dialogs/ImportDialog.tsx
@@ -8,6 +8,20 @@ import { announce } from '@/lib/announce'
 
 const ACCEPT = '.puml,.plantuml,.iuml,.wsd,.pu,.mmd,.mermaid,.md,.txt'
 
+const PANEL_WIDTH = 'min(640px, calc(100vw - 32px))'
+
+/** DialogShell ships no default surface for centred modals — the "shade"
+ *  variant gets its background from the `.shade-panel` class, but a centred
+ *  panel renders transparent over the backdrop unless the caller supplies one.
+ *  Same tones as TagManagerDialog / SearchDialog (TEA-332). */
+const CENTER_SURFACE: React.CSSProperties = {
+  background: 'var(--color-bg-panel)',
+  border: '1px solid var(--color-border)',
+  borderRadius: 'var(--radius-lg)',
+  boxShadow: '0 24px 60px -12px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(0, 0, 0, 0.2)',
+  overflow: 'hidden',
+}
+
 interface ImportDialogProps {
   onClose: () => void
   /** Called with the normalised workspace once the user confirms. The caller
@@ -65,7 +79,12 @@ export default function ImportDialog({ onClose, onImport, position = 'center' }:
   const formatLabel = outcome?.ok ? (outcome.result.format === 'mermaid-c4' ? 'Mermaid C4' : 'C4-PlantUML') : null
 
   return (
-    <DialogShell onClose={onClose} ariaLabel="Import PlantUML or Mermaid" position={position} style={{ width: 'min(640px, calc(100vw - 32px))' }}>
+    <DialogShell
+      onClose={onClose}
+      ariaLabel="Import PlantUML or Mermaid"
+      position={position}
+      style={position === 'center' ? { width: PANEL_WIDTH, ...CENTER_SURFACE } : { width: PANEL_WIDTH }}
+    >
       <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--color-border)', display: 'flex', alignItems: 'center', gap: 8 }}>
         <FileInput size={16} color="var(--color-accent)" aria-hidden="true" />
         <span style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: 'var(--color-text-primary)' }}>Import PlantUML / Mermaid</span>


### PR DESCRIPTION
## What

The PlantUML / Mermaid import dialog rendered transparent when opened from the welcome screen — the page behind it showed straight through the panel and its own text.

## Cause

`DialogShell` ships no default surface for its `center` variant. The `shade` variant picks up a background from the `.shade-panel` CSS class, which is why the app-menu path looked correct; the centred variant used by `WelcomeScreen` passed only a `width`, so the panel body stayed transparent over the backdrop.

## Fix

Supply the panel surface — background, border, radius, shadow, `overflow: hidden` — for the centred case **only**, so the shade variant keeps its glass treatment rather than having it overridden by inline styles. Same tones `TagManagerDialog` and `SearchDialog` already use.

## Tests

New `ImportDialog.test.tsx`:
- centred panel carries its own opaque surface
- shade panel leaves the background to `.shade-panel`

Confirmed non-vacuous — reverting the component fails the centred case with `expected 'position: relative; z-index: 1; width…' to contain 'background'`.

`npm run check` passes (lint, typecheck, 2926 tests / 150 files, build); `test:coverage` clean as well.

## Follow-up (not in this PR)

`DialogShell`'s centred variant has no default background and every consumer re-solves it by hand — `TagManagerDialog` carries a comment saying exactly that. Worth giving the shell an overridable default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWKv2j6qH52tVDpMs1yjHs
